### PR TITLE
fix(voice): "Put it back" is a state restore, never a revert of the change

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "A risk-tiered multi-agent development pipeline for Claude Code, with a file-based knowledge store and no external service dependencies.",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
       "description": "Risk-tiered multi-agent pipeline: spec and tier, single-writer implementation with tests, adversarial review panel. Ships BA, DBA, DevOps, SecOps, Dev, QA, Design, and Librarian agents plus /pipeline, /phase, and /warmup.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "category": "development"
     }
   ]

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Risk-tiered multi-agent development pipeline. BA specs and tiers an ask, a single-writer implements code and tests together, an adversarial panel reviews the finished diff. File-based knowledge store, no external services.",
   "author": {
     "name": "NS Media"

--- a/plugins/pipeline/voice.md
+++ b/plugins/pipeline/voice.md
@@ -93,7 +93,9 @@ hides the change, and how to tell]
 **Cannot be seen this way:** [what these steps do not cover, and what covers it
 instead]
 
-**Put it back:** [the exact command or steps to restore the starting state]
+**Put it back** (only when the steps above changed data): [the exact command or
+steps to restore the starting state. This is NEVER a revert of the change
+itself; omit the line entirely when the steps only read.]
 ```
 
 The rules that make this worth reading:
@@ -102,7 +104,7 @@ The rules that make this worth reading:
 - **Steps are actions, not assertions.** "Log in, open the reports page, switch to the hourly view" is a step. "Verify the grid does not overflow" is not; that is the next section.
 - **Always give the before.** A change is only visible against a baseline. If they never saw the old behaviour, describe it so the difference means something.
 - **Name what this cannot show.** If part of the work is only provable by a test, a query, or a log, say so and say which. A surface nobody could render, a race that needs two sessions, a state no fixture reaches: name it rather than letting the steps imply full coverage. Never let a walkthrough stand in for evidence it does not provide.
-- **Make it reversible.** If following the steps changes data, hand them the exact way back in the same message. Do not make them ask.
+- **Make it reversible, and only when it needs to be.** If following the steps changes data, hand them the exact way back in the same message; do not make them ask. If the steps only read, leave the line out. **It is never a revert of the change itself.** Filling it with a revert command reads as a recommendation to roll back, which is how this field misfired the first time it was used.
 - **If you could not verify it yourself, say so here**, and say what you did instead. "I could not render this; the tests cover the logic but nobody has looked at it" is a legitimate and useful line.
 
 ## The decision block


### PR DESCRIPTION
The `See it yourself` **Put it back** field misfired the first time it was used downstream, a few hours after it landed.

A walkthrough of a merged, CI-green, working change carried a revert command in that slot. The owner read it as a suggestion the change should be rolled back and asked what was being reverted. That is a reasonable reading, because nothing in the field said otherwise.

The field is for replication steps that **mutate state**, so the reader can get back to where they started: a staging database reset needs its restore command handed over in the same message. It is not an undo button for the feature.

Now conditional and explicit in both the template and the rule beside it: omit the line when the steps only read, and never fill it with a revert.

`0.6.1`, docs only. `tests/run.sh` 25 passed.