### PR TITLE
Set turn budgets from observed load, not from a guess

### DIFF
--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Risk-tiered multi-agent development pipeline. BA specs and tiers an ask, a single-writer implements code and tests together, an adversarial panel reviews the finished diff. File-based knowledge store, no external services.",
   "author": {
     "name": "NS Media"

--- a/plugins/pipeline/agents/dba.md
+++ b/plugins/pipeline/agents/dba.md
@@ -4,7 +4,7 @@ description: Database Administrator. Reviews schema impact, migration safety (up
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: opus
 effort: high
-maxTurns: 60
+maxTurns: 120
 color: blue
 ---
 

--- a/plugins/pipeline/agents/qa.md
+++ b/plugins/pipeline/agents/qa.md
@@ -4,7 +4,7 @@ description: Quality Assurance engineer. Owns the test-discipline standard every
 tools: Read, Grep, Glob, Bash, Write, Edit
 model: opus
 effort: high
-maxTurns: 80
+maxTurns: 160
 color: yellow
 ---
 

--- a/plugins/pipeline/agents/secops.md
+++ b/plugins/pipeline/agents/secops.md
@@ -4,7 +4,7 @@ description: Security Operations engineer with VETO power. Reviews auth, encrypt
 tools: Read, Grep, Glob, Bash, Write, Edit, WebFetch, WebSearch
 model: opus
 effort: xhigh
-maxTurns: 80
+maxTurns: 140
 color: red
 ---
 


### PR DESCRIPTION
Ten truncations in one long autonomous session, three putting a binding verdict at risk. 0.8.0 added the rule that makes truncation *survivable*; this makes it *rarer*. Both are needed — a bigger budget still gets exhausted by a harder question, and the discipline is what makes exhaustion cheap.

## Measured, not guessed

Tool-call counts across one session:

| role | limit | runs over limit | max seen | action |
|---|---|---|---|---|
| qa | 80 | **5/8** | 115 | → 160 |
| secops | 80 | **3/7** | 92 | → 140 |
| dba | 60 | **2/7** | 87 | → 120 |
| ba | 80 | 0/7 | 60 | unchanged |
| devops | 60 | 0/5 | 46 | unchanged |
| dev | 250 | 0/7 | 191 | unchanged |

## Why these three

They do adversarial verification: plant a mutation, revert it, re-run a suite, repeat. That is inherently many more turns than reading a diff. QA is worst because it does it against its **own** contract and then again against the implementation.

Dev already had headroom at 250 and used up to 191 without truncating, which is the calibration point the other three were missing.

BA and DevOps are untouched — raising a budget nobody reaches buys nothing and makes a runaway more expensive.

## Verification

13 suites / 421 assertions green, exit 0 read from `$?`. **That suite does not read frontmatter, so it is not evidence for this change** — the frontmatter scan is, and it confirms all nine agents parse with the intended values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)