### PR TITLE
The reply is the durable artifact, the worktree is not

### DIFF
--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Risk-tiered multi-agent development pipeline. BA specs and tiers an ask, a single-writer implements code and tests together, an adversarial panel reviews the finished diff. File-based knowledge store, no external services.",
   "author": {
     "name": "NS Media"

--- a/plugins/pipeline/agents/art-director.md
+++ b/plugins/pipeline/agents/art-director.md
@@ -102,7 +102,13 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 ## Artifact I/O contract
 
-Read and write only at the absolute `ARTIFACT_DIR` you are given. Never resolve the pipeline run directory from your own cwd.
+Read and write only at the absolute `ARTIFACT_DIR` you are given.
+
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost. Never resolve the pipeline run directory from your own cwd.
 
 Write `visual-contract.json` (Duty A) or `peer-review.art_director.json` (Duty B on a panel), or `art-direction.json` (Duty B standalone), as a BARE object with `verdict` at the top level, alongside `first_impression`, `clauses`, `strongest_flaw`, `strongest_strength`, `proposal`, `advisory_notes`, and `evidence` (paths to renders you captured, all inside the artifact directory; a screenshot outside it is refused, because a committed render can carry sensitive data).
 

--- a/plugins/pipeline/agents/ba.md
+++ b/plugins/pipeline/agents/ba.md
@@ -68,6 +68,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute path in your prompt (Phase 1: `PIPELINE_BASE`, to which you append the new issue number; later phases: an absolute `ARTIFACT_DIR`). Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back. This is the bug that sent a `spec.json` to the wrong checkout and forced the orchestrator to hunt for it.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** When you act as a Phase 4 panelist you write your OWN file (`peer-review.ba.json`); the orchestrator merges it under the `ba` key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"ba"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict. (`spec.json` in Phase 1 is a single-author, non-shard file and keeps its normal top-level shape below.)
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "..." }`

--- a/plugins/pipeline/agents/dba.md
+++ b/plugins/pipeline/agents/dba.md
@@ -96,6 +96,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 2 fan-out and the Phase 4 panel you write your OWN file (`review.<role>.json` / `peer-review.<role>.json`); the orchestrator merges it under your role key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"<role>"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict and silently pass a gate the wrong way.
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "...", ...role fields... }`

--- a/plugins/pipeline/agents/design.md
+++ b/plugins/pipeline/agents/design.md
@@ -98,6 +98,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 2 fan-out and the Phase 4 panel you write your OWN file (`review.design_review.json` / `peer-review.design_review.json`); the orchestrator merges it under the `design_review` key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"design_review"` key, and do NOT add a sibling key beside the block. A wrapped or sibling-buried block makes the merge read a null verdict.
 
 - **Shard KEY is `design_review`, not `design`.** This is deliberate: `design.json` is the Phase 2.5 design bake-off artifact (chosen approach, rejected alternatives), an entirely different thing. Using `design` for your shard would collide with it. Always `design_review`.

--- a/plugins/pipeline/agents/dev.md
+++ b/plugins/pipeline/agents/dev.md
@@ -99,6 +99,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 2 fan-out and the Phase 4 panel you write your OWN file (`review.<role>.json` / `peer-review.<role>.json`); the orchestrator merges it under your role key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"<role>"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict and silently pass a gate the wrong way. (Your Phase 3 outputs `tasks.json` and `impl-report.json` are single-thread, non-shard files and keep their normal top-level shapes below; the bare-shard rule is specifically for `peer-review.dev.json`.)
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "..." }`

--- a/plugins/pipeline/agents/devops.md
+++ b/plugins/pipeline/agents/devops.md
@@ -102,6 +102,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 2 fan-out and the Phase 4 panel you write your OWN file (`review.<role>.json` / `peer-review.<role>.json`); the orchestrator merges it under your role key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"<role>"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict and silently pass a gate the wrong way.
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "...", ...role fields... }`

--- a/plugins/pipeline/agents/librarian.md
+++ b/plugins/pipeline/agents/librarian.md
@@ -119,6 +119,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Your whole output is a zero, which makes this rule yours more than anyone's.** A drift scan reporting "no drift" and a drift scan that never resolved its inputs produce the identical line. Before reporting a clean consistency check, plant one inconsistency and confirm the scan names it. Report the number of items actually SCANNED alongside the number of problems found, so "0 problems" can never be printed by a run where 0 items were read. (Origin: a scanner had seven inputs that silently returned zero sites, under a header promising it never skips.)
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 ## Artifact contract: librarian-report.json
 
 For each run:

--- a/plugins/pipeline/agents/qa.md
+++ b/plugins/pipeline/agents/qa.md
@@ -119,6 +119,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before rendering any verdict. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 4 panel you write your OWN file (`peer-review.qa.json`); the orchestrator merges it under the `qa` key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"qa"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict and silently pass a gate the wrong way. (The Phase 3a tests you commit, and the `tasks.json` you may write, are not shards; the bare-shard rule is specifically for `peer-review.qa.json`.)
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "..." }`

--- a/plugins/pipeline/agents/secops.md
+++ b/plugins/pipeline/agents/secops.md
@@ -132,6 +132,12 @@ Read `${CLAUDE_PLUGIN_ROOT}/evidence.md` before you conclude anything. It is the
 
 **Absolute paths.** The orchestrator passes an absolute `ARTIFACT_DIR` in your prompt. Read and write every pipeline artifact at that absolute path. Never resolve `.pipeline/...` relative to your own cwd: your cwd may differ from the orchestrator's (it runs inside a worktree), and a cwd-relative write lands in a different checkout than the one the orchestrator reads back.
 
+**Your REPLY is the durable artifact. The file may not survive you.** When you run worktree-isolated, the harness refuses writes to the shared checkout and directs you to the worktree copy, and then reclaims that worktree when you finish, because it holds no tracked commits. In one night this destroyed three completed reviews, including a spec rewrite and a review carrying two blockers. Each survived only to the extent its author had restated it in the reply.
+
+So: **write the file, and assume the orchestrator will never read it.** Put the substance in your final message: every finding with its severity, the evidence (command and output), the numbers with their window and grain, and your verdict. Where your deliverable IS prose (copy, a spec sentence, a runbook step), write the prose out in the reply. "Wording revised" plus a path is worth nothing when the path is gone.
+
+This is not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema. Report the content that would otherwise be lost.
+
 **Bare shard shape (parallel phases).** In the Phase 2 fan-out and the Phase 4 panel you write your OWN file (`review.<role>.json` / `peer-review.<role>.json`); the orchestrator merges it under your role key. Your shard's top-level object IS your block, with `verdict` as a direct top-level key. Do NOT wrap it under a `"<role>"` key. Do NOT add a sibling key beside a wrapped block. A wrapped or sibling-buried block makes the merge read a null verdict and silently pass a gate the wrong way.
 
 - Correct (bare): `{ "verdict": "APPROVE", "reviewed_at": "<iso>", "concerns": [], "notes": "...", ...role fields... }`


### PR DESCRIPTION
**Three completed reviews were destroyed in one night by the same mechanism.**

A worktree-isolated agent is refused writes to the shared checkout and directed to the worktree copy. When it finishes holding no tracked commits, **the worktree is reclaimed — and the untracked artifacts go with it.** The orchestrator arrives to collect a shard and finds no directory.

Lost this way:

| agent | artifact | 
| --- | --- |
| BA (#220) | a spec rewrite **and** its Phase 4 shard |
| DBA (#219) | a Phase 2 review carrying **two blockers** |
| Design (#219) | a review whose entire deliverable was **copy** |

Every one had followed the write-the-file-first rule. One had even written a stub *before* investigating and overwritten it at the end, exactly as instructed, and still lost everything.

All three survived only to the extent their authors had restated the substance in the reply — and the orchestrator reconstructed all three shards from those replies.

## The change

Write the file, and **assume it will never be read.** The reply carries every finding with its severity, its evidence, its numbers with window and grain, and the verdict.

Where the deliverable *is* prose — copy, a spec sentence, a runbook step — the prose goes in the reply. "Wording revised" plus a path is worth nothing once the path is gone.

Explicitly not a licence to skip the file, and not an excuse to pad the reply with a formatted duplicate of a JSON schema.

## Drift found while applying it

Three files needed different anchors: `ba` and `design` carry role-specific variants of the absolute-paths paragraph, and `art-director` and `librarian` have **no such paragraph at all**. So the "identical for every pipeline agent" heading is once again not quite true — worth a separate pass.

The script refused to write anything until every file had a verified insertion point, rather than partially applying.

## Verification

| check | result |
| --- | --- |
| rule present | 9/9 agents |
| same, at `HEAD` (control) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)