### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "A risk-tiered multi-agent development pipeline for Claude Code, with a file-based knowledge store and no external service dependencies.",
-    "version": "0.20.0"
+    "version": "0.21.0"
   },
   "plugins": [
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
       "description": "Risk-tiered multi-agent pipeline: spec and tier, single-writer implementation with tests, adversarial review panel. Ships BA, DBA, DevOps, SecOps, Dev, QA, Design, Art Director, and Librarian agents plus /pipeline, /phase, and /warmup.",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development"
     }
   ]

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Risk-tiered multi-agent development pipeline. BA specs and tiers an ask, a single-writer implements code and tests together, an adversarial panel reviews the finished diff. File-based knowledge store, no external services.",
   "author": {
     "name": "NS Media"


### PR DESCRIPTION
Version bump only. `plugins/pipeline/.claude-plugin/plugin.json` to 0.21.0, `marketplace.json` propagated by `scripts/sync-manifests.mjs` rather than hand-copied, which is the drift this repo already learned about the hard way (twelve releases invisible to marketplace installers).

Verified locally: `sync-manifests.mjs --check` reports in sync at 0.21.0 (9 agents, 3 commands); full suite 24 suites, 1369 passed, 0 failed, rc 0.

## What 0.21.0 contains

Everything from #17 (PR #18) and the follow-up in #26.

**The headline fix.** "Does this diff touch the data layer?" had six definitions in three shapes, and the mis-tier tripwire was the narrowest of them. A migration under `db/migrations/` did not trip the halt; one under `supabase/migrations/` did not trip it and did not seat the DBA at all. Now one module, two predicates (narrow for the halt and the down-check, broad for the panel seat), config-driven, with per-framework preset defaults covering Rails, Django, Alembic, Prisma, Drizzle, Supabase (migrations and declarative schemas), Flyway, EF Core, Laravel and Liquibase.

**Two silent-drop defects found by the panel and fixed:**
- The surface probes returned "no match" indistinguishably from "could not evaluate", so a stale plugin cache silently dropped DBA, DevOps and Design from panels. Now three outcomes, with a reserved exit code, and an unevaluable probe SEATS the reviewer and says so.
- Those probes relied on shell word splitting, which zsh does not do. Any multi-file diff was handed over as one glued string and matched nothing, so the halt did not fire on the shell Claude Code actually runs. Paths are now NUL-delimited on stdin and git's exit status is checked.

**Also in:** a dispatch model routing table replacing seven scattered prose pins (behaviour-neutral, with SecOps and QA pinned in code and unreachable from config); self-telemetry with a partition property so dropped time is reported rather than vanishing; a config-doctor report when configured globs match zero files, which is where this beats the CODEOWNERS-style mechanism it re-derives; the Phase 4 shard fallback, which named the directory that had just refused the write; the `panel_roles` schema gap; and CI that actually runs the test suite, which did not exist before.

Known follow-ups are filed: #19, #21, #22, #23, #25, #27.