### PR TITLE
docs: the front page describes what 0.21.0 actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ plugins/pipeline/
   commands/                          # /pipeline, /phase, /warmup
   agents/                            # ba, dba, devops, secops, dev, qa, design, art-director, librarian
   hooks/                             # session-start, stop, subagent-stop (all fail-open, opt-in)
-  scripts/                           # gates, artifact validator, file-based knowledge store
+  scripts/                           # gates, surface predicates, dispatch routing, telemetry, config doctor, artifact validator, knowledge store
   schemas/                           # typed artifact JSON schemas
   knowledge/                         # empty template for the file-based knowledge store
   pipeline.config.example.json       # the CUSTOMIZE knobs
   README.md                          # start here
+  tests/                             # the suite CI runs on every push and pull request
 ```
 
 ## Customize
 
-Copy `plugins/pipeline/pipeline.config.example.json` to `pipeline.config.json` at your project root and edit. The session-start warmup checks that file every session and tells you if a key is misspelled, wrongly typed, or missing in a way that silently disables a gate; it stays quiet when the config is sound. Grep the plugin for `CUSTOMIZE` to find every knob (build command, integration branch, frontend globs, migration glob, tier triggers). Edit the `STANDARD-TIER CONSTRAINTS` blocks in the DBA/DevOps/SecOps agents to match your stack.
+Copy `plugins/pipeline/pipeline.config.example.json` to `pipeline.config.json` at your project root and edit. The session-start warmup checks that file every session and tells you if a key is misspelled, wrongly typed, or missing in a way that silently disables a gate; it stays quiet when the config is sound. Grep the plugin for `CUSTOMIZE` to find every knob. The config keys are `integrationBranch`, `checkCommand`, `knowledgeDir`, `frontendSurface`, `migrationGlobs`, `extraMigrationGlobs`, `dataLayerGlobs`, `infraGlobs`, `dispatchModels`, `migrationDownMarker`, and `architecturalTriggers`. The path globs ship per-framework defaults (Rails, Django, Alembic, Prisma, Drizzle, Supabase, Flyway, EF Core, Laravel, Liquibase), so most projects need not set them at all, and the warmup tells you when a glob you did set matches nothing in your repo. Edit the `STANDARD-TIER CONSTRAINTS` blocks in the DBA/DevOps/SecOps agents to match your stack.
 
 ## License
 


### PR DESCRIPTION
Public-facing README only, no code.

Three things had gone stale, and the third is the same class of defect #17 existed to fix (documentation asserting a config surface that does not match reality):

1. **`scripts/`** was described as "gates, artifact validator, file-based knowledge store". It now also ships the data-layer and infra surface predicates, the dispatch-model resolver, telemetry, and the config doctor.
2. **`tests/` was absent from the tree**, and it is now the thing CI runs on every push and pull request. Before 0.21.0 no CI ran the suite at all, so the omission was accurate then and is not now.
3. **"frontend globs, migration glob"** undersold the config surface and named a key shape that no longer matches. The eleven real keys are listed instead, taken from `config-doctor.mjs`'s own registry rather than transcribed from memory, along with the fact that the path globs now ship per-framework defaults so most projects need not set them, and that the warmup reports a glob matching nothing.

Verified: full suite green on this tree (rc 0).