### PR TITLE
Prevent the two classes we keep finding, and notice when review stops converging

### DIFF
--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -971,6 +971,53 @@ Because the Librarian is dispatched non-blocking, mark the run terminal at DISPA
 - **The completion summary is the feature complete report** from `${CLAUDE_PLUGIN_ROOT}/voice.md`, used verbatim as the template: what it does now that it did not do before (from a user's point of view), the analogy and where it breaks, what changed grouped by what a person would notice rather than by file, what it means for the owner, what you deliberately did not do, and what to watch for over the next two weeks. This is the report the owner actually reads, and for most runs it is the only part of the pipeline they see. It replaces the changelog dump; do not substitute a verdict line for it.
 - Optional: the Librarian itself (or a later session) removes `.pipeline/<issue>/status.json` or moves the whole dir to `.pipeline/_archived/<issue>/` for audit after it verifies archival.
 
+### Convergence budget (the pipeline's own failure mode)
+
+**This pipeline is much better at finding defects than at converging on a fix, and nothing in it
+notices when that is happening.** Every gate here loops back on a finding, and every loop-back is
+individually justified, so a spec can round-trip indefinitely while each round looks like the gate
+working. Measured on one issue: three Phase 2 rounds, four spec revisions, an 86KB spec that grew to
+95KB while its substance HALVED, two connection failures mid-write that each lost a full round's
+reasoning, and zero lines of code. Every blocker in every round was real. That is the point — real
+findings are not evidence that continuing is correct.
+
+Two budgets, both cheap, both fail-loud:
+
+**1. Round budget.** After the SECOND Phase 2 round returns any `REQUEST_CHANGES`, do NOT loop back
+by default. Stop and present the owner a decision: **split** the spec, **defer** the unresolved half
+to a follow-up issue, or **proceed** to Phase 2.5 carrying the findings as constraints. Say which you
+recommend and why. A third round happens because the owner chose it, not because the loop-back table
+said to.
+
+The same evidence that justifies each round justifies the split: if round two's findings are in a
+different part of the spec from round one's, the spec is too big to review as a unit.
+
+**2. Spec size tripwire.** When a spec crosses **10 requirements or 12 acceptance criteria**, BA must
+either justify the size in `spec.json` or propose a split. These are not hard limits; they are the
+point at which "is this one issue?" stops being rhetorical. On the run above, BA recommended a
+three-way split the first time it was asked directly — and was right — but nothing had asked.
+
+**Write the artifact before composing the reply.** The Phase 4 reviewer preamble already says this.
+It applies to BA too, and for a sharper reason: BA's artifact is the largest single write in the
+pipeline, and a connection drop between "I have concluded" and "I have written it down" costs the
+entire round. When a spec exceeds ~30KB, write it as several smaller files (a delta against the
+prior revision, not a rewrite) and let the orchestrator merge them.
+
+### Match the mechanism to the reversibility, not to the tier table
+
+The architectural tier is the right shape for a change whose failure is unrecoverable — data loss,
+credential exposure, a wrong number reaching a customer. It is the wrong shape for most of a backlog.
+
+Two habits carry most of the value at any tier and cost almost nothing: **a second independent reader
+on anything customer-facing**, and **run the control before believing the zero**. Reach for the full
+apparatus when the downside is permanent; reach for those two when it is not.
+
+A corollary worth stating because it was learned the expensive way: when a review finds a one-file,
+obviously-correct safety defect, **fix it immediately rather than routing it through the pipeline.**
+On the run above, two tracked files were instructing future agents to corrupt the production database.
+Both were found mid-review and both were fixed in ten minutes as their own small PR. Filing them as
+issues to be specced would have left live hazards in the tree for days.
+
 ---
 
 ## Loop-back triggers

--- a/plugins/pipeline/evidence.md
+++ b/plugins/pipeline/evidence.md
@@ -10,6 +10,60 @@ The whole file reduces to one sentence. **A check that cannot fail has not passe
 
 ---
 
+## A machine-readable claim and a human-readable caveat can disagree, and only one is checked
+
+`gate-pre-phase4-frontend.mjs` reads `raw.token_lint_pass === true` and `raw.axe_pass === true` from
+the impl-report. On two consecutive issues in one repo, Dev set both to `true` and wrote an honest
+adjacent note saying **no token-lint script and no axe package exist anywhere in the project.** The
+note was accurate. The boolean was what the gate read.
+
+Nobody lied. The disclosure and the assertion lived in the same object and said different things, and
+the machine consumed the one that could not carry the caveat.
+
+Design caught it both times by looking for the tool rather than reading the field — grepping
+`package.json`, every workspace manifest, the lockfile and the ESLint configs, finding nothing, and
+recording `token_lint: "n/a"` / `axe.status: "not-run"` instead of inheriting `true`. Its own words:
+*a claim I didn't witness, not a run.*
+
+**The rule.** A gate must be satisfied by a COMMAND AND ITS OUTPUT, never by a self-declared boolean.
+Where the tool does not exist, the honest value is "not-run", and a gate that cannot distinguish
+"not-run" from "passed" is not a gate. If you are the author, do not set a pass flag for a check you
+did not execute, however good your substitute was — write the substitute in the note and leave the
+flag false.
+
+## An artifact nobody can read is not the durable half of a fix
+
+`.pipeline/` is gitignored in most projects that use this pipeline. So an implementation report, a
+review shard and a spec are all invisible to the next reader of the repository.
+
+Twice in one day a correction was written into an implementation report and treated as the
+deliverable. One of those was to a report that had ALREADY been corrected at its own Phase 4 — the
+stale claim the new issue existed to fix had moved on, while the same false sentence sat in a
+`printablePath` doc comment in TRACKED CODE, where the next reader actually meets it.
+
+**The rule.** If a fix is a correction to a claim, the correction lands in tracked code — a comment,
+a test name, a doc under `docs/` — or it has not landed. An artifact may RECORD the reasoning; it can
+never BE the fix. Before accepting "corrected in the impl-report", ask whether `git grep` would find
+it.
+
+## Reviewers who RUN tests need isolation, not just reviewers who plant mutations
+
+The existing rule covers mutation-planting. It is too narrow. Three reviewers dispatched into one
+worktree produced 74 failures across 6 files, every one `table 'main.organizations' does not exist` —
+a schema-teardown collision between two concurrent vitest processes sharing one `test.db`. None of
+the failing files was touched by the diff under review.
+
+The cost is not just wasted runs. One reviewer began investigating whether the change under review
+had reordered the suite; another wrote a provisional pessimistic verdict; a third recorded its own
+result as contaminated and refused to report either number. All three were reasoning about the
+orchestrator's mistake as though it were a property of the diff.
+
+**The rule.** Any reviewer that RUNS a suite — not only one that mutates — gets `isolation:
+"worktree"` when the project's tests share state (one test database, one fixture store, one port).
+If isolation is unavailable, dispatch them SERIALLY. And when contamination is discovered, tell every
+running reviewer the window and the files, so they can discard rather than attribute: the failure
+mode is a reviewer confidently explaining your own interference.
+
 ## A property over a possibly-empty set is not a check
 
 The commonest defect this pipeline finds, and the one it keeps re-introducing **inside its own

--- a/plugins/pipeline/evidence.md
+++ b/plugins/pipeline/evidence.md
@@ -10,6 +10,58 @@ The whole file reduces to one sentence. **A check that cannot fail has not passe
 
 ---
 
+## A property over a possibly-empty set is not a check
+
+The commonest defect this pipeline finds, and the one it keeps re-introducing **inside its own
+remedies**, is a criterion that ranges over a collection that can be empty. `for every X in S, assert
+P(X)` is vacuously true when `S` is `∅`, exits 0, and is indistinguishable from a real pass.
+
+One issue produced six instances in four review rounds, three of them in the fix for the previous one:
+
+- A credential-leak guard asserted "every committed fixture contains no credential rows". The same
+  round preferred a GENERATOR over a committed binary — making the committed set empty, so the
+  property passed without looking.
+- Its replacement asserted `|committed ∪ generated| > 0`, which the generated side satisfies alone,
+  so it still said nothing about the committed side — the only side that reaches git history.
+- A mount-closure criterion asserted over `docker compose config --services`, which silently omits
+  profile-gated services. The one service the criterion was written about was profile-gated.
+- The same command exits non-zero without a full env. Swallowed, the service set is empty and
+  "no service mounts the data dir" is vacuously true.
+- A runbook-command extractor that lifts zero commands executes nothing and passes green.
+- A host-side-invocation scan whose count was PINNED to a number: the cheapest way to make a correct
+  scanner return that number is to narrow the pattern until it does, and the narrowing drops exactly
+  the sites nobody knew about. **A pinned count with the answer pre-printed is a target.**
+
+**The rule.** Before a criterion asserts a property over a set, it must assert the set is non-empty
+and of the expected shape, and that whatever produced the set actually ran. Derive counts; never
+pin them. And when you write the guard against this, ask what THAT guard fails to bind before you
+adopt it — three of the six above were introduced by the fix for the one before.
+
+## A number carries the population it was measured on
+
+The second commonest class here. A figure is correct for one grain and gets quoted for another,
+where it is wrong and still plausible. Four instances in one week:
+
+- A vendor's 12-month TRAILING AVERAGE read as a per-month value, so 12 of 16 client-facing cards
+  named the wrong peak month.
+- A per-task price for one API endpoint applied to a different endpoint's workload — 7.75x apart —
+  producing a cost figure 8x too high inside the very issue filed to correct stale cost figures.
+- "N of 20" used for two different quantities in one file; a reviewer conflated them and nearly
+  replaced a correct number with a wrong one.
+- "integrity_check costs 0.64s on the live file" where the measurement was taken on a 343MB COPY and
+  the live file is 505MB, stated two paragraphs from the sentence that said so.
+
+**The rule.** A number in an artifact carries its population, its window and its units, or it does
+not appear. When you quote a figure from another artifact, re-derive it or say you did not.
+
+## Capture the status of the command, not the pipeline
+
+`cmd 2>&1 | head; echo rc=$?` reports `head`'s status. So does `cmd | tail`, and so does any check
+whose liveness gate is written that way — a gate that cannot fail, guarding a gate that cannot fail.
+Observed three times in one session's shell work and once inside an acceptance criterion whose whole
+job was proving a renderer had run. Capture directly, or use `${PIPESTATUS[0]}` (bash) / `$pipestatus`
+(zsh) and be aware they differ.
+
 ## 1. A skip is not a pass
 
 Every `continue`, every early `return`, every `if (!x) continue` inside a verification loop is a


### PR DESCRIPTION
Feedback from a full day dogfooding **0.21.0** on `nsmedia-platform`. The owner's summary, which is exactly right:

> Great at finding bugs, not great at preventing them / solving them quickly.

Both halves, grounded in measurements from that run.

## Prevention

Across **148 issues** in that repo, four defect classes account for **77**. Two were entirely absent from `evidence.md` — `grep -ci vacuit` returned **0**.

**A property over a possibly-empty set is not a check.** Six instances in one issue across four rounds, and **three were introduced by the fix for the previous one**:

| instance | why it passed without looking |
|---|---|
| credential guard over "every committed fixture" | the same round preferred a generator, making the committed set empty |
| its replacement, `\|committed ∪ generated\| > 0` | satisfied by the generated side alone, so it said nothing about the side that reaches git history |
| mount closure over `docker compose config --services` | silently omits profile-gated services — and the one service it was written about was profile-gated |
| the same command with no env | exits non-zero; swallowed, the empty service list reads as clean |
| a runbook-command extractor | lifting zero commands executes nothing and passes green |
| a scan with a **pinned count** | narrowing the pattern until it returns N is the cheapest pass, and drops exactly the sites nobody knew about |

**A number carries the population it was measured on.** Four in one week: a 12-month trailing average read as per-month, so 12 of 16 client-facing cards named the wrong month; a per-task price applied to a different endpoint 7.75x apart, *inside the issue filed to correct stale prices*; "N of 20" used for two quantities in one file; a timing figure from a 343MB copy quoted as the live 505MB file, two paragraphs from the sentence that said so.

Plus the `$?`-through-a-pipe trap — a liveness gate that could not fail, guarding a gate that could not fail.

## Convergence

**Nothing notices when the pipeline is not converging.** Every loop-back is individually justified, so a spec round-trips while each round looks like the gate working.

Measured on one issue: **three Phase 2 rounds, four spec revisions, an 86KB spec grown to 95KB while its substance halved, two connection failures mid-write each losing a full round, and zero lines of code.** Every blocker was real — which is the point. Real findings are not evidence that continuing is correct.

- **Round budget** — after the second `REQUEST_CHANGES` round, stop and put **split / defer / proceed** to the owner with a recommendation. The same evidence that justifies each round justifies the split: if round two's findings sit in a different part of the spec from round one's, the spec is too big to review as a unit.
- **Size tripwire** at 10 requirements or 12 criteria. On that run BA recommended a three-way split the first time it was asked directly, and was right. Nothing had asked.
- **Write the artifact before the reply**, extended to BA — it owns the largest write in the pipeline, and a drop between concluding and writing costs the whole round. Large specs go out as deltas, not rewrites.

## Match the mechanism to reversibility

Architectural tier is right when failure is unrecoverable and wrong for most of a backlog. Two habits carry most of the value at any tier: a second independent reader on anything customer-facing, and run the control before believing the zero.

And when review finds a **one-file, obviously-correct safety defect, fix it immediately.** On that run two tracked files were instructing future agents to corrupt the production database — found mid-review, fixed in ten minutes as their own PR. Speccing them would have left live hazards in the tree for days.

## Verification

`passed=30 failed=0` across the plugin's test scripts.

Worth noting how that number was reached. `test-claims-consumers.sh` failed before I committed, on `AC30 CONTROL: and there were subjects on this branch to check` — *"no commits ahead of origin/main"*. That is a non-zero control correctly refusing to let AC30 pass vacuously over an empty commit set: **the exact rule this PR adds, already working in this repo.** It passed once there was something to check. I mention it because the first reading was "I broke a test," and the second reading is the argument for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)