### PR TITLE
fix(tests): AC30's population cannot come from a range against origin/main

### DIFF
--- a/plugins/pipeline/tests/test-claims-consumers.sh
+++ b/plugins/pipeline/tests/test-claims-consumers.sh
@@ -193,9 +193,19 @@ while IFS= read -r d; do
     [[ "$s" == *"$d"* ]] && COLLISIONS="$COLLISIONS[$s <- $d]"
   done <<< "$BRANCH_SUBJECTS"
 done <<< "$DELIMS"
+# On the INTEGRATION BRANCH itself `origin/main..HEAD` is empty, and that is not a failure --
+# it is the same "population derived from a ref that moves" defect that broke the R17 series
+# delimiters once already, arriving in a newer assertion. An empty range here is not "nothing
+# to check": every delimiter IS a real commit subject, so over full history each one matches
+# its own commit, and the property "no OTHER commit contains a delimiter" is exactly what the
+# resolves-to-exactly-one assertion below already enforces over full history. So on the
+# integration branch this half is SUBSUMED, and says so, rather than asserting over an empty
+# set (which passes for the wrong reason) or demanding a population that cannot exist.
 assert_eq "AC30: no subject on this branch contains a frozen delimiter" "$COLLISIONS" ""
-assert_eq "AC30 CONTROL: and there were subjects on this branch to check" \
-  "$([[ -n "$BRANCH_SUBJECTS" ]] && echo ok || echo "no commits ahead of origin/main")" "ok"
+assert_eq "AC30 CONTROL: the population was real, or is subsumed on the integration branch" \
+  "$(if [[ -n "$BRANCH_SUBJECTS" ]]; then echo ok; \
+     elif [[ -z "$(cd "$REPO_ROOT" && git log --format=%s origin/main..HEAD 2>/dev/null)" ]]; then echo ok; \
+     else echo "no subjects and not on the integration branch"; fi)" "ok"
 
 # The other half: each delimiter must still resolve to EXACTLY ONE commit. A collision that
 # shifts `head -1` shows up here as a 2.


### PR DESCRIPTION
Main went red on the merge of #32. Same defect class as the one that reddened main on the merge of #17, arriving in an assertion added during #30 itself.

`test-claims-consumers.sh:187` built AC30's population from `git log --format=%s origin/main..HEAD`. On the integration branch that range is **empty**, so the control asserting there were subjects to check fails, and the fresh-checkout meta-test cascades from it (4 further failures).

**Why the obvious fix is wrong.** Falling back to full history collides with itself: every frozen delimiter *is* a real commit subject, so each one matches its own commit. The property AC30's first half wants — "no OTHER commit contains a delimiter" — is exactly what the resolves-to-exactly-one assertion below it already enforces, over full history, and that one works on main.

So on the integration branch this half is **subsumed, and now says so**, rather than asserting over an empty set (which passes for the wrong reason) or demanding a population that cannot exist there.

## Witnessed controls

| | result |
|---|---|
| on `main`, after fix | `test-claims-consumers.sh` **30/0**; full suite **29 suites, 1615 passed, 0 failed**, rc 0 |
| on a branch, colliding subject planted | **28/2** — both `AC30: no subject … contains a frozen delimiter` and `AC30: every frozen delimiter still resolves to exactly one commit` |
| restored | **30/0** |

So it still bites where a collision can actually occur, and it is honest about being subsumed where one cannot.

## The recurring shape

This is the second time a test whose population is derived from a ref that **moves** has broken `main` at merge. The first was the R17 series window, fixed by delimiting on commit subject and resolving against full history. That lesson did not generalise, because nothing enforces it — a new assertion three rounds later made the same choice. Worth a ratchet that refuses a real-repo population built from `origin/main..HEAD`; filed separately rather than bundled here, since main is currently red and this is the minimal fix.