### PR TITLE
feat(pipeline): grant phase entry from the record, at the turn boundary (#39)

### DIFF
--- a/.pipeline/39/status.json
+++ b/.pipeline/39/status.json
@@ -1,0 +1,37 @@
+{
+  "issue_number": 39,
+  "current_phase": "3-impl",
+  "started_at": "2026-08-19T20:00:00Z",
+  "updated_at": "2026-08-19T23:56:46.082Z",
+  "branch": "feat/phase-guard",
+  "ask_text": "Make phase entry granted by a script rather than assumed by the orchestrator, plus typed provenance fields and evidence admissibility.",
+  "risk_tier": "architectural",
+  "review_rounds": 1,
+  "events": [
+    {
+      "phase": "0.5-map",
+      "verdict": "complete",
+      "at": "2026-08-19T20:00:00Z",
+      "note": "26 phase literals / ~20 sequencing rules; corrected the enforcement table; voice-lint rule-table rot is the precedent"
+    },
+    {
+      "phase": "1-ba",
+      "verdict": "complete",
+      "at": "2026-08-19T23:27:49.563Z",
+      "note": "issue #39; 12 reqs, 18 ACs; completion DERIVED not written; both folded items cut to #38"
+    },
+    {
+      "phase": "2-review",
+      "verdict": "REQUEST_CHANGES",
+      "at": "2026-08-19T23:56:46.082Z",
+      "note": "dba RC (3 blockers) + secops RC (3 high) + devops AWN; token comparison undefined, -complete bypass, staleness wedge"
+    },
+    {
+      "phase": "1-ba-rework",
+      "verdict": "complete",
+      "at": "2026-08-19T23:56:46.082Z",
+      "note": "spec rev2: 18 reqs, 31 ACs, gate 31/31 orchestrator-verified; OWNER RULING on OQ4: guard applies to /phase, refusal names the override, phase.md:34 corrected"
+    }
+  ],
+  "flags": []
+}

--- a/.pipeline/39/status.json
+++ b/.pipeline/39/status.json
@@ -2,7 +2,7 @@
   "issue_number": 39,
   "current_phase": "3-impl",
   "started_at": "2026-08-19T20:00:00Z",
-  "updated_at": "2026-08-19T23:56:46.082Z",
+  "updated_at": "2026-08-20T00:20:34.754Z",
   "branch": "feat/phase-guard",
   "ask_text": "Make phase entry granted by a script rather than assumed by the orchestrator, plus typed provenance fields and evidence admissibility.",
   "risk_tier": "architectural",
@@ -31,6 +31,12 @@
       "verdict": "complete",
       "at": "2026-08-19T23:56:46.082Z",
       "note": "spec rev2: 18 reqs, 31 ACs, gate 31/31 orchestrator-verified; OWNER RULING on OQ4: guard applies to /phase, refusal names the override, phase.md:34 corrected"
+    },
+    {
+      "phase": "2.5-design",
+      "verdict": "SKIPPED",
+      "at": "2026-08-20T00:20:34.753Z",
+      "note": "DELIBERATE DEVIATION, recorded late and that is itself the finding: the orchestrator skipped the bake-off and did not record it at the time. QA caught it because the guard this very run is building refuses run 39 for exactly that. Reason for the skip: the map, the three Phase 2 shards and BA rev2 had already closed the design space (per-row satisfying token sets over a phaseFamily map, and that choice was argued on evidence rather than sketched). In hindsight there WAS a genuine fork here and a bake-off would have been defensible; the honest record is that it was skipped for cost, not because no fork existed."
     }
   ],
   "flags": []

--- a/.pipeline/exp-airlock/status.json
+++ b/.pipeline/exp-airlock/status.json
@@ -1,0 +1,12 @@
+{
+  "issue_number": null,
+  "current_phase": "1-ba",
+  "started_at": "2026-08-19T20:00:00Z",
+  "updated_at": "2026-08-19T20:00:00Z",
+  "branch": "feat/phase-guard",
+  "ask_text": "Make phase entry granted by a script rather than assumed by the orchestrator, plus typed provenance fields and evidence admissibility.",
+  "risk_tier": "architectural",
+  "review_rounds": 0,
+  "events": [{"phase":"0.5-map","verdict":"complete","at":"2026-08-19T20:00:00Z","note":"26 phase literals / ~20 sequencing rules; corrected the enforcement table; voice-lint rule-table rot is the precedent"}],
+  "flags": []
+}

--- a/plugins/pipeline/commands/phase.md
+++ b/plugins/pipeline/commands/phase.md
@@ -32,7 +32,7 @@ Example invocations:
 1. **Resolve the absolute artifact dir.** Run `PIPELINE_BASE="$(git rev-parse --show-toplevel)/.pipeline"`, `ARTIFACT_DIR="$PIPELINE_BASE/<issue>"`. Pass `ARTIFACT_DIR` (fully expanded) into the subagent prompt, exactly as `/pipeline` does, so the subagent reads and writes artifacts at an absolute path and never resolves `.pipeline/...` from its own cwd. For a phase that runs inside the implementation worktree (`dev`, `qa`, `peer-review`), `ARTIFACT_DIR` is `<WORKTREE_PATH>/.pipeline/<issue>` instead, matching `/pipeline` Phases 3-4.
 2. If `--issue` provided: verify `$ARTIFACT_DIR/` exists. If not, halt and tell the owner.
 3. Read `$ARTIFACT_DIR/status.json` (if present) to understand the pipeline's current state.
-4. Verify the phase is a valid next step or a re-run. Do not block on order; the owner may be intentionally re-running.
+4. Verify the phase is a valid next step or a re-run. A re-run is legitimate and this command does not police order, but it is not exempt from the phase-entry guard: the guard runs at YOUR turn boundary, it cannot tell a `/phase` invocation from a `/pipeline` one, and it judges the record rather than the intent. So a `/phase ba` on an architectural run whose record shows no `map.json` and no `0.5-map` event is refused when the turn ends, and correctly: the run genuinely has no map. Clear it the way the refusal says -- run the missing phase, or record the deviation as a `SKIPPED` event with a written note.
 
 ---
 
@@ -116,7 +116,7 @@ In the full `/pipeline` run the Librarian is dispatched NON-BLOCKING at Phase 5 
 
 After the subagent returns:
 1. Validate the expected artifact was written or updated.
-2. Update `.pipeline/<issue>/status.json` to append a `"phase-rerun"` event with timestamp.
+2. Update `.pipeline/<issue>/status.json` to append a `<phase-token>-rerun` event with timestamp: `{"phase": "1-ba-rerun", "verdict": "<verdict>", "at": "<iso>"}` for `/phase ba`, `3b-dev-rerun` for `/phase dev`, and so on. The token prefix is load-bearing rather than cosmetic: a phase-less label resolves to no phase at all, so a re-run that did real work would leave a record that cannot clear the phase-entry guard, and the owner would be refused at their own turn boundary for work they just watched complete.
 3. Return to the owner with the subagent's verdict, in your own words per `${CLAUDE_PLUGIN_ROOT}/voice.md`.
 
 **On voice.** You are invoked by hand, so the owner is sitting there waiting on this one result: you are talking to them directly, not to a parent orchestrator. Do not relay the subagent's raw text. It was written for a machine reader, in its specialist's register (table names, CVE severity, line numbers), and it assumes context the owner does not have.

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -19,7 +19,7 @@ The phases are **gates, not a one-way waterfall**. The shape of the work, not th
 **Argument:** `$ARGUMENTS`
 
 Parse the argument:
-- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipeline/<issue>/status.json`, continue from the phase after `current_phase`.
+- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipeline/<issue>/status.json`, and re-enter the phase named by `current_phase` from the top (see the durable-checkpoint convention below; `current_phase` is an ENTRY marker, so the phase it names has not been completed).
 - If starts with `--issue <number>`: set `ISSUE=<number>` (existing tracker issue), start at Phase 2 (skip BA spec creation; BA reads the existing issue and seeds spec.json).
 - Otherwise: treat as a fresh ask text. No issue number yet. BA will create one.
 
@@ -63,6 +63,8 @@ Non-negotiables (carry through to every subagent prompt you construct):
 **`ask_text` is a truncated, human-written task summary. It must never carry a secret.** If a /pipeline argument contains a token-shaped substring (API key, Bearer token, OAuth code, password, `.env` line), redact it before writing `ask_text`, because `status.json` is committed to git history (see the durable-checkpoint convention below) and a pasted secret would persist there. Only the truncated ask, phase events, and 140-char flag summaries are written to `status.json`; no code path copies provider tokens, Bearer tokens, OAuth codes, or database rows into it.
 
 Append an entry to `events` after each phase transition: `{"phase": "1-ba", "verdict": "<agent verdict>", "at": "<iso>"}`.
+
+**The exit event for phase N and the entry checkpoint for phase N+1 are ONE write, in that order, committed together.** Appending the closing event first and checkpointing the next phase second are not two steps to be interleaved with anything, least of all with the end of a turn. The Stop hook fires at the turn boundary and a turn very commonly ends right after a checkpoint commit, so checkpointing first and appending later leaves a window in which the record says "entering 3-impl" with neither `design.json` (absent in a fresh checkout, because every artifact except `status.json` is gitignored) nor a closing 2.5 event. The phase-entry guard is CORRECT to refuse in that window -- the record is the only truth it has, and it genuinely does not show the phase closed -- so this convention, not a guard exemption, is what prevents the state.
 
 **`events[]` entries are EXIT markers and `current_phase` is an ENTRY marker.** An event is appended AFTER a phase finishes and carries that phase's `verdict`, so it records a phase CLOSING; `current_phase` is set BEFORE a phase begins and names the phase being ENTERED. Two fields with opposite conventions five lines apart is the trap that made the telemetry credit every interval to the wrong phase, so the two are named here rather than left to be inferred.
 

--- a/plugins/pipeline/hooks/session-start.sh
+++ b/plugins/pipeline/hooks/session-start.sh
@@ -137,6 +137,36 @@ if [[ -d .pipeline ]]; then
     printf '%s' "$ACTIVE"
     echo ""
   fi
+
+  # --- Phase-entry guard availability ---
+  #
+  # The Stop-hook guard (scripts/gate-phase-entry.mjs) fails OPEN on tooling: a missing node or
+  # a missing script disarms it exactly like a grant, permanently, with nothing said at the
+  # moment it happens. That disarm occurs in the OPERATOR's environment, and session start is
+  # the only place in that environment this plugin already speaks, so the check is paid once
+  # here instead of at every stop.
+  GATE_SCRIPT="$(dirname "${BASH_SOURCE[0]}")/../scripts/gate-phase-entry.mjs"
+  GATE_DISARM=""
+  [[ -f "$GATE_SCRIPT" ]] || GATE_DISARM="its script is not installed"
+  command -v node >/dev/null 2>&1 || GATE_DISARM="node is not on this hook's PATH"
+  if [[ -n "$GATE_DISARM" ]]; then
+    # "In flight" is APPROXIMATED here, and it has to be: this must report in the very
+    # environment where node is absent, so there is nothing available to parse an ISO
+    # `updated_at`. The file's own mtime stands in for it. "Guarded" reuses the phase-5 /
+    # completed_at / final_verdict exclusions rather than restating the guard's 15-row phase
+    # table, which would be a second vocabulary with no drift test behind it, so the notice is
+    # a superset: a run parked in a tripwire state is not guarded but is still reported here.
+    for dir in .pipeline/[0-9]*/ .pipeline/exp-*/; do
+      [[ -f "$dir/status.json" ]] || continue
+      grep -q '"completed_at"\|"final_verdict"' "$dir/status.json" 2>/dev/null && continue
+      PHASE=$(grep -oE '"current_phase"[[:space:]]*:[[:space:]]*"[^"]*"' "$dir/status.json" 2>/dev/null | head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
+      [[ "$PHASE" == 5-* ]] && continue
+      [[ -n "$(find "$dir/status.json" -mtime -1 2>/dev/null)" ]] || continue
+      echo "NOTICE: a pipeline run is in flight and the phase-entry guard (scripts/gate-phase-entry.mjs) is DISARMED because $GATE_DISARM. A turn can end at a phase whose prerequisite was never produced and nothing will refuse it."
+      echo ""
+      break
+    done
+  fi
 fi
 
 # CUSTOMIZE: if your project wires monitoring / DB / log / docs data sources (via MCP or CLI),

--- a/plugins/pipeline/hooks/stop.sh
+++ b/plugins/pipeline/hooks/stop.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
-# Stop hook (agent-pipeline plugin). When the project defines a check command AND the working
-# tree has uncommitted changes, run the check; block completion (exit 2 + stderr) if it fails,
-# nudging the model to fix rather than declare the task done. No-op (exit 0) when no check is
-# configured. Fail-open on any tooling error.
+# Stop hook (agent-pipeline plugin). Two blocking steps, in this order: the phase-entry guard
+# (a pipeline run may not END a turn at a phase whose prerequisite was never produced), then
+# the project check (when a check command is configured AND the tree has uncommitted changes,
+# run it and block completion with exit 2 + stderr if it fails, nudging the model to fix rather
+# than declare the task done). No-op (exit 0) when neither applies.
+#
+# FAIL DIRECTION, which is no longer one rule. The project check and the voice lint are
+# fail-open throughout: any tooling error is a no-op. The phase-entry guard splits the two
+# apart, because they are events in different environments: its DECISION is fail-CLOSED (a
+# recognised phase with an absent prerequisite refuses, and that is discretion exercised inside
+# the agent session), while its TOOLING stays fail-OPEN (no node, no script, no readable
+# record -> exit 0 in silence, because that is the operator's machine and not a decision at
+# all). A tooling fail-open is invisible by construction, so hooks/session-start.sh reports a
+# disarmed guard once per session.
 #
 # Deliberately `set -u` only (NOT -e / pipefail): the check's exit code is handled explicitly,
 # and an early abort would defeat the block-on-failure behavior.
@@ -27,7 +37,30 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 PAYLOAD=""
 if [[ ! -t 0 ]]; then PAYLOAD=$(cat 2>/dev/null || true); fi
 
-# Opt-out for one-off iterations.
+# Phase-entry guard. Placement is a WINDOW, not a floor. It sits BELOW the PAYLOAD read because
+# stdin is not re-readable: above it, this step would consume the payload, PAYLOAD would come
+# back empty, and the voice lint would be skipped by its own emptiness test with no error
+# anywhere. It sits ABOVE every early exit below it, all five of which are states in which a
+# turn very commonly ends -- a checkpoint commit leaves the tree CLEAN, and an adopting project
+# with no checkCommand and no package.json typecheck script exits before the clean-tree check
+# is ever reached, so a guard placed lower would be inert exactly when it matters most.
+#
+# Only exit code 2 blocks. Its stderr is a fixed template built from the phase table, never
+# from status.json's free text, and nothing else this step could print is repeated here.
+GATE="$(dirname "${BASH_SOURCE[0]}")/../scripts/gate-phase-entry.mjs"
+if [[ -f "$GATE" ]] && command -v node >/dev/null 2>&1; then
+  GATE_ERR=$(node "$GATE" --root "$PROJECT_DIR" 2>&1 >/dev/null </dev/null)
+  GATE_RC=$?
+  if [[ "$GATE_RC" -eq 2 && -n "$GATE_ERR" ]]; then
+    printf '%s\n' "$GATE_ERR" >&2
+    exit 2
+  fi
+fi
+
+# CLAUDE_HOOK_STOP_SKIP bypasses the voice lint and the project check for one-off iterations,
+# but NOT the phase-entry guard, which sits above this line and can still exit 2: an
+# environment variable that disarms a halting control leaves no trace in the archived run
+# record, and this repo has already refused that shape twice.
 [[ "${CLAUDE_HOOK_STOP_SKIP:-0}" == "1" ]] && exit 0
 
 # Voice lint. Runs BEFORE the project check because it is the cheaper of the two and its

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -339,7 +339,17 @@ function refusalMessage(result) {
     // The guard only holds turns for a run it can still see in flight, so concluding an abandoned
     // one clears it and refuses nothing. Without this route the in-flight predicate's own escape
     // hatch was undocumented at the only moment anyone needs it.
-    `  3. If this run is over, conclude it: give ${dir}/status.json a \`final_verdict\`, a \`completed_at\`, or \`"current_phase": "5-archived"\`. A run this guard cannot see in flight is never refused.`,
+    //
+    // It is also the WIDEST and CHEAPEST disarm this guard has, and naming it here is what made
+    // that worth stating. Route 2 clears ONE row and costs a written note that stays in the
+    // committed record; route 3 clears every remaining row of the run at once, at zero cost, and
+    // records no reason. Measured: a refusing record at `3-impl` given a `final_verdict` goes
+    // rc 2 -> 0, and every later phase of that run is not-applicable thereafter. That is the same
+    // affirmative-act class as back-dating `updated_at` past the in-flight ceiling, disclosed in
+    // the spec's guarantee_and_threat_model.does_not_stop rather than defended against -- the
+    // capability is the in-flight predicate's, not this message's. Hence "YOURS": the one thing
+    // the text can do is stop reading as a licence to conclude somebody else's run.
+    `  3. If this run is YOURS and is over, conclude it: give ${dir}/status.json a \`final_verdict\`, a \`completed_at\`, or \`"current_phase": "5-archived"\`. A run this guard cannot see in flight is never refused.`,
     `A /phase re-run that did the work records it the same way, as a \`<phase-token>-rerun\` event (e.g. \`1-ba-rerun\`); the bare \`phase-rerun\` label resolves to no phase and clears nothing.`,
   ].join("\n");
 }

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -208,12 +208,18 @@ function eventsSatisfy(events, tokens) {
  * artifact is, so an unapproved spec.json would be waved through by the event that recorded the
  * BA dispatch. The events path exists for the fresh checkout, where the artifact is absent
  * because everything except status.json is gitignored, and there it is knowingly weaker.
+ *
+ * Returns WHICH SOURCE decided as well as the outcome, because the two refusals need different
+ * messages: telling an operator that a file they are looking at is not present, and telling them
+ * to re-run the phase that already produced it, are both false on a content failure.
  */
 function prerequisiteSatisfied(issueDir, row, events) {
-  if (!row.file) return true;
+  if (!row.file) return { ok: true, artifact: "none" };
   const artifactPath = path.join(issueDir, row.file);
-  if (existsSync(artifactPath)) return contentSatisfies(artifactPath, row);
-  return eventsSatisfy(events, row.tokens);
+  if (existsSync(artifactPath)) {
+    return { ok: contentSatisfies(artifactPath, row), artifact: "present" };
+  }
+  return { ok: eventsSatisfy(events, row.tokens), artifact: "absent" };
 }
 
 /**
@@ -275,17 +281,21 @@ function decideForDir(issueDir, now) {
   }
 
   const row = rowFor(phase, tier);
-  if (prerequisiteSatisfied(issueDir, row, status.events)) {
+  const prereq = prerequisiteSatisfied(issueDir, row, status.events);
+  if (prereq.ok) {
     return decided("granted", `${at}: its prerequisite is satisfied.`);
   }
+  const reason =
+    prereq.artifact === "present"
+      ? `${at} (${tier}) has a \`${row.file}\` that does not satisfy this row, and a present artifact is not rescued by events[].`
+      : `${at} (${tier}) has no \`${row.file}\` and no events[] entry recording that phase closing.`;
   return {
-    ...decided(
-      "refused",
-      `${at} (${tier}) has no \`${row.file}\` and no events[] entry recording that phase closing.`,
-    ),
+    ...decided("refused", reason),
     phase,
     file: row.file,
     tier,
+    artifact: prereq.artifact,
+    content: row.content || null,
   };
 }
 
@@ -297,15 +307,39 @@ function decideForDir(issueDir, now) {
  * i.e. it treats that field as one that can receive a pasted token before anyone notices, and
  * stderr is fed straight back into the transcript.
  */
+const CONTENT_DIAGNOSIS = {
+  "ba-approved": "carries no `ba_approved_at`",
+  "non-empty": "is empty",
+};
+
+const CONTENT_REPAIR = {
+  "ba-approved": "Record BA's approval: set `ba_approved_at` in",
+  "non-empty": "Write the content that phase produces into",
+};
+
 function refusalMessage(result) {
   const dir = `.pipeline/${result.issue_dir}`;
+  // A refusal on a PRESENT artifact must not send the operator after a missing file. Both of the
+  // absent-case lines are false there -- the file is in front of them, and re-running the phase
+  // that produced it changes nothing -- and this is the text a blocked turn reads.
+  const present = result.artifact === "present";
+  const diagnosis = present
+    ? `Its prerequisite \`${result.file}\` IS present in ${dir}, but it ${CONTENT_DIAGNOSIS[result.content] || "does not satisfy this row"}. A present artifact settles the row on its own; events[] are not consulted to rescue it, or the event that recorded the phase being DISPATCHED would stand in for its approval.`
+    : `Its prerequisite \`${result.file}\` is not present in ${dir}, and no events[] entry records that phase closing.`;
+  const route1 = present
+    ? `  1. ${CONTENT_REPAIR[result.content] || "Supply the content this row requires in"} ${dir}/${result.file}, then commit it.`
+    : `  1. Run the phase that produces \`${result.file}\`, then append its events[] entry and commit ${dir}/status.json.`;
   return [
     `Phase-entry guard: this turn cannot end with ${dir} recorded at \`${result.phase}\`.`,
-    `Its prerequisite \`${result.file}\` is not present in ${dir}, and no events[] entry records that phase closing.`,
+    diagnosis,
     `Work already done in this turn is not undone; only the turn boundary is blocked.`,
-    `Two ways to clear it:`,
-    `  1. Run the phase that produces \`${result.file}\`, then append its events[] entry and commit ${dir}/status.json.`,
+    `Ways to clear it:`,
+    route1,
     `  2. If the skip was deliberate, record it: append an events[] entry for the phase you skipped with "verdict": "SKIPPED" and a non-empty "note" saying why.`,
+    // The guard only holds turns for a run it can still see in flight, so concluding an abandoned
+    // one clears it and refuses nothing. Without this route the in-flight predicate's own escape
+    // hatch was undocumented at the only moment anyone needs it.
+    `  3. If this run is over, conclude it: give ${dir}/status.json a \`final_verdict\`, a \`completed_at\`, or \`"current_phase": "5-archived"\`. A run this guard cannot see in flight is never refused.`,
     `A /phase re-run that did the work records it the same way, as a \`<phase-token>-rerun\` event (e.g. \`1-ba-rerun\`); the bare \`phase-rerun\` label resolves to no phase and clears nothing.`,
   ].join("\n");
 }

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+/**
+ * The phase-entry guard: decides whether the run recorded in `.pipeline/<issue>/status.json`
+ * is allowed to be where it says it is.
+ *
+ *   node gate-phase-entry.mjs [--root <project-root>]
+ *
+ * Prints ONE line of JSON on a decision -- {"decision","reason","issue_dir"} -- and exits 2 on
+ * `refused`, 0 on `granted` and `not-applicable`. A tooling failure prints NOTHING and exits 0.
+ *
+ * WHAT IT IS. A turn-boundary consistency gate, wired into hooks/stop.sh. It prevents a turn
+ * from ENDING in a state whose prerequisites are absent, and forces the orchestrator to either
+ * do the missed work or say in writing that it skipped it.
+ *
+ * WHAT IT IS NOT (verbatim from the spec's guarantee_and_threat_model, because a stated limit
+ * that gets paraphrased is how a limit becomes a guarantee):
+ * A pre-dispatch airlock. It CANNOT prevent a phase being skipped mid-turn; the phase's absence is detected when the turn tries to end. The cost of a skip is therefore the wasted work in that turn, not zero. Work already done in this turn is not undone.
+ *
+ * WHOSE RUN IT JUDGES, AND THE LIMITATION IT INHERITS. The active issue is resolved through
+ * validate-pipeline-artifact.mjs's activeIssueDir seam. That seam's top-priority `active_issue`
+ * marker is populated from a SubagentStop payload, NOT the Stop payload, so from this hook the
+ * active issue will almost always resolve through the mtime fallback: the newest status.json
+ * among the issue dirs. Two consequences are load-bearing and neither is hypothetical:
+ *   - The Stop hook is PROJECT-scoped, not run-scoped, so without a recency ceiling an
+ *     abandoned run parked at a guarded phase would refuse every turn in that project forever.
+ *     Hence the in-flight predicate below (R6), reusing pipeline-status.mjs's own 24h /
+ *     no-final-verdict definition rather than inventing a second one.
+ *   - An explicit signal (CLAUDE_PIPELINE_ACTIVE_ISSUE / PIPELINE_ACTIVE_ISSUE) must not be
+ *     able to NARROW the subject: pointing it at a satisfied dir would be the env-var opt-out
+ *     the design rejected, and it would leave no trace in the archived record. So both the
+ *     signal-named dir and the mtime-derived dir are evaluated, and EITHER may refuse (R6b).
+ *
+ * FAIL-DIRECTION SPLIT (R11), which is a contract change to a hook that declares itself
+ * fail-open, so it is stated in both places. The DECISION is fail-CLOSED: a recognised phase
+ * whose prerequisite is absent refuses. The TOOLING is fail-OPEN: node absent, this file
+ * absent, status.json absent or unparseable, no resolvable active issue, or any thrown error
+ * exits 0 in silence. The events are in different environments, which is the whole reason the
+ * split is legitimate: a skipped phase happens inside the agent session and is discretion; a
+ * missing Node install happens in the operator's environment and is not. Because that
+ * fail-open is permanently invisible, hooks/session-start.sh reports it once per session.
+ *
+ * VOCABULARY. This module declares NO phase list and NO phase-shape regex of its own. Event
+ * labels resolve through the shared phaseKey/KNOWN_PHASES resolver, and every token in every
+ * satisfying set below is asserted by the drift suite to be a member of the imported
+ * KNOWN_PHASES. Prefix / startsWith comparison is forbidden by name: `"2.5"` shares a leading
+ * character with `"2"`, so a prefix rule lets a recorded 2.5-design skip clear the Phase 2
+ * review gate it never ran.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { isMain } from "./lib.mjs";
+import { KNOWN_TIERS } from "./dispatch-model.mjs";
+import { phaseKey } from "./pipeline-telemetry.mjs";
+import { activeIssueDir } from "./validate-pipeline-artifact.mjs";
+
+/**
+ * The 15 guarded rows: the 8 phases pipeline.md checkpoints into ("Checkpoint first:") and the
+ * 7 `<phase>-complete` literals it parks at. Each row carries its own prerequisite file and its
+ * own SATISFYING TOKEN SET -- the tokens that, seen in events[], stand in for that file.
+ *
+ * TWO EXCLUSIONS ARE LOAD-BEARING, and each closes a hole traced on real records.
+ *   - `2.5-design` satisfies on {2}, NOT {2, 2.5}. Its own token must not appear, or the
+ *     recorded 2.5-design SKIPPED entry in .pipeline/17 would self-grant the phase it skipped.
+ *   - `4-review` and `3-impl-complete` satisfy on {3, 3b} and EXCLUDE 3a. An events[] carrying
+ *     only 3a-qa-tests means QA authored the contract and Dev was never dispatched; granting
+ *     there would declare a run panel-ready when the implementation step never ran.
+ *
+ * `content` marks a row whose prerequisite is not satisfied by mere presence. Such a row is
+ * strictly weaker through events[] than through the file, because an event attests DISPATCH,
+ * never APPROVAL, and that asymmetry is stated rather than defended against.
+ */
+const PREREQUISITES = {
+  "0.5-map": { file: null, tokens: [] },
+  "1-ba": { file: "map.json", tokens: ["0.5"], tiers: ["architectural"] },
+  "2-constraints": { file: "spec.json", tokens: ["1"], content: "ba-approved" },
+  "2-review": { file: "spec.json", tokens: ["1"], content: "ba-approved" },
+  "2.5-design": { file: "review.json", tokens: ["2"] },
+  "3-impl": {
+    byTier: {
+      trivial: { file: "spec.json", tokens: ["1"] },
+      standard: { file: "constraints.md", tokens: ["2"], content: "non-empty" },
+      architectural: { file: "design.json", tokens: ["2.5"] },
+    },
+  },
+  "4-review": { file: "impl-report.json", tokens: ["3", "3b"] },
+  "5-archive": { file: "peer-review.json", tokens: ["4"] },
+  "0.5-map-complete": { file: "map.json", tokens: ["0.5"] },
+  "1-ba-complete": { file: "spec.json", tokens: ["1"] },
+  "2-constraints-complete": { file: "constraints.md", tokens: ["2"] },
+  "2-review-complete": { file: "review.json", tokens: ["2"] },
+  "2.5-design-complete": { file: "design.json", tokens: ["2.5"] },
+  "3-impl-complete": { file: "impl-report.json", tokens: ["3", "3b"] },
+  "4-review-complete": { file: "peer-review.json", tokens: ["4"] },
+};
+
+const GUARDED = Object.keys(PREREQUISITES);
+
+/** The entry/exit split is DERIVED from the one table, so the two cannot drift apart. */
+export const ENTRY = GUARDED.filter((p) => !p.endsWith("-complete"));
+export const EXIT = GUARDED.filter((p) => p.endsWith("-complete"));
+
+/**
+ * Phases that are explicitly NOT guarded: a run parked in a halt, a tripwire, an open-questions
+ * pause or a rework state has already stopped, and refusing its turn would trap the owner in
+ * the state the halt exists to surface.
+ */
+export const UNGUARDED = [
+  "1-ba-open-questions",
+  "1-ba-rework-required",
+  "2.5-design-owner-decision",
+  "3-impl-frontend-gate-failed",
+  "3-impl-gate-failed",
+  "3-impl-live-verify-unverified",
+  "3-impl-tripwire",
+  "3-impl-tripwire-indeterminate",
+  "4-veto-rework-required",
+];
+
+/**
+ * The terminal literal pipeline.md writes. The runtime terminal check below is wider than this
+ * set on purpose (it also covers `halted-error`, any `<phase>-error` instantiation, and any
+ * record carrying `completed_at`), but only the pipeline.md literal belongs in the set the
+ * drift suite partitions.
+ */
+export const TERMINAL = ["5-archived"];
+
+const IN_FLIGHT_MS = 24 * 60 * 60 * 1000;
+
+/** An unusable risk_tier resolves to the STRICTEST row, never the loosest. */
+function normalizeTier(tier) {
+  return KNOWN_TIERS.includes(tier) ? tier : "architectural";
+}
+
+function rowFor(phase, tier) {
+  const raw = PREREQUISITES[phase];
+  if (!raw) return null;
+  if (raw.byTier) return raw.byTier[tier] || raw.byTier.architectural;
+  return raw;
+}
+
+/** A row that only exists at some tiers (the deep map is architectural-only). */
+function appliesAtTier(phase, tier) {
+  const raw = PREREQUISITES[phase];
+  return !raw || !raw.tiers || raw.tiers.includes(tier);
+}
+
+/**
+ * The row's satisfying token set. Empty for a phase with no prerequisite and for any phase that
+ * is not a guarded row, so a caller cannot read "no tokens" as "any token will do".
+ */
+export function satisfyingTokens(phase, tier) {
+  const row = rowFor(phase, normalizeTier(tier));
+  return row && Array.isArray(row.tokens) ? [...row.tokens] : [];
+}
+
+function contentSatisfies(artifactPath, row) {
+  if (row.content === "ba-approved") {
+    try {
+      const doc = JSON.parse(readFileSync(artifactPath, "utf8"));
+      return typeof doc.ba_approved_at === "string" && doc.ba_approved_at.trim() !== "";
+    } catch {
+      return false;
+    }
+  }
+  if (row.content === "non-empty") {
+    try {
+      return readFileSync(artifactPath, "utf8").trim() !== "";
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Path (b): an events[] entry whose RESOLVED token is a member of the row's set.
+ *
+ * No verdict is required. events[].verdict is optional in the schema and a committed record
+ * carries six verdict-less events, so a verdict-keyed rule would reject a schema-valid record;
+ * and the artifact an event stands in for exists whatever the verdict said, because a review
+ * that demanded changes still ran. The ONE exception is a recorded SKIP, which is the deviation
+ * hatch and costs a written reason -- without the note the hatch is free, and a free hatch is
+ * not a hatch. A noteless skip only disqualifies THAT entry; another entry may still satisfy.
+ */
+function eventsSatisfy(events, tokens) {
+  if (!Array.isArray(events) || tokens.length === 0) return false;
+  for (const event of events) {
+    if (!event || typeof event !== "object") continue;
+    const token = phaseKey(event.phase);
+    if (token === null || !tokens.includes(token)) continue;
+    if (event.verdict === "SKIPPED") {
+      const note = typeof event.note === "string" ? event.note.trim() : "";
+      if (note === "") continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Two sources, in priority order: the artifact, then the record.
+ *
+ * A PRESENT artifact decides the row by itself, including when its CONTENT fails the row's
+ * condition -- events[] are not consulted to rescue it. Otherwise the `content` column would be
+ * dead on any real run: a dispatch event for the phase is always present by the time its
+ * artifact is, so an unapproved spec.json would be waved through by the event that recorded the
+ * BA dispatch. The events path exists for the fresh checkout, where the artifact is absent
+ * because everything except status.json is gitignored, and there it is knowingly weaker.
+ */
+function prerequisiteSatisfied(issueDir, row, events) {
+  if (!row.file) return true;
+  const artifactPath = path.join(issueDir, row.file);
+  if (existsSync(artifactPath)) return contentSatisfies(artifactPath, row);
+  return eventsSatisfy(events, row.tokens);
+}
+
+/**
+ * A run is IN FLIGHT when it was updated under 24h ago and carries no final verdict -- the
+ * predicate pipeline-status.mjs already uses to call a run "possibly stuck", inverted. A record
+ * with no readable `updated_at` is not in flight: the guard cannot date it, and a control that
+ * cannot date a record must not hold a project's turns open on it.
+ */
+function inFlight(status, now) {
+  if (status.final_verdict) return false;
+  const updated = Date.parse(status.updated_at);
+  if (!Number.isFinite(updated)) return false;
+  return now - updated <= IN_FLIGHT_MS;
+}
+
+function isTerminal(phase, status) {
+  if (status.completed_at) return true;
+  if (TERMINAL.includes(phase)) return true;
+  if (phase === "halted-error") return true;
+  return /-error$/.test(phase);
+}
+
+/**
+ * The decision for ONE issue dir. Returns null for a tooling failure (unreadable record), which
+ * the caller renders as silence rather than as a decision.
+ */
+function decideForDir(issueDir, now) {
+  const name = path.basename(issueDir);
+  let status;
+  try {
+    status = JSON.parse(readFileSync(path.join(issueDir, "status.json"), "utf8"));
+  } catch {
+    return null;
+  }
+  if (!status || typeof status !== "object" || Array.isArray(status)) return null;
+
+  const decided = (decision, reason) => ({ decision, reason, issue_dir: name });
+  const phase = typeof status.current_phase === "string" ? status.current_phase : "";
+  const at = `.pipeline/${name} at \`${phase}\``;
+
+  if (isTerminal(phase, status)) return decided("not-applicable", `${at} is finished.`);
+  if (UNGUARDED.includes(phase)) {
+    return decided("not-applicable", `${at} is a halt or rework state, which is never guarded.`);
+  }
+  // Fail-OPEN on vocabulary, fail-CLOSED on sequence. An unrecognised phase is a gap in this
+  // table's knowledge, not an orchestrator exercising discretion, and status.schema.json blesses
+  // at least two phases pipeline.md never writes -- deny-by-default would refuse every turn in a
+  // project holding one of those records.
+  if (!GUARDED.includes(phase)) {
+    return decided("not-applicable", `${at}, which is not a guarded phase.`);
+  }
+  if (!inFlight(status, now)) {
+    return decided("not-applicable", `${at} is not in flight (stale or already concluded).`);
+  }
+
+  const tier = normalizeTier(status.risk_tier);
+  if (!appliesAtTier(phase, tier)) {
+    return decided("not-applicable", `${at} is not a guarded phase at the ${tier} tier.`);
+  }
+
+  const row = rowFor(phase, tier);
+  if (prerequisiteSatisfied(issueDir, row, status.events)) {
+    return decided("granted", `${at}: its prerequisite is satisfied.`);
+  }
+  return {
+    ...decided(
+      "refused",
+      `${at} (${tier}) has no \`${row.file}\` and no events[] entry recording that phase closing.`,
+    ),
+    phase,
+    file: row.file,
+    tier,
+  };
+}
+
+/**
+ * The stderr message on a refusal. FIXED TEMPLATE, four bounded values, no passthrough: the
+ * phase and the filename come from the table above, and the dir name matched the issue-dir
+ * shape. status.json's free-text fields (ask_text, events[].note, error) are NEVER interpolated
+ * -- the schema itself says ask_text "must never carry a secret" because the file is committed,
+ * i.e. it treats that field as one that can receive a pasted token before anyone notices, and
+ * stderr is fed straight back into the transcript.
+ */
+function refusalMessage(result) {
+  const dir = `.pipeline/${result.issue_dir}`;
+  return [
+    `Phase-entry guard: this turn cannot end with ${dir} recorded at \`${result.phase}\`.`,
+    `Its prerequisite \`${result.file}\` is not present in ${dir}, and no events[] entry records that phase closing.`,
+    `Work already done in this turn is not undone; only the turn boundary is blocked.`,
+    `Two ways to clear it:`,
+    `  1. Run the phase that produces \`${result.file}\`, then append its events[] entry and commit ${dir}/status.json.`,
+    `  2. If the skip was deliberate, record it: append an events[] entry for the phase you skipped with "verdict": "SKIPPED" and a non-empty "note" saying why.`,
+    `A /phase re-run that did the work records it the same way, as a \`<phase-token>-rerun\` event (e.g. \`1-ba-rerun\`); the bare \`phase-rerun\` label resolves to no phase and clears nothing.`,
+  ].join("\n");
+}
+
+/**
+ * A sentinel the issue-dir shape rejects, so activeIssueDir's signal branch fails over to its
+ * mtime derivation. It is passed as the payload field rather than by unsetting the environment,
+ * because the point is to ask ONE resolver two questions -- "who does the signal name" and "who
+ * is newest" -- without a second scan that could answer differently.
+ */
+const MTIME_ONLY = "!";
+
+function candidateDirs(pipelineDir) {
+  const dirs = [];
+  for (const dir of [
+    activeIssueDir(pipelineDir, {}),
+    activeIssueDir(pipelineDir, { active_issue: MTIME_ONLY }),
+  ]) {
+    if (dir && !dirs.includes(dir)) dirs.push(dir);
+  }
+  return dirs;
+}
+
+function parseRoot(argv) {
+  const i = argv.indexOf("--root");
+  if (i !== -1 && argv[i + 1]) return argv[i + 1];
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+function main() {
+  const pipelineDir = path.join(parseRoot(process.argv.slice(2)), ".pipeline");
+  if (!existsSync(pipelineDir)) return;
+
+  const now = Date.now();
+  const results = [];
+  for (const dir of candidateDirs(pipelineDir)) {
+    const result = decideForDir(dir, now);
+    if (result) results.push(result);
+  }
+  if (results.length === 0) return; // no resolvable, readable active issue: silence
+
+  // EITHER dir may refuse. That is what stops the explicit signal from being strictly more
+  // permissive than leaving it unset, which is the env-var opt-out this design rejected.
+  const chosen =
+    results.find((r) => r.decision === "refused") ||
+    results.find((r) => r.decision === "granted") ||
+    results[0];
+
+  process.stdout.write(
+    `${JSON.stringify({
+      decision: chosen.decision,
+      reason: chosen.reason,
+      issue_dir: chosen.issue_dir,
+    })}\n`,
+  );
+  if (chosen.decision === "refused") {
+    process.stderr.write(`${refusalMessage(chosen)}\n`);
+    process.exitCode = 2;
+  }
+}
+
+// Self-run ONLY as a real CLI entry. isMain compares the basename of argv[1], and the drift
+// suite passes THIS module's path as argv[1] to an eval script that imports it -- self-running
+// there would print a decision into the middle of that suite's own report and could exit(2)
+// mid-import, turning a test of the exported sets into a test of the caller's .pipeline tree.
+const evalEntry = process.execArgv.some(
+  (a) => a === "-e" || a === "--eval" || a === "--input-type=module" || /^--eval=/.test(a),
+);
+if (isMain("gate-phase-entry.mjs") && !evalEntry) {
+  try {
+    main();
+  } catch {
+    // Fail-OPEN on tooling: a guard that crashes must never wedge a turn, and it must not
+    // announce the crash either, because stderr here is read as a refusal.
+    process.exitCode = 0;
+  }
+}

--- a/plugins/pipeline/scripts/pipeline-telemetry.mjs
+++ b/plugins/pipeline/scripts/pipeline-telemetry.mjs
@@ -103,8 +103,13 @@ function parseTime(v) {
  * drop its time: it lands in `unattributed_ms`, which is a number a reader can see. Adding a
  * phase to KNOWN_PHASES is what teaches this function to attribute it, so the declaration and
  * the accounting cannot drift apart.
+ *
+ * EXPORTED because gate-phase-entry.mjs resolves the same labels for a different purpose, and
+ * a second copy of this three-line function would be a fourth phase vocabulary: it would keep
+ * working while KNOWN_PHASES moved underneath it, which is the exact rot the shape regex above
+ * already cost this repo once.
  */
-function phaseKey(phase) {
+export function phaseKey(phase) {
   if (typeof phase !== "string") return null;
   const dash = phase.indexOf("-");
   const token = dash === -1 ? phase : phase.slice(0, dash);

--- a/plugins/pipeline/tests/harness.sh
+++ b/plugins/pipeline/tests/harness.sh
@@ -14,6 +14,37 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 CURRENT_SUITE=""
 
+# ---- the assertion LEDGER: a counter that survives a subshell ----------------
+#
+# WHY A FILE. TESTS_PASSED/TESTS_FAILED are shell variables, so an assertion evaluated inside a
+# `( ... )`, a `$( ... )` or a pipeline element increments a COPY that is discarded when that
+# subshell exits. assert_* also returns 0 on both branches (the printf succeeds either way), so
+# the subshell's own exit status carries nothing either. The result is an assertion that PRINTS
+# its FAIL line and cannot fail the build: seven of them shipped in one suite, including two
+# non-zero CONTROLs whose only job was to be falsifiable, and the suite reported failed=0.
+#
+# Every assertion therefore records itself HERE as well, by appending a line. A file append
+# crosses a subshell boundary where a variable increment does not, so finish() can compare what
+# was RECORDED against what was COUNTED and refuse the mismatch. $BASH_SUBSHELL (present in bash
+# 3.2, which is what macOS ships) names the offenders rather than only reporting an arithmetic
+# gap.
+#
+# NOT mktemp: test-harness.sh sources this file with a deliberately failing mktemp stub on PATH,
+# and a harness that could not be sourced under that stub would break the suite that proves
+# new_tmpdir refuses an empty path. $$ is the SUITE's pid and stays the suite's pid inside a
+# subshell, which is exactly the scope wanted.
+_ASSERT_LEDGER="${TMPDIR:-/tmp}/.pipeline-test-harness-ledger.$$"
+: > "$_ASSERT_LEDGER" 2>/dev/null || _ASSERT_LEDGER=""
+
+# _ledger <ok|FAIL> <name>. Called AFTER the counter increment, so the recorded index is the
+# value the incrementing shell saw.
+_ledger() {
+  [[ -n "$_ASSERT_LEDGER" ]] || return 0
+  printf '%s\t%s\t%s\t%s\n' "$((TESTS_PASSED + TESTS_FAILED))" "$BASH_SUBSHELL" "$1" "$2" \
+    >> "$_ASSERT_LEDGER" 2>/dev/null
+  return 0
+}
+
 suite() {
   CURRENT_SUITE="$1"
   printf '\n%s\n' "$CURRENT_SUITE"
@@ -24,9 +55,11 @@ assert_eq() {
   local name="$1" actual="$2" expected="$3"
   if [[ "$actual" == "$expected" ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
+    _ledger ok "$name"
     printf '  ok    %s\n' "$name"
   else
     TESTS_FAILED=$((TESTS_FAILED + 1))
+    _ledger FAIL "$name"
     printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' "$name" "$expected" "$actual"
   fi
 }
@@ -35,9 +68,11 @@ assert_contains() {
   local name="$1" haystack="$2" needle="$3"
   if [[ "$haystack" == *"$needle"* ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
+    _ledger ok "$name"
     printf '  ok    %s\n' "$name"
   else
     TESTS_FAILED=$((TESTS_FAILED + 1))
+    _ledger FAIL "$name"
     printf '  FAIL  %s\n        expected to contain: %s\n        actual: %s\n' \
       "$name" "$needle" "$(printf '%s' "$haystack" | head -3)"
   fi
@@ -47,9 +82,11 @@ assert_not_contains() {
   local name="$1" haystack="$2" needle="$3"
   if [[ "$haystack" != *"$needle"* ]]; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
+    _ledger ok "$name"
     printf '  ok    %s\n' "$name"
   else
     TESTS_FAILED=$((TESTS_FAILED + 1))
+    _ledger FAIL "$name"
     printf '  FAIL  %s\n        expected NOT to contain: %s\n' "$name" "$needle"
   fi
 }
@@ -132,6 +169,9 @@ _cleanup_tmpdirs() {
     _remove_owned_tmpdir "$line"
   done <<< "$registry"
   TMP_REGISTRY=""                      # idempotent: a second run removes nothing
+  # The ledger is a single FILE at a path this process composed from its own pid, so it is
+  # removed by exact name and never through the dir registry above.
+  [[ -n "$_ASSERT_LEDGER" ]] && rm -f "$_ASSERT_LEDGER"
   return $rc
 }
 
@@ -181,8 +221,29 @@ trap '_cleanup_tmpdirs' EXIT
 trap '_cleanup_tmpdirs; exit 130' INT
 trap '_cleanup_tmpdirs; exit 143' TERM
 
+# Every assertion this suite RAN, versus every assertion it COUNTED. A mismatch means at least
+# one assert_* ran somewhere its increment could not survive -- a subshell, a command
+# substitution, a pipeline element -- so its FAIL would print and the suite would still exit 0.
+# That is an assertion which cannot fail the build, and it is indistinguishable from a passing
+# one in the output. Reported as a FAILURE of the suite, because a suite whose count is wrong
+# cannot support any claim about what it checked.
+_assert_count_guard() {
+  [[ -n "$_ASSERT_LEDGER" && -f "$_ASSERT_LEDGER" ]] || return 0
+  local recorded counted
+  recorded="$(grep -c . "$_ASSERT_LEDGER" | tr -d ' ')"
+  counted=$((TESTS_PASSED + TESTS_FAILED))
+  [[ "$recorded" -eq "$counted" ]] && return 0
+  printf '\nHARNESS: %s assertion(s) ran but %s were counted.\n' "$recorded" "$counted" >&2
+  printf 'An uncounted assertion prints its result and cannot fail the build.\n' >&2
+  printf 'Ran outside the shell that owns the counters (level > 0):\n' >&2
+  awk -F'\t' '$2 != 0 { printf "  [subshell level %s] %s  %s\n", $2, $3, $4 }' "$_ASSERT_LEDGER" >&2
+  printf 'Scope the environment/cwd around the CHILD PROCESS, not around the assertion.\n' >&2
+  return 1
+}
+
 finish() {
   printf '\npassed=%s failed=%s\n' "$TESTS_PASSED" "$TESTS_FAILED"
+  _assert_count_guard || return 1
   [[ "$TESTS_FAILED" -eq 0 ]]
 }
 

--- a/plugins/pipeline/tests/harness.sh
+++ b/plugins/pipeline/tests/harness.sh
@@ -33,8 +33,9 @@ CURRENT_SUITE=""
 # and a harness that could not be sourced under that stub would break the suite that proves
 # new_tmpdir refuses an empty path. $$ is the SUITE's pid and stays the suite's pid inside a
 # subshell, which is exactly the scope wanted.
-_ASSERT_LEDGER="${TMPDIR:-/tmp}/.pipeline-test-harness-ledger.$$"
-: > "$_ASSERT_LEDGER" 2>/dev/null || _ASSERT_LEDGER=""
+#
+# The ledger FILE is created further down, once the temp registry it is removed through exists.
+_ASSERT_LEDGER=""
 
 # _ledger <ok|FAIL> <name>. Called AFTER the counter increment, so the recorded index is the
 # value the incrementing shell saw.
@@ -162,6 +163,39 @@ _remove_owned_tmpdir() {
   rm -rf "$d"                          # the exact registered dir; never a "$d"/* glob
 }
 
+# ---- the ledger FILE, created inside a directory this process proved it owns ----------------
+#
+# The earlier shape composed a PREDICTABLE path directly in a world-writable dir and opened it
+# with truncation and no exclusivity (`: > "$path"`). MEASURED: with a symlink pre-placed at
+# that name, a 49-byte file elsewhere on disk went to 9 bytes and came back holding this
+# harness's own ledger line; the same run with no symlink left it byte-identical. TMPDIR is
+# unset on ubuntu-latest, so the dir was literally /tmp, and the sticky bit does not help --
+# it stops you deleting someone else's file, not creating an untaken name. run.sh is this
+# project's checkCommand, which stop.sh executes at every dirty-tree turn end, and each
+# run_child gets its own pid, so the blast radius is dozens of predictable names per run.
+#
+# mkdir is the fix that keeps the no-mktemp constraint above: it is atomic, it FAILS on an
+# existing path, and it does not follow a symlink. The ledger then lives inside a dir this
+# process is the only writer of. $RANDOM widens the name beyond the pid so a pre-placed
+# squat has to win a race rather than read a counter.
+_LEDGER_DIR="${TMPDIR:-/tmp}/.pipeline-harness.$$.${RANDOM}"
+if mkdir -m 700 "$_LEDGER_DIR" 2>/dev/null; then
+  TMP_REGISTRY="${TMP_REGISTRY}${_LEDGER_DIR}
+"
+  _ASSERT_LEDGER="$_LEDGER_DIR/ledger"
+else
+  # ANNOUNCE, do not refuse. An unwritable TMPDIR is a tooling condition in the operator's
+  # environment, and a harness that refused over it would be the wrong fail direction (this is
+  # a guard, not a prerequisite like require_node). But the DISARM must not be silent: measured
+  # on the old shape, an identical suite carrying one genuinely uncounted assertion exited 1
+  # with the offender named on a writable tmp and 0 with byte-identical stdout on an unwritable
+  # one. The only signal was bash's own redirection diagnostic, which says nothing about the
+  # guard and does not appear at all for a later append failure. Same shape as the once-per-
+  # session disarm notice in hooks/session-start.sh, for the same reason.
+  printf 'HARNESS: assertion ledger unavailable at %s; the uncounted-assertion guard is DISABLED for this suite.\n' \
+    "$_LEDGER_DIR" >&2
+fi
+
 _cleanup_tmpdirs() {
   local rc=$? line registry="$TMP_REGISTRY"
   while IFS= read -r line; do
@@ -169,9 +203,8 @@ _cleanup_tmpdirs() {
     _remove_owned_tmpdir "$line"
   done <<< "$registry"
   TMP_REGISTRY=""                      # idempotent: a second run removes nothing
-  # The ledger is a single FILE at a path this process composed from its own pid, so it is
-  # removed by exact name and never through the dir registry above.
-  [[ -n "$_ASSERT_LEDGER" ]] && rm -f "$_ASSERT_LEDGER"
+  # The ledger needs no special case: its DIRECTORY is registered like any other, so the loop
+  # above removed it by exact path through the same refusing helper.
   return $rc
 }
 

--- a/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# gate-phase-entry.mjs -- the drift tests, and the prose the guard is pinned to.
+#
+# WHY THESE ARE IMPORTS AND SET OPERATIONS, NOT GREPS. voice-lint.mjs records what the
+# alternative cost: its first phase table was written from memory, invented four phases nothing
+# writes and missed two real ones, and its drift test is `grep -q "\"$phase\"" "$LINT_SRC"` --
+# a substring grep that a phase named in a COMMENT satisfies and that cannot tell a table key
+# from a mention. The guard is a module, so this suite IMPORTS it and asserts set membership
+# over its exported sets. Counting uses `grep -o ... | wc -l`, never `grep -c`, which counts
+# LINES and would silently lower a count if two occurrences shared one.
+#
+# AND WHY THERE IS A SECOND GROUND TRUTH (in the sibling suite, AC19). Prose alone is provably
+# insufficient: status.schema.json:13's own description blesses `3-scope-drift-adjudication`
+# and `3-impl-verification-unverified`, and pipeline.md writes NEITHER. A vocabulary in this
+# repo has already rotted, in the one file a prose-derived test does not read.
+
+. "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
+require_node
+
+GUARD="$SCRIPTS_DIR/gate-phase-entry.mjs"
+PIPELINE_MD="$PLUGIN_ROOT/commands/pipeline.md"
+PHASE_MD="$PLUGIN_ROOT/commands/phase.md"
+STOP_SH="$HOOKS_DIR/stop.sh"
+
+# derive <sets-json-or-MODULE> -> a JSON report over the pipeline.md ground truth.
+# Passing MODULE reads the four sets from the guard's exports; passing a JSON object of the
+# same shape runs the IDENTICAL derivation over a synthetic assignment, which is what makes
+# AC18(vii)'s detectability control a control rather than a claim.
+derive() {
+  node --input-type=module -e '
+    import { readFileSync } from "node:fs";
+    const [mdPath, guardPath, setsArg] = process.argv.slice(1);
+    let sets;
+    if (setsArg === "MODULE") {
+      const m = await import(guardPath);
+      sets = { ENTRY: m.ENTRY, EXIT: m.EXIT, UNGUARDED: m.UNGUARDED, TERMINAL: m.TERMINAL };
+    } else {
+      sets = JSON.parse(setsArg);
+    }
+    const md = readFileSync(mdPath, "utf8");
+    // The STRICT form, matching tests/test-voice-lint.sh:225-239. A looser pattern picks up
+    // `0-setup` from the Phase 0 JSON block, so the two checks would disagree about their own
+    // population.
+    const literals = [...new Set([...md.matchAll(/current_phase: *"([^"]*)"/g)].map((m) => m[1]))]
+      .filter((p) => p !== "<phase>-error");
+    const names = ["ENTRY", "EXIT", "UNGUARDED", "TERMINAL"];
+    const counts = {}; const seen = new Map(); const dupes = [];
+    for (const n of names) {
+      const arr = Array.isArray(sets[n]) ? sets[n] : [];
+      counts[n] = arr.length;
+      for (const p of arr) {
+        if (seen.has(p)) dupes.push(p + " in " + seen.get(p) + " and " + n);
+        else seen.set(p, n);
+      }
+    }
+    const unassigned = literals.filter((p) => !seen.has(p));
+    const notInMd = [...seen.keys()].filter((p) => !literals.includes(p));
+    process.stdout.write(JSON.stringify({
+      literalCount: literals.length, counts, dupes, unassigned, notInMd,
+    }));
+  ' "$PIPELINE_MD" "$GUARD" "${1:-MODULE}" 2>/dev/null
+}
+
+# field/num return an explicit <no-report> marker rather than an empty string when the report
+# itself is missing. Without that, every "expected: (empty)" assertion below passes VACUOUSLY
+# the moment the derivation cannot run -- which is precisely the state this contract is
+# authored in. An absence assertion that cannot tell "nothing wrong" from "nothing measured"
+# is not an assertion.
+field() {
+  [[ -n "$1" ]] || { printf '<no-report>'; return; }
+  case "$1" in *"\"$2\":"*) ;; *) printf '<no-field:%s>' "$2"; return ;; esac
+  printf '%s' "$1" | sed -n "s/.*\"$2\":\\[\\([^]]*\\)\\].*/\\1/p"
+}
+num()   { printf '%s' "$1" | sed -n "s/.*\"$2\":\\([0-9]*\\).*/\\1/p"; }
+
+REPORT="$(derive MODULE)"
+
+# ---------------------------------------------------------------------------
+suite "AC18(vi): VACUITY CONTROL -- the derivation found a population at all"
+# ---------------------------------------------------------------------------
+LIT_N="$(num "$REPORT" literalCount)"
+assert_eq "the pipeline.md derivation found at least 20 current_phase literals" \
+  "$([[ "${LIT_N:-0}" -ge 20 ]] && echo enough || echo "ONLY ${LIT_N:-<no-report>}")" "enough"
+assert_eq "and exactly the 25 concrete ones (26 distinct minus the <phase>-error template)" \
+  "${LIT_N:-<no-report>}" "25"
+
+# ---------------------------------------------------------------------------
+suite "AC18(i): the four sets PARTITION the 25 literals"
+# ---------------------------------------------------------------------------
+# A partition is strictly stronger than a union check, and it is what makes 'decided' tellable
+# from 'forgot' in BOTH directions: a literal in two sets fails, and a literal in none fails.
+assert_eq "the sets are pairwise DISJOINT" "$(field "$REPORT" dupes)" ""
+assert_eq "every pipeline.md literal is assigned to exactly one set" "$(field "$REPORT" unassigned)" ""
+assert_eq "and no set names a phase pipeline.md does not write" "$(field "$REPORT" notInMd)" ""
+
+# ---------------------------------------------------------------------------
+suite "AC18(vii): DETECTABILITY CONTROL -- the same derivation reports a planted miss"
+# ---------------------------------------------------------------------------
+# Without this, three green assertions above are indistinguishable from a derivation that
+# reports nothing at all. The control runs the SAME code over a deliberately broken assignment.
+CTRL_MISS='{"ENTRY":["0.5-map","1-ba","2-constraints","2-review","2.5-design","3-impl","4-review"],"EXIT":["0.5-map-complete","1-ba-complete","2-constraints-complete","2-review-complete","2.5-design-complete","3-impl-complete","4-review-complete"],"UNGUARDED":["1-ba-open-questions","1-ba-rework-required","2.5-design-owner-decision","3-impl-frontend-gate-failed","3-impl-gate-failed","3-impl-live-verify-unverified","3-impl-tripwire","3-impl-tripwire-indeterminate","4-veto-rework-required"],"TERMINAL":["5-archived"]}'
+CTRL_REPORT="$(derive "$CTRL_MISS")"
+assert_contains "a literal placed in NO set is reported as unassigned" \
+  "$(field "$CTRL_REPORT" unassigned)" "5-archive"
+CTRL_DUPE='{"ENTRY":["3-impl"],"EXIT":["3-impl"],"UNGUARDED":[],"TERMINAL":[]}'
+assert_contains "a literal placed in TWO sets fails disjointness" \
+  "$(field "$(derive "$CTRL_DUPE")" dupes)" "3-impl"
+
+# ---------------------------------------------------------------------------
+suite "AC18(ii): |ENTRY| is pinned to pipeline.md's 'Checkpoint first' sites"
+# ---------------------------------------------------------------------------
+CP_N="$(grep -o 'Checkpoint first' "$PIPELINE_MD" | wc -l | tr -d ' ')"
+assert_eq "pipeline.md has 8 'Checkpoint first' occurrences (grep -o | wc -l, never grep -c)" "$CP_N" "8"
+assert_eq "and |ENTRY| equals that count" "$(num "$REPORT" ENTRY)" "$CP_N"
+
+# Each literal at a Checkpoint-first site must BE an entry key. The count agreeing while the
+# membership does not is the exact drift a count-only check misses.
+CP_MISSING=""
+while IFS= read -r line; do
+  lit="$(printf '%s' "$line" | sed -n 's/.*current_phase: *"\([^"]*\)".*/\1/p')"
+  [[ -n "$lit" ]] || { CP_MISSING="$CP_MISSING <no-literal-on-line>"; continue; }
+  node --input-type=module -e '
+    const m = await import(process.argv[1]);
+    process.exit(m.ENTRY.includes(process.argv[2]) ? 0 : 1);
+  ' "$GUARD" "$lit" 2>/dev/null || CP_MISSING="$CP_MISSING $lit"
+done < <(grep 'Checkpoint first' "$PIPELINE_MD")
+assert_eq "every phase literal at a 'Checkpoint first' site IS an ENTRY key" "${CP_MISSING# }" ""
+
+# ---------------------------------------------------------------------------
+suite "AC18(iii): every <phase>-complete literal pipeline.md writes is an EXIT key"
+# ---------------------------------------------------------------------------
+assert_eq "|EXIT| is 7" "$(num "$REPORT" EXIT)" "7"
+COMPLETE_MISSING=""
+while IFS= read -r lit; do
+  [[ -n "$lit" ]] || continue
+  node --input-type=module -e '
+    const m = await import(process.argv[1]);
+    process.exit(m.EXIT.includes(process.argv[2]) ? 0 : 1);
+  ' "$GUARD" "$lit" 2>/dev/null || COMPLETE_MISSING="$COMPLETE_MISSING $lit"
+done < <(grep -o 'current_phase: *"[^"]*-complete"' "$PIPELINE_MD" | sed -n 's/.*"\([^"]*\)"/\1/p' | sort -u)
+assert_eq "no -complete literal is missing from EXIT" "${COMPLETE_MISSING# }" ""
+
+# ---------------------------------------------------------------------------
+suite "AC18(iv): the satisfying token sets REFERENCE the registry, they do not restate it"
+# ---------------------------------------------------------------------------
+# This is what keeps the phase-vocabulary table count at three. Every token in every row's set,
+# at every tier, must be a member of the IMPORTED KNOWN_PHASES -- imported, never grepped.
+TOKEN_REPORT="$(node --input-type=module -e '
+  const g = await import(process.argv[1]);
+  const { KNOWN_PHASES } = await import(process.argv[2]);
+  const tiers = ["trivial", "standard", "architectural"];
+  const strays = []; let tokens = 0;
+  for (const phase of [...g.ENTRY, ...g.EXIT]) {
+    for (const tier of tiers) {
+      const set = g.satisfyingTokens(phase, tier);
+      if (!Array.isArray(set)) { strays.push(phase + "@" + tier + ":not-an-array"); continue; }
+      for (const t of set) {
+        tokens++;
+        if (!KNOWN_PHASES.includes(t)) strays.push(phase + "@" + tier + ":" + t);
+      }
+    }
+  }
+  process.stdout.write(JSON.stringify({ tokens, strays }));
+' "$GUARD" "$SCRIPTS_DIR/dispatch-model.mjs" 2>/dev/null)"
+assert_eq "every satisfying token is a member of the imported KNOWN_PHASES" \
+  "$(field "$TOKEN_REPORT" strays)" ""
+TOK_N="$(num "$TOKEN_REPORT" tokens)"
+assert_eq "VACUITY CONTROL: the walk actually saw tokens (>=15)" \
+  "$([[ "${TOK_N:-0}" -ge 15 ]] && echo enough || echo "ONLY ${TOK_N:-<no-report>}")" "enough"
+
+# ---------------------------------------------------------------------------
+suite "AC18(v): the guard declares no fourth vocabulary and no shape regex of its own"
+# ---------------------------------------------------------------------------
+assert_eq "the module exports no KNOWN_PHASES of its own" \
+  "$(node --input-type=module -e 'const m=await import(process.argv[1]);process.stdout.write(m.KNOWN_PHASES===undefined?"absent":"DECLARED")' "$GUARD" 2>/dev/null || printf '<import-failed>')" \
+  "absent"
+# The source check strips comments FIRST. If a phrase in a comment can redden this, the
+# assertion is a source grep and has regressed to the shape this suite exists to replace.
+SRC_REPORT="$(node --input-type=module -e '
+  import { readFileSync } from "node:fs";
+  const raw = readFileSync(process.argv[1], "utf8");
+  const code = raw.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+  const hits = [];
+  if (/\bstartsWith\s*\(/.test(code)) hits.push("startsWith");
+  if (/const\s+KNOWN_PHASES\s*=/.test(code)) hits.push("local KNOWN_PHASES");
+  if (/\/\^?\(?\[0-5\]/.test(code)) hits.push("phase-shape regex");
+  process.stdout.write(JSON.stringify({ hits, codeLen: code.length }));
+' "$GUARD" 2>/dev/null)"
+assert_eq "no startsWith, no local KNOWN_PHASES, no [0-5] shape regex in the guard's CODE" \
+  "$(field "$SRC_REPORT" hits)" ""
+CODE_N="$(num "$SRC_REPORT" codeLen)"
+assert_eq "VACUITY CONTROL: the source check read real code, not an empty string" \
+  "$([[ "${CODE_N:-0}" -ge 500 ]] && echo enough || echo "ONLY ${CODE_N:-<no-report>}")" "enough"
+
+# ---------------------------------------------------------------------------
+suite "R5/AC4/AC29: ONE shared resolver, importable, with no fourth table behind it"
+# ---------------------------------------------------------------------------
+# WHERE it lives is Dev's call (exported from pipeline-telemetry.mjs, or relocated to lib.mjs);
+# that ONE exists and both call sites use it is the contract. phaseKey's own docstring records
+# what a shape regex cost: 3a-/3b- labels matched nothing and 4,088,488 ms, 39% of one run's
+# lead time, was silently discarded.
+RESOLVER_REPORT="$(node --input-type=module -e '
+  const cands = process.argv.slice(1);
+  let fn = null, from = null;
+  for (const c of cands) {
+    try { const m = await import(c); if (typeof m.phaseKey === "function") { fn = m.phaseKey; from = c; break; } } catch {}
+  }
+  if (!fn) { process.stdout.write(JSON.stringify({ from: null, results: {} })); process.exit(0); }
+  const cases = ["3b-dev", "3a-qa-tests", "2.5-design", "1-ba-rerun", "phase-rerun", "9-nope"];
+  const results = {}; for (const c of cases) results[c] = String(fn(c));
+  process.stdout.write(JSON.stringify({ from, results }));
+' "$SCRIPTS_DIR/lib.mjs" "$SCRIPTS_DIR/pipeline-telemetry.mjs" 2>/dev/null)"
+assert_contains "phaseKey is importable from lib.mjs or pipeline-telemetry.mjs" "$RESOLVER_REPORT" '"from":"'
+assert_contains "  it reads the suffixed label 3b-dev as token 3b" "$RESOLVER_REPORT" '"3b-dev":"3b"'
+assert_contains "  and 3a-qa-tests as token 3a (distinct from 3b, which is why AC6 can exist)" "$RESOLVER_REPORT" '"3a-qa-tests":"3a"'
+assert_contains "  and 2.5-design as token 2.5" "$RESOLVER_REPORT" '"2.5-design":"2.5"'
+assert_contains "  and the R15 label 1-ba-rerun as token 1" "$RESOLVER_REPORT" '"1-ba-rerun":"1"'
+assert_contains "  while the bare 'phase-rerun' still resolves to null (do NOT special-case it)" "$RESOLVER_REPORT" '"phase-rerun":"null"'
+assert_contains "  and an unknown leading token resolves to null" "$RESOLVER_REPORT" '"9-nope":"null"'
+
+# ---------------------------------------------------------------------------
+suite "AC20 (prose half): resume semantics stated once, in the re-enter form"
+# ---------------------------------------------------------------------------
+# Under the 'phase after current_phase' reading, a run interrupted mid-Phase-3 resumes at
+# Phase 4 having never finished Phase 3 -- the exact failure this issue exists to stop.
+assert_not_contains "the 'continue from the phase after current_phase' wording is gone" \
+  "$(cat "$PIPELINE_MD")" 'continue from the phase after'
+assert_contains "and the re-enter-the-same-phase statement is present" \
+  "$(cat "$PIPELINE_MD")" 're-enters that same phase from the top'
+
+# ---------------------------------------------------------------------------
+suite "AC30 (prose half): the exit event and the next entry checkpoint are ONE write"
+# ---------------------------------------------------------------------------
+# Checkpoint-first-then-append is fully compliant with pipeline.md as written and leaves a
+# window in which the record says 'entering 3-impl' with neither design.json nor a closing
+# event. The Stop hook fires at the turn boundary, and a turn very commonly ends right after a
+# checkpoint commit, so the window is not hypothetical at this seam.
+assert_contains "the convention states the two are a single write" \
+  "$(cat "$PIPELINE_MD")" 'ONE write'
+assert_contains "  and names which two things it joins" \
+  "$(cat "$PIPELINE_MD")" 'exit event'
+
+# ---------------------------------------------------------------------------
+suite "AC29 (prose half): /phase appends a token-prefixed rerun label"
+# ---------------------------------------------------------------------------
+assert_not_contains "the phase-less 'phase-rerun' literal is no longer instructed" \
+  "$(cat "$PHASE_MD")" '"phase-rerun"'
+assert_contains "and a token-prefixed <phase-token>-rerun label is" \
+  "$(cat "$PHASE_MD")" '<phase-token>-rerun'
+# The owner ruling made after the spec was written: the guard DOES apply to /phase re-runs, so
+# the line promising the opposite gets corrected rather than left contradicting the code.
+assert_not_contains "phase.md no longer promises the opposite of what the guard does" \
+  "$(cat "$PHASE_MD")" 'Do not block on order'
+
+# ---------------------------------------------------------------------------
+suite "AC31: the header carries the guarantee's LIMIT, verbatim, where an implementer reads it"
+# ---------------------------------------------------------------------------
+# Verbatim, not a keyword grep: a paraphrase is exactly how a stated limit becomes a stated
+# guarantee. The text is embedded here rather than read from spec.json because spec.json is
+# gitignored -- status.json is the only tracked per-issue artifact -- so a run-time read would
+# be a false red on any fresh checkout.
+WHAT_IT_IS_NOT="A pre-dispatch airlock. It CANNOT prevent a phase being skipped mid-turn; the phase's absence is detected when the turn tries to end. The cost of a skip is therefore the wasted work in that turn, not zero. Work already done in this turn is not undone."
+GUARD_SRC="$(cat "$GUARD" 2>/dev/null || printf '<guard-absent>')"
+assert_contains "the script header carries what_it_is_not VERBATIM" "$GUARD_SRC" "$WHAT_IT_IS_NOT"
+assert_contains "  and names the inherited active-issue limitation (SubagentStop payload)" "$GUARD_SRC" "SubagentStop"
+assert_contains "  and that the active issue therefore resolves by the mtime fallback" "$GUARD_SRC" "mtime fallback"
+
+STOP_SRC="$(cat "$STOP_SH")"
+assert_contains "stop.sh's opt-out comment names the variable it is about" "$STOP_SRC" "CLAUDE_HOOK_STOP_SKIP bypasses"
+assert_contains "  and says the phase-entry guard is NOT bypassed" "$STOP_SRC" "NOT the phase-entry guard"
+assert_not_contains "  and the bare 'Opt-out for one-off iterations.' comment is corrected, not kept" \
+  "$STOP_SRC" "# Opt-out for one-off iterations."
+
+finish

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -55,16 +55,31 @@ mk_project() {
   git -C "$HP_ROOT" -c user.email=t@t -c user.name=t commit -q -m init >/dev/null 2>&1
 }
 
+# The stderr capture file lives OUTSIDE every fixture repo, and that is load-bearing, not
+# tidiness. A redirection is set up by the shell BEFORE the command runs, so `2>"$root/..."`
+# created an untracked file inside the fixture repo before stop.sh ever started: measured, the
+# tree was [] before run_stop and [?? .stop-err.txt] as the hook saw it. AC26(a) asserts the
+# guard still refuses on a CLEAN tree, and with the capture file inside the repo that fixture
+# was never clean at the moment under test -- the cell could not fail, and a guard gated on a
+# dirty tree passed it.
+new_tmpdir || exit 90
+ERR_DIR="$NEW_TMPDIR"
+ERR_SEQ=0
+
 # run_stop <hook-path> <root> <payload> [VAR=VAL ...] -> STOP_RC, STOP_ERR
 # stdin is ALWAYS piped: stop.sh reads it when it is not a tty, and leaving it inherited makes
 # the result depend on how the suite was launched.
 run_stop() {
   local hook="$1" root="$2" payload="$3"; shift 3
-  local errf="$root/.stop-err.txt"
+  ERR_SEQ=$((ERR_SEQ + 1))
+  local errf="$ERR_DIR/stop-err-$ERR_SEQ.txt"
   printf '%s' "$payload" | env "$@" CLAUDE_PROJECT_DIR="$root" bash "$hook" >/dev/null 2>"$errf"
   STOP_RC=$?
   STOP_ERR="$(cat "$errf" 2>/dev/null)"
 }
+
+# porcelain <root> -> the working-tree status as ONE line, or `[]` when clean.
+porcelain() { printf '[%s]' "$(git -C "$1" status --porcelain 2>/dev/null | tr '\n' ';')"; }
 
 lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
 
@@ -107,9 +122,14 @@ suite "AC26: the placement WINDOW, four cells, one per bound"
 # (a) A checkpoint commit leaves the tree CLEAN, so a guard below the clean-tree exit never
 #     runs at the moment it matters most.
 mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
-assert_eq "  precondition: the fixture tree really is clean" \
-  "$(git -C "$HP_ROOT" status --porcelain | grep -c . | tr -d ' ')" "0"
+assert_eq "  precondition: the fixture tree really is clean BEFORE the hook runs" \
+  "$(porcelain "$HP_ROOT")" "[]"
 run_stop "$HOOK" "$HP_ROOT" ''
+# Both sides of the run, because the defect this brackets was a file created by the harness's
+# own redirection at hook-start. stop.sh writes nothing into the project dir (its only temp is
+# an mktemp LOG), so clean-before AND clean-after is the tree the hook saw.
+assert_eq "  precondition: and STILL clean after it, so the hook's own view was clean" \
+  "$(porcelain "$HP_ROOT")" "[]"
 assert_eq "(a) clean tree, guard refuses -> exit 2" "$STOP_RC" "2"
 
 # (b) The opt-out bypasses voice-lint and the project check. It must NOT bypass the guard:
@@ -200,6 +220,41 @@ assert_eq "  CONTROL: the same phase in a PARSEABLE record refuses" "$STOP_RC" "
 mk_project '{"current_phase": "3-impl", "events": [' '{"checkCommand":"true"}'
 run_stop "$HOOK" "$HP_ROOT" ''
 assert_eq "(c) unparseable status.json -> exit 0" "$STOP_RC" "0"
+
+# (d) THE LEG THE OTHER THREE CANNOT REACH: a guard that RUNS and FAILS. (a) is short-circuited
+#     by `command -v node`, (b) by the `-f $GATE` test, and (c) exits 0 inside the guard itself,
+#     so none of them ever reaches the hook's own exit-code test and none distinguishes "blocks
+#     on exactly 2" from "blocks on anything non-zero". A partial install -- scripts/ present
+#     but one of the guard's imports missing -- makes node exit 1 with a message on stderr,
+#     which is the shape that turns a fail-open contract into a permanent wedge: under
+#     `-ne 0` this fixture exits 2, i.e. EVERY turn in EVERY adopting project with a broken
+#     install would be unstoppable, and that is the exact failure R11 exists to prevent.
+new_tmpdir || exit 90
+BROKEN_ROOT="$NEW_TMPDIR"
+mkdir -p "$BROKEN_ROOT/hooks" "$BROKEN_ROOT/scripts"
+cp "$HOOKS_DIR"/*.sh "$BROKEN_ROOT/hooks/" 2>/dev/null
+cp "$SCRIPTS_DIR"/*.mjs "$BROKEN_ROOT/scripts/" 2>/dev/null
+rm -f "$BROKEN_ROOT/scripts/lib.mjs"          # an IMPORT of the guard, not the guard itself
+assert_eq "  precondition: the guard script is PRESENT in the broken copy (unlike case (b))" \
+  "$([[ -f "$BROKEN_ROOT/scripts/gate-phase-entry.mjs" ]] && echo present || echo MISSING)" "present"
+assert_eq "  precondition: and one of its imports is genuinely gone" \
+  "$([[ -f "$BROKEN_ROOT/scripts/lib.mjs" ]] && echo PRESENT || echo absent)" "absent"
+# The leg is only reached if node really runs and really fails NON-ZERO-BUT-NOT-2. Asserted on
+# the guard directly, because "the hook exited 0" is otherwise indistinguishable from a guard
+# that was skipped before it ever started -- which is what the other three cells do.
+BROKEN_ERR="$(node "$BROKEN_ROOT/scripts/gate-phase-entry.mjs" --root "$HP_ROOT" 2>&1 >/dev/null)"
+BROKEN_RC=$?
+assert_eq "  precondition: the broken guard exits non-zero and NOT 2 (it is a crash, not a refusal)" \
+  "$([[ "$BROKEN_RC" -ne 0 && "$BROKEN_RC" -ne 2 ]] && echo "crash($BROKEN_RC)" || echo "UNEXPECTED($BROKEN_RC)")" \
+  "crash($BROKEN_RC)"
+assert_eq "  precondition: and it printed to stderr, so the hook's -n GATE_ERR test is satisfied too" \
+  "$([[ -n "$BROKEN_ERR" ]] && echo nonempty || echo EMPTY)" "nonempty"
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "  CONTROL: the SAME fixture refuses through the intact install" "$STOP_RC" "2"
+run_stop "$BROKEN_ROOT/hooks/stop.sh" "$HP_ROOT" ''
+assert_eq "(d) a guard that RUNS and CRASHES -> exit 0, because only exit 2 blocks" "$STOP_RC" "0"
+assert_eq "  and the crash text is not republished as if it were a refusal" "$STOP_ERR" ""
 
 # ---------------------------------------------------------------------------
 suite "AC25: an ordinary developer session in a project that ran a pipeline once"

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# The phase-entry guard as WIRED: hooks/stop.sh, hooks/session-start.sh, and the two suites
+# that already own this hook.
+#
+# THE PLACEMENT IS A WINDOW, NOT A FLOOR, AND IT WAS MEASURED. stop.sh has FIVE early exits
+# above a natural insertion point, and one UPPER bound:
+#
+#   TREE GENUINELY CLEAN                        CLEAN + CLAUDE_HOOK_STOP_SKIP=1
+#   A above both early exits   exit=2  wanted   A  exit=2  wanted
+#   C below CHECK-config exit  exit=2           C  exit=0  disarmed
+#   B below clean-tree exit    exit=0  wrong    B  exit=0  disarmed
+#   NON-ZERO CONTROL (dirty):  C exit=2, B exit=2
+#
+# The exit most easily missed is `CHECK` empty -> exit 0: no checkCommand and no package.json
+# typecheck script is the ADOPTING-PROJECT DEFAULT, in which stop.sh is already a complete
+# no-op before the clean-tree check is ever reached -- and every fixture in
+# tests/test-stop-hook.sh sets a checkCommand, so that state is asserted NOWHERE today.
+#
+# The UPPER bound is silent by nature: stdin is not re-readable, so a guard placed above the
+# `PAYLOAD=$(cat)` read consumes it, PAYLOAD comes back empty, and the voice-lint block --
+# guarded by its own `[[ -n "$PAYLOAD" ]]` test -- is skipped with no error anywhere. AC26(d)
+# reddens under a mutation in the OPPOSITE direction from the other three cells. That is what
+# makes this a window.
+
+. "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
+require_node
+
+HOOK="$HOOKS_DIR/stop.sh"
+SESSION_START="$HOOKS_DIR/session-start.sh"
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FRESH_ISO="$(node -e 'process.stdout.write(new Date(Date.now()-3600e3).toISOString())')"
+
+# Two token-shaped plants for AC22. NEITHER shares a substring with anything AC21 asserts is
+# PRESENT (3-impl, design.json, 4242, SKIPPED, note, /phase, "cannot end", "already done").
+# evidence.md's exact-match-twin trap is what that constraint is for: a control added to make
+# another control falsifiable can BLIND it.
+PLANT_ASK='ghp_zzqqwwxxyyvv99887766'
+PLANT_NOTE='sk_live_qqzzwwxxyyvv55443322'
+
+REFUSING_STATUS="$(printf '{"issue_number":4242,"current_phase":"3-impl","risk_tier":"architectural","updated_at":"%s","ask_text":"%s","events":[{"phase":"2-review","verdict":"complete","at":"2026-01-01T00:00:00Z","note":"%s"}]}' \
+  "$FRESH_ISO" "$PLANT_ASK" "$PLANT_NOTE")"
+GRANTING_STATUS="$(printf '{"issue_number":4242,"current_phase":"4-review-complete","risk_tier":"architectural","updated_at":"%s","events":[]}' "$FRESH_ISO")"
+
+# mk_project <status-json> [config-json] [issue-dir] -> HP_ROOT (a committed, CLEAN git repo)
+mk_project() {
+  new_tmpdir || exit 90
+  HP_ROOT="$NEW_TMPDIR"
+  HP_ISSUE="${3:-4242}"
+  git -C "$HP_ROOT" init -q
+  mkdir -p "$HP_ROOT/.pipeline/$HP_ISSUE"
+  printf '%s' "$1" > "$HP_ROOT/.pipeline/$HP_ISSUE/status.json"
+  [[ -n "${2:-}" ]] && printf '%s' "$2" > "$HP_ROOT/pipeline.config.json"
+  git -C "$HP_ROOT" add -A >/dev/null 2>&1
+  git -C "$HP_ROOT" -c user.email=t@t -c user.name=t commit -q -m init >/dev/null 2>&1
+}
+
+# run_stop <hook-path> <root> <payload> [VAR=VAL ...] -> STOP_RC, STOP_ERR
+# stdin is ALWAYS piped: stop.sh reads it when it is not a tty, and leaving it inherited makes
+# the result depend on how the suite was launched.
+run_stop() {
+  local hook="$1" root="$2" payload="$3"; shift 3
+  local errf="$root/.stop-err.txt"
+  printf '%s' "$payload" | env "$@" CLAUDE_PROJECT_DIR="$root" bash "$hook" >/dev/null 2>"$errf"
+  STOP_RC=$?
+  STOP_ERR="$(cat "$errf" 2>/dev/null)"
+}
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# ---------------------------------------------------------------------------
+suite "AC21: the refusal names four bounded values and both ways out"
+# ---------------------------------------------------------------------------
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "a turn cannot END at 3-impl with no design.json: exit 2" "$STOP_RC" "2"
+assert_contains "  (i) the message names the current_phase token" "$STOP_ERR" "3-impl"
+assert_contains "  (ii) and the prerequisite FILENAME" "$STOP_ERR" "design.json"
+assert_contains "  (iii) and the ISSUE DIR, so a sibling-caused wedge is self-diagnosing" "$STOP_ERR" "4242"
+assert_contains "  (iv-a) clearance route one: record a SKIPPED events[] entry" "$STOP_ERR" "SKIPPED"
+assert_contains "  (iv-a) which costs a written reason" "$STOP_ERR" "note"
+assert_contains "  (iv-b) clearance route two names the /phase re-run case" "$STOP_ERR" "/phase"
+assert_contains "  (v) and it says the TURN cannot end in this state" "$(lower "$STOP_ERR")" "cannot end"
+assert_contains "  (v) and that work already done in this turn is not undone" "$(lower "$STOP_ERR")" "already done"
+
+# ---------------------------------------------------------------------------
+suite "AC22: stderr is a FIXED template -- status.json free text is never republished"
+# ---------------------------------------------------------------------------
+# status.schema.json says outright that ask_text 'must never carry a secret' because the file
+# is committed, i.e. the schema already treats it as a field that can receive a pasted token
+# before anyone notices. stderr is fed back into the transcript, so echoing it republishes it.
+#
+# NON-ZERO CONTROL for the two absence assertions: the same substring search, over a haystack
+# that DOES contain the plants (stderr plus the record itself). If those two do not fire, the
+# absence checks below prove nothing about the template.
+HAYSTACK_CONTROL="$STOP_ERR$(cat "$HP_ROOT/.pipeline/4242/status.json")"
+assert_contains "CONTROL: the ask_text plant really is in the record being read" "$HAYSTACK_CONTROL" "$PLANT_ASK"
+assert_contains "CONTROL: and so is the events[].note plant" "$HAYSTACK_CONTROL" "$PLANT_NOTE"
+assert_eq "CONTROL: and the message under test is non-empty" \
+  "$([[ -n "$STOP_ERR" ]] && echo nonempty || echo EMPTY)" "nonempty"
+assert_not_contains "ask_text is not passed through to stderr" "$STOP_ERR" "$PLANT_ASK"
+assert_not_contains "and neither is an events[].note" "$STOP_ERR" "$PLANT_NOTE"
+
+# ---------------------------------------------------------------------------
+suite "AC26: the placement WINDOW, four cells, one per bound"
+# ---------------------------------------------------------------------------
+# (a) A checkpoint commit leaves the tree CLEAN, so a guard below the clean-tree exit never
+#     runs at the moment it matters most.
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+assert_eq "  precondition: the fixture tree really is clean" \
+  "$(git -C "$HP_ROOT" status --porcelain | grep -c . | tr -d ' ')" "0"
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "(a) clean tree, guard refuses -> exit 2" "$STOP_RC" "2"
+
+# (b) The opt-out bypasses voice-lint and the project check. It must NOT bypass the guard:
+#     Q3 rejected a config knob and an env opt-out, and this is the same door.
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" '' CLAUDE_HOOK_STOP_SKIP=1
+assert_eq "(b) CLAUDE_HOOK_STOP_SKIP=1, guard refuses -> still exit 2" "$STOP_RC" "2"
+
+# (c) THE ADOPTING-PROJECT DEFAULT, unasserted anywhere in tests/test-stop-hook.sh today: no
+#     checkCommand and no package.json typecheck script, in which stop.sh is a total no-op
+#     before the clean-tree check is ever reached.
+mk_project "$REFUSING_STATUS" ''
+assert_eq "  precondition: no pipeline.config.json in the fixture" \
+  "$([[ -f "$HP_ROOT/pipeline.config.json" ]] && echo PRESENT || echo absent)" "absent"
+assert_eq "  precondition: and no package.json either" \
+  "$([[ -f "$HP_ROOT/package.json" ]] && echo PRESENT || echo absent)" "absent"
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "(c) no check configured at all, guard refuses -> exit 2" "$STOP_RC" "2"
+
+# (d) UPPER BOUND. A guard above the PAYLOAD read consumes stdin, PAYLOAD comes back empty,
+#     and voice-lint is skipped by its own emptiness test with no error anywhere. This cell
+#     reddens under the OPPOSITE mutation from the three above.
+mk_project "$GRANTING_STATUS" '{"checkCommand":"true"}'
+printf '{}' > "$HP_ROOT/.pipeline/4242/peer-review.json"     # the granting prerequisite
+TRANSCRIPT="$HP_ROOT/transcript.jsonl"
+node -e '
+  const fs=require("fs");
+  fs.writeFileSync(process.argv[1], JSON.stringify({
+    type:"assistant", message:{content:[{type:"text",
+      text:"Done — the panel returned — six blocks merged — nothing else to report."}]}
+  })+"\n");
+' "$TRANSCRIPT"
+run_stop "$HOOK" "$HP_ROOT" "$(printf '{"cwd":"%s","transcript_path":"%s"}' "$HP_ROOT" "$TRANSCRIPT")" \
+  CLAUDE_PIPELINE_ACTIVE_ISSUE=4242
+assert_contains "(d) with the guard installed and GRANTING, voice-lint still sees the payload" \
+  "$STOP_ERR" "full voice mode moment"
+assert_eq "  and voice-lint still blocks on its own account" "$STOP_RC" "2"
+
+# ---------------------------------------------------------------------------
+suite "AC23: the DECISION is fail-closed; the TOOLING is fail-open"
+# ---------------------------------------------------------------------------
+# SecOps was invited to reverse this and declined, naming the event and its environment: the
+# skip occurs inside the agent session, a missing Node install occurs in the operator's
+# environment and is not discretion. A fail-closed-on-tooling control would refuse 100% of
+# legitimate stops in every adopting project without Node on the hook's PATH.
+
+# (a) node not on PATH. HOME is redirected too, because stop.sh explicitly prepends the newest
+#     nvm Node from $HOME/.nvm; leaving HOME alone would put node back on the PATH it just
+#     stripped, and the case would pass while testing nothing.
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+new_tmpdir || exit 90
+NO_NODE_HOME="$NEW_TMPDIR"
+NO_NODE_BIN="$NO_NODE_HOME/bin"
+mkdir -p "$NO_NODE_BIN"
+for t in git bash cat mktemp rm tail dirname grep sed; do
+  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$NO_NODE_BIN/$t"
+done
+assert_eq "  precondition: node is genuinely unreachable from the stripped PATH+HOME" \
+  "$(env -i HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN" bash -c 'command -v node >/dev/null 2>&1 && echo FOUND || echo absent')" \
+  "absent"
+# NON-ZERO CONTROL, on the SAME fixture. Without it, "exit 0" is indistinguishable from a
+# guard that never runs at all -- which is exactly the state this contract is authored in.
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "  CONTROL: this same fixture DOES refuse when the tooling is present" "$STOP_RC" "2"
+run_stop "$HOOK" "$HP_ROOT" '' HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+assert_eq "(a) node absent -> exit 0, the guard does not wedge the operator's environment" "$STOP_RC" "0"
+
+# (b) the guard script itself missing. A COPY of the plugin, minus the one file.
+new_tmpdir || exit 90
+COPY_ROOT="$NEW_TMPDIR"
+mkdir -p "$COPY_ROOT/hooks" "$COPY_ROOT/scripts"
+cp "$HOOKS_DIR"/*.sh "$COPY_ROOT/hooks/" 2>/dev/null
+cp "$SCRIPTS_DIR"/*.mjs "$COPY_ROOT/scripts/" 2>/dev/null
+rm -f "$COPY_ROOT/scripts/gate-phase-entry.mjs"
+assert_eq "  precondition: the copy really is missing the guard" \
+  "$([[ -f "$COPY_ROOT/scripts/gate-phase-entry.mjs" ]] && echo PRESENT || echo absent)" "absent"
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "  CONTROL: the SAME fixture refuses through the installed hook, which has the guard" "$STOP_RC" "2"
+run_stop "$COPY_ROOT/hooks/stop.sh" "$HP_ROOT" ''
+assert_eq "(b) guard script absent -> exit 0" "$STOP_RC" "0"
+
+# (c) a status.json that parses as nothing. R11 covers the TRUNCATED half; R14's write-order
+#     convention is what covers the semantically PARTIAL half, which is a different case.
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "  CONTROL: the same phase in a PARSEABLE record refuses" "$STOP_RC" "2"
+mk_project '{"current_phase": "3-impl", "events": [' '{"checkCommand":"true"}'
+run_stop "$HOOK" "$HP_ROOT" ''
+assert_eq "(c) unparseable status.json -> exit 0" "$STOP_RC" "0"
+
+# ---------------------------------------------------------------------------
+suite "AC25: an ordinary developer session in a project that ran a pipeline once"
+# ---------------------------------------------------------------------------
+new_tmpdir || exit 90
+NOPIPE="$NEW_TMPDIR"
+git -C "$NOPIPE" init -q
+git -C "$NOPIPE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+run_stop "$HOOK" "$NOPIPE" ''
+assert_eq "no .pipeline/ at all -> exit 0" "$STOP_RC" "0"
+assert_eq "  and the hook says nothing" "$STOP_ERR" ""
+# NON-ZERO CONTROL: the same hook, the same invocation, one refusing record added. Silence has
+# to be shown to be a CHOICE about this project rather than the hook's only behaviour.
+mkdir -p "$NOPIPE/.pipeline/4242"
+printf '%s' "$REFUSING_STATUS" > "$NOPIPE/.pipeline/4242/status.json"
+printf '%s' '{"checkCommand":"true"}' > "$NOPIPE/pipeline.config.json"
+run_stop "$HOOK" "$NOPIPE" ''
+assert_eq "  CONTROL: add one refusing record to that same repo and the hook exits 2" "$STOP_RC" "2"
+
+# ---------------------------------------------------------------------------
+suite "AC27: the two suites that already own this hook are UNCHANGED consumers"
+# ---------------------------------------------------------------------------
+# Recorded at f6ba1c4, BEFORE this contract was authored. Exact counts, not just failed=0: a
+# suite that silently stopped running half its cases also reports failed=0.
+run_suite_counts() {  # <suite-file> -> SUITE_PASSED, SUITE_FAILED
+  local out
+  out="$(cd "$TESTS_DIR" && bash "$1" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+  SUITE_PASSED="$(printf '%s\n' "$out" | sed -n 's/^passed=\([0-9]*\).*/\1/p' | tail -1)"
+  SUITE_FAILED="$(printf '%s\n' "$out" | sed -n 's/^passed=[0-9]* failed=\([0-9]*\).*/\1/p' | tail -1)"
+}
+run_suite_counts test-stop-hook.sh
+assert_eq "test-stop-hook.sh still passes exactly its 18 pre-existing assertions" "${SUITE_PASSED:-<none>}" "18"
+assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
+run_suite_counts test-voice-lint.sh
+assert_eq "test-voice-lint.sh still passes exactly its 41 pre-existing assertions" "${SUITE_PASSED:-<none>}" "41"
+assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
+
+# ---------------------------------------------------------------------------
+suite "AC28: the session-start notice, because a fail-open disarm is otherwise INVISIBLE"
+# ---------------------------------------------------------------------------
+# A broken Node install disarms the guard identically to a grant, forever, with no signal.
+# session-start.sh already runs in the operator's environment and already reads status.json,
+# so it is the one place in that environment the plugin already speaks.
+NOTICE_ANCHOR="gate-phase-entry"
+
+# start_notice <session-start-path> <root> [VAR=VAL ...] -> NOTICE_N
+# Cell (b) runs the COPY of session-start.sh, whose sibling scripts/ dir genuinely has no
+# gate-phase-entry.mjs in it. Simulating a missing script with a test-only env knob would add
+# exactly the narrowing knob Q3 rejected, and would prove the knob works rather than the check.
+start_notice() {
+  local hook="$1" root="$2"; shift 2
+  local out
+  out="$( cd "$root" && env "$@" CLAUDE_PROJECT_DIR="$root" bash "$hook" 2>&1 )"
+  NOTICE_N="$(printf '%s\n' "$out" | grep -c "$NOTICE_ANCHOR" | tr -d ' ')"
+}
+
+mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
+start_notice "$SESSION_START" "$HP_ROOT" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+assert_eq "(a) guarded run in flight + node absent -> exactly one notice line" "$NOTICE_N" "1"
+
+start_notice "$COPY_ROOT/hooks/session-start.sh" "$HP_ROOT"
+assert_eq "(b) guarded run in flight + guard script missing -> exactly one notice line" "$NOTICE_N" "1"
+
+start_notice "$SESSION_START" "$HP_ROOT"
+assert_eq "(c) both present -> no notice" "$NOTICE_N" "0"
+
+# (d) The cell a positive-only test omits, and where a notice that ALWAYS fires would hide.
+mk_project "$(printf '{"issue_number":4242,"current_phase":"5-archived","risk_tier":"architectural","updated_at":"%s","events":[]}' "$FRESH_ISO")" '{"checkCommand":"true"}'
+start_notice "$SESSION_START" "$HP_ROOT" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+assert_eq "(d) no in-flight GUARDED run -> no notice, even with node absent" "$NOTICE_N" "0"
+
+finish

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -230,6 +230,13 @@ done
 ln -sf "$(command -v node)" "$WITH_NODE_BIN/node"
 DECLINE_PREPEND="$NO_NODE_HOME/decline-path-prepend.sh"
 printf 'readonly PATH\n' > "$DECLINE_PREPEND"
+# THE COUPLING THIS FIXTURE RESTS ON, pinned rather than left in the prose above. `readonly PATH`
+# works because the hook's failed `export PATH=...` is a diagnostic and not a control-flow change,
+# which is only true while stop.sh stays `set -u` ONLY. Add -e and the assignment aborts the hook
+# before its body, and AC23(a) below plus its rc=2 CONTROL both go red for a reason that has
+# nothing to do with the guard.
+assert_not_contains "the declined-prepend fixture requires stop.sh to stay set -u only" \
+  "$(cat "$HOOK")" "set -e"
 NO_NODE_ENV=(BASH_ENV="$DECLINE_PREPEND" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN")
 WITH_NODE_ENV=(BASH_ENV="$DECLINE_PREPEND" HOME="$NO_NODE_HOME" PATH="$WITH_NODE_BIN")
 

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -176,26 +176,115 @@ suite "AC23: the DECISION is fail-closed; the TOOLING is fail-open"
 # environment and is not discretion. A fail-closed-on-tooling control would refuse 100% of
 # legitimate stops in every adopting project without Node on the hook's PATH.
 
-# (a) node not on PATH. HOME is redirected too, because stop.sh explicitly prepends the newest
-#     nvm Node from $HOME/.nvm; leaving HOME alone would put node back on the PATH it just
-#     stripped, and the case would pass while testing nothing.
+# (a) node not on PATH. THE CONDITION IS CONSTRUCTED THROUGH THE PATH THE HOOK ACTUALLY RUNS
+#     WITH, not the one this file hands it, and the difference between those two is the whole of
+#     issue #46.
+#
+#     stop.sh and session-start.sh both OPEN with an unconditional
+#       export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+#     so a PATH= passed on the command line is REBUILT by the hook before `command -v node` ever
+#     runs. On ubuntu-latest node is /usr/local/bin/node, so the guard was ARMED in CI: this cell
+#     got exit 2 where it expects 0, and -- because it was armed -- AC28(a) below correctly
+#     emitted no notice where it expects 1. One cause, both failures. It passed on the author's
+#     macOS only because that machine's node lives under ~/.nvm, which is in none of the four
+#     prepended dirs. The old precondition measured `command -v node` under the PATH THIS FILE
+#     builds, before stop.sh mutated it, so it inspected something other than what acts and
+#     reported "absent" while the hook went on to find node three lines later.
+#
+#     SHADOWING WAS TRIED FIRST AND CANNOT WORK. A `node` planted in an earlier PATH entry does
+#     not SUPPRESS a later one: bash's path search skips a non-executable file, a directory and a
+#     dangling symlink alike and walks on to the real binary (all three measured, against a
+#     control that reports NOTFOUND when the later dir is empty). And a shadow that IS found makes
+#     `command -v node` SUCCEED, which arms the guard and lands the run on case (d)'s
+#     runs-and-crashes leg -- this cell would go green for the wrong reason and AC28(a) would fail
+#     outright. There is no directory this suite can write to that sits ahead of /usr/local/bin.
+#
+#     So the prepend is DECLINED rather than out-run. BASH_ENV names a file bash sources before
+#     the hook body, and that file marks PATH readonly; the hook's own `export PATH=...` then
+#     fails (one diagnostic line on stderr, no change of control flow -- these hooks are `set -u`
+#     only, and the assignment is a standalone statement) and PATH stays exactly the node-free
+#     directory built below. Nothing here doctors an ANSWER: `command -v node` fails because node
+#     genuinely is not on the PATH the hook is holding at the moment it asks. That is the property
+#     the two rejected alternatives lack -- a stub on PATH and an override of the `command`
+#     builtin both leave the real node reachable and only change what the hook is told.
+#
+#     WHAT THIS CELL STILL DOES NOT PROVE: that an operator whose node sits in one of those four
+#     hardcoded dirs can ever present a node-free PATH to these hooks. They cannot, and that is a
+#     property of the prepend rather than of the guard. It is #46's sibling half and belongs to
+#     whoever owns that posture, not to this fixture.
 mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
 new_tmpdir || exit 90
 NO_NODE_HOME="$NEW_TMPDIR"
 NO_NODE_BIN="$NO_NODE_HOME/bin"
-mkdir -p "$NO_NODE_BIN"
-for t in git bash cat mktemp rm tail dirname grep sed; do
-  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$NO_NODE_BIN/$t"
+WITH_NODE_BIN="$NO_NODE_HOME/bin-with-node"
+mkdir -p "$NO_NODE_BIN" "$WITH_NODE_BIN"
+# THE LIST HAS TO BE COMPLETE NOW, which it did not before. With the system dirs declined these
+# two dirs are the hooks' whole world, and a missing tool does not fail loudly: stop.sh exits 0 at
+# its is-inside-work-tree line the moment `git` is unreachable, which is the same exit code this
+# cell asserts. The WITH_NODE control below is what tells those two apart.
+for t in git bash sh cat cut mktemp rm rmdir tail head dirname basename grep sed tr wc find ls sort env; do
+  p="$(command -v "$t" 2>/dev/null)" || continue
+  ln -sf "$p" "$NO_NODE_BIN/$t"
+  ln -sf "$p" "$WITH_NODE_BIN/$t"
 done
-assert_eq "  precondition: node is genuinely unreachable from the stripped PATH+HOME" \
-  "$(env -i HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN" bash -c 'command -v node >/dev/null 2>&1 && echo FOUND || echo absent')" \
-  "absent"
-# NON-ZERO CONTROL, on the SAME fixture. Without it, "exit 0" is indistinguishable from a
-# guard that never runs at all -- which is exactly the state this contract is authored in.
+ln -sf "$(command -v node)" "$WITH_NODE_BIN/node"
+DECLINE_PREPEND="$NO_NODE_HOME/decline-path-prepend.sh"
+printf 'readonly PATH\n' > "$DECLINE_PREPEND"
+NO_NODE_ENV=(BASH_ENV="$DECLINE_PREPEND" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN")
+WITH_NODE_ENV=(BASH_ENV="$DECLINE_PREPEND" HOME="$NO_NODE_HOME" PATH="$WITH_NODE_BIN")
+
+# THE PRECONDITION IS THE HOOK'S OWN PROLOGUE, cut out of stop.sh at the first line that stops
+# touching PATH, so it measures the effective PATH rather than restating how it is built. A
+# hand-written copy of the prepend here would be a second vocabulary with no drift test behind it.
+# stop.sh's prologue is a superset of session-start.sh's (same four dirs, plus the ~/.nvm entry),
+# so node unreachable here is node unreachable there too, and one probe covers both AC23(a) and
+# AC28(a).
+HOOK_PROLOGUE="$NO_NODE_HOME/hook-prologue-probe.sh"
+awk '/^PROJECT_DIR=/{exit} {print}' "$HOOK" > "$HOOK_PROLOGUE"
+printf 'command -v node >/dev/null 2>&1 && echo FOUND || echo absent\n' >> "$HOOK_PROLOGUE"
+node_on_hook_path() { env "$@" bash "$HOOK_PROLOGUE" 2>/dev/null; }
+assert_contains "  precondition: the probe really carries the hook's PATH prepend, or it measures nothing" \
+  "$(cat "$HOOK_PROLOGUE")" 'export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"'
+assert_eq "  precondition: node is unreachable from the EFFECTIVE PATH stop.sh builds, not the one passed in" \
+  "$(node_on_hook_path "${NO_NODE_ENV[@]}")" "absent"
+assert_eq "  CONTROL: the same probe says FOUND once node is put back, so 'absent' is a measurement" \
+  "$(node_on_hook_path "${WITH_NODE_ENV[@]}")" "FOUND"
+
+# THE DECLINED PREPEND IS LOAD-BEARING, and this is where that is watched rather than asserted.
+# On the machine this suite was written on, node lives under ~/.nvm and none of the four hardcoded
+# dirs contains it, so the cell below would go green with or without any of the above -- luck
+# about one machine's layout, which is precisely how #46 shipped. stop.sh carries a SECOND prepend
+# that is reproducible anywhere: point HOME at an nvm layout holding a node and the hook rebuilds
+# a PATH that reaches it, the same shape /usr/local/bin/node produced on ubuntu-latest. So the red
+# is reproduced here, on purpose, and then shown to turn green on the declined prepend alone --
+# same fixture, same hook, same caller PATH, one variable. session-start.sh has no ~/.nvm block,
+# so its half of the red is only reproducible where the hardcoded prepend reaches a node; it
+# shares the first prepend and this same construction.
+new_tmpdir || exit 90
+NVM_HOME="$NEW_TMPDIR"
+mkdir -p "$NVM_HOME/.nvm/versions/node/v99.0.0/bin"
+ln -sf "$(command -v node)" "$NVM_HOME/.nvm/versions/node/v99.0.0/bin/node"
+assert_eq "  CONTROL: left alone, the hook's own prepend reaches a node the caller's PATH does not" \
+  "$(node_on_hook_path HOME="$NVM_HOME" PATH="$NO_NODE_BIN")" "FOUND"
+run_stop "$HOOK" "$HP_ROOT" '' HOME="$NVM_HOME" PATH="$NO_NODE_BIN"
+assert_eq "  CONTROL: so the guard is ARMED and refuses -- this is the #46 red, reproduced" "$STOP_RC" "2"
+assert_eq "  CONTROL: declining the prepend, and nothing else, makes node unreachable again" \
+  "$(node_on_hook_path BASH_ENV="$DECLINE_PREPEND" HOME="$NVM_HOME" PATH="$NO_NODE_BIN")" "absent"
+run_stop "$HOOK" "$HP_ROOT" '' BASH_ENV="$DECLINE_PREPEND" HOME="$NVM_HOME" PATH="$NO_NODE_BIN"
+assert_eq "  CONTROL: and the same run then exits 0, which is the fix and not the machine" "$STOP_RC" "0"
+# NON-ZERO CONTROLS, on the SAME fixture. Without them, "exit 0" is indistinguishable from a
+# guard that never runs at all -- which is exactly the state this contract is authored in. The
+# FIRST of the two is the one #46 added: it holds the constructed environment fixed and changes
+# only node, so it fails if the stripped bin dir is missing anything the hook needs.
+run_stop "$HOOK" "$HP_ROOT" '' "${WITH_NODE_ENV[@]}"
+assert_eq "  CONTROL: the same fixture in that same stripped env, node restored -> refuses, exit 2" "$STOP_RC" "2"
 run_stop "$HOOK" "$HP_ROOT" ''
 assert_eq "  CONTROL: this same fixture DOES refuse when the tooling is present" "$STOP_RC" "2"
-run_stop "$HOOK" "$HP_ROOT" '' HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+run_stop "$HOOK" "$HP_ROOT" '' "${NO_NODE_ENV[@]}"
 assert_eq "(a) node absent -> exit 0, the guard does not wedge the operator's environment" "$STOP_RC" "0"
+# ...and it exited 0 because the guard never RAN, not because it ran and chose to allow. The
+# refusal template is the only thing that distinguishes those two from outside.
+assert_not_contains "  and it is silent about the phase it did not check" "$(lower "$STOP_ERR")" "cannot end"
 
 # (b) the guard script itself missing. A COPY of the plugin, minus the one file.
 new_tmpdir || exit 90
@@ -312,8 +401,16 @@ start_notice() {
 }
 
 mk_project "$REFUSING_STATUS" '{"checkCommand":"true"}'
-start_notice "$SESSION_START" "$HP_ROOT" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+# Same constructed environment as AC23(a): session-start.sh opens with the same unconditional
+# PATH prepend, so a bare PATH= here is rebuilt before line 151's `command -v node` and the notice
+# is correctly withheld -- a cell that fails for the guard being ARMED, not for the notice being
+# broken.
+start_notice "$SESSION_START" "$HP_ROOT" "${NO_NODE_ENV[@]}"
 assert_eq "(a) guarded run in flight + node absent -> exactly one notice line" "$NOTICE_N" "1"
+# NON-ZERO CONTROL for (a), holding the stripped environment fixed and changing only node: the
+# notice has to be a statement about the DISARM rather than about running in a bare environment.
+start_notice "$SESSION_START" "$HP_ROOT" "${WITH_NODE_ENV[@]}"
+assert_eq "  CONTROL: node restored in that same stripped env -> no notice" "$NOTICE_N" "0"
 
 start_notice "$COPY_ROOT/hooks/session-start.sh" "$HP_ROOT"
 assert_eq "(b) guarded run in flight + guard script missing -> exactly one notice line" "$NOTICE_N" "1"
@@ -323,7 +420,7 @@ assert_eq "(c) both present -> no notice" "$NOTICE_N" "0"
 
 # (d) The cell a positive-only test omits, and where a notice that ALWAYS fires would hide.
 mk_project "$(printf '{"issue_number":4242,"current_phase":"5-archived","risk_tier":"architectural","updated_at":"%s","events":[]}' "$FRESH_ISO")" '{"checkCommand":"true"}'
-start_notice "$SESSION_START" "$HP_ROOT" HOME="$NO_NODE_HOME" PATH="$NO_NODE_BIN"
+start_notice "$SESSION_START" "$HP_ROOT" "${NO_NODE_ENV[@]}"
 assert_eq "(d) no in-flight GUARDED run -> no notice, even with node absent" "$NOTICE_N" "0"
 
 finish

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -351,8 +351,8 @@ suite "R3 kind: content-conditioned rows test CONTENT on path (a), not mere pres
 # artifact-absent-with-event cell is the non-zero control that makes the rest mean anything: it
 # is what proves the event in cells 1 and 2 really does satisfy the row, so a refusal alongside
 # it is the ARTIFACT overriding the event rather than an inert fixture.
-r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <satisfying-event-json>
-  local phase="$1" tier="$2" file="$3" bad="$4" good="$5" ev="$6"
+r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <satisfying-event-json> <repair-token>
+  local phase="$1" tier="$2" file="$3" bad="$4" good="$5" ev="$6" repair="$7"
 
   # 1. THE MISSING LEG: present-and-failing, WITH an event that would satisfy the row on its own.
   new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$ev")"
@@ -361,6 +361,15 @@ r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <sat
   assert_eq "$phase ($tier): a failing $file is NOT rescued by a satisfying events[] entry" \
     "$GATE_DEC" "refused"
   assert_eq "  and the refusal exits 2" "$GATE_RC" "2"
+  # The operator-facing half of the same cell. The message a blocked turn reads used to say the
+  # file was NOT PRESENT and send them to re-run the phase that produced it -- both false when
+  # the file is sitting in front of them, and the wrong repair either way.
+  assert_not_contains "  and the refusal does not claim the file is missing" \
+    "$GATE_ERR" "\`$file\` is not present"
+  assert_contains "  it says the file IS present" "$GATE_ERR" "\`$file\` IS present"
+  assert_contains "  and names the repair this row actually needs ($repair)" "$GATE_ERR" "$repair"
+  assert_not_contains "  and does not send them back to the phase that already produced it" \
+    "$GATE_ERR" "Run the phase that produces"
 
   # 2. Same fixture, same event, CONTENT REPAIRED. The twin: without it, cell 1's refusal could
   #    be about the phase, the tier or the event rather than about the content.
@@ -386,9 +395,31 @@ r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <sat
 BA_EVENT='[{"phase":"1-ba","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
 P2_EVENT='[{"phase":"2-constraints","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
 
-r3_row 2-review     architectural spec.json      '{"issue_number":4242}' "$SPEC_APPROVED"  "$BA_EVENT"
-r3_row 2-constraints standard     spec.json      '{"issue_number":4242}' "$SPEC_APPROVED"  "$BA_EVENT"
-r3_row 3-impl       standard      constraints.md ''                      '# real content' "$P2_EVENT"
+r3_row 2-review      architectural spec.json      '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" ba_approved_at
+r3_row 2-constraints standard      spec.json      '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" ba_approved_at
+r3_row 3-impl        standard      constraints.md ''                      '# real content' "$P2_EVENT" "is empty"
+
+# NON-ZERO CONTROL for the four message assertions above: the ABSENT case must still say the two
+# things the present case must not. Without it, "does not claim the file is missing" is satisfied
+# by a template that lost the absent-case wording entirely, and the operator blocked by a genuinely
+# missing artifact is the one who pays.
+new_case 4242 "$(mk_status "2-review" '"architectural"' "$NO_EVENTS")"
+gate "$CASE_ROOT"
+assert_contains "CONTROL: an ABSENT prerequisite still says it is not present" \
+  "$GATE_ERR" "\`spec.json\` is not present"
+assert_contains "CONTROL: and still sends the operator to the phase that produces it" \
+  "$GATE_ERR" "Run the phase that produces"
+assert_not_contains "CONTROL: and does not claim a file that is absent IS present" \
+  "$GATE_ERR" "\`spec.json\` IS present"
+
+# The route the in-flight predicate exists for, which the message never named. Concluding an
+# abandoned run is the escape that works -- inFlight is false on a final_verdict, and isTerminal
+# is true on completed_at and on 5-archived, each already asserted by AC12/AC15 -- so this route
+# refuses nothing that was not already refused.
+assert_contains "the refusal offers the abandoned-run route" "$GATE_ERR" "If this run is over"
+assert_contains "  naming final_verdict" "$GATE_ERR" "final_verdict"
+assert_contains "  and completed_at" "$GATE_ERR" "completed_at"
+assert_contains "  and 5-archived" "$GATE_ERR" "5-archived"
 
 # The stated consequence, asserted rather than left as prose: on a fresh checkout the SAME run
 # is granted through path (b), because an event attests DISPATCH and not APPROVAL. This is the

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -481,12 +481,7 @@ two_dirs() {
   touch -t "$2" "$CASE_ROOT/.pipeline/6160/status.json"
 }
 
-two_dirs 202601010101 202601010102        # granting dir is newest
-( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; gate "$CASE_ROOT"
-  assert_eq "(a) signal unset: the mtime-derived (granting) dir is the one evaluated" "$GATE_DEC" "granted"
-  assert_contains "  and the decision names that dir" "$GATE_ISSUE" "6160" )
-
-# gate_signal <root> <VAR=VAL ...> -> GATE_OUT, GATE_RC, GATE_DEC, GATE_ISSUE
+# gate_signal <root> <env-arg ...> -> GATE_OUT, GATE_RC, GATE_DEC, GATE_ISSUE
 # The env has to be set for the child, so this cannot reuse gate() as written.
 gate_signal() {
   local root="$1"; shift
@@ -497,6 +492,22 @@ gate_signal() {
   GATE_ISSUE="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"issue_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
   [[ -n "$GATE_ISSUE" ]] || GATE_ISSUE="<no-issue-dir-on-stdout>"
 }
+
+# gate_nosignal <root> -> the same outputs, with BOTH signal names removed from the CHILD's
+# environment.
+#
+# `env -u` rather than the `( unset ...; assert ... )` this used to be, and the difference is the
+# whole reason the cells below count. harness.sh tracks TESTS_PASSED/TESTS_FAILED in shell
+# variables and assert_* returns 0 on both branches, so an assertion evaluated inside a `( ... )`
+# printed its FAIL line and incremented nothing that survived the subshell: seven assertions in
+# this file -- including the two (b') CONTROLs, whose entire job is to be falsifiable -- could not
+# fail the build. Scope the environment around the CHILD process, never around the assertion.
+gate_nosignal() { gate_signal "$1" -u CLAUDE_PIPELINE_ACTIVE_ISSUE -u PIPELINE_ACTIVE_ISSUE; }
+
+two_dirs 202601010101 202601010102        # granting dir is newest
+gate_nosignal "$CASE_ROOT"
+assert_eq "(a) signal unset: the mtime-derived (granting) dir is the one evaluated" "$GATE_DEC" "granted"
+assert_contains "  and the decision names that dir" "$GATE_ISSUE" "6160"
 
 two_dirs 202601010102 202601010101        # refusing dir is newest; signal points at the granting one
 gate_signal "$CASE_ROOT" CLAUDE_PIPELINE_ACTIVE_ISSUE=6160
@@ -514,8 +525,8 @@ for signal_var in CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; do
   two_dirs 202601010101 202601010102      # granting dir (6160) is newest; 5150 refuses
   # NON-ZERO CONTROL, on this exact fixture: with no signal the answer is `granted`, so the
   # refusal below is attributable to the signal and to nothing else about the tree.
-  ( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; gate "$CASE_ROOT"
-    assert_eq "  CONTROL ($signal_var): with no signal this same tree GRANTS (mtime picks 6160)" "$GATE_DEC" "granted" )
+  gate_nosignal "$CASE_ROOT"
+  assert_eq "  CONTROL ($signal_var): with no signal this same tree GRANTS (mtime picks 6160)" "$GATE_DEC" "granted"
   gate_signal "$CASE_ROOT" "$signal_var=5150"
   assert_eq "(b') $signal_var naming the REFUSING dir is honoured, not discarded for mtime" "$GATE_DEC" "refused"
   assert_eq "  and the decision names the signal-named dir" "$GATE_ISSUE" "5150"
@@ -523,13 +534,12 @@ for signal_var in CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; do
 done
 
 two_dirs 202601010103 202601010103        # the measured tie: three records in this tree share one mtime
-( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE
-  gate "$CASE_ROOT"; FIRST_DEC="$GATE_DEC"; FIRST_DIR="$GATE_ISSUE"
-  gate "$CASE_ROOT"
-  assert_eq "(c) an mtime tie is DETERMINISTIC across runs (decision)" "$GATE_DEC" "$FIRST_DEC"
-  assert_eq "  and deterministic in the dir it names" "$GATE_ISSUE" "$FIRST_DIR"
-  assert_eq "  and it names one of the two dirs rather than nothing" \
-    "$([[ "$FIRST_DIR" == "5150" || "$FIRST_DIR" == "6160" ]] && echo named || echo "UNNAMED: $FIRST_DIR")" "named" )
+gate_nosignal "$CASE_ROOT"; FIRST_DEC="$GATE_DEC"; FIRST_DIR="$GATE_ISSUE"
+gate_nosignal "$CASE_ROOT"
+assert_eq "(c) an mtime tie is DETERMINISTIC across runs (decision)" "$GATE_DEC" "$FIRST_DEC"
+assert_eq "  and deterministic in the dir it names" "$GATE_ISSUE" "$FIRST_DIR"
+assert_eq "  and it names one of the two dirs rather than nothing" \
+  "$([[ "$FIRST_DIR" == "5150" || "$FIRST_DIR" == "6160" ]] && echo named || echo "UNNAMED: $FIRST_DIR")" "named"
 
 # ---------------------------------------------------------------------------
 suite "AC17: exp-<slug> runs are GUARDED, not exempt"

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -191,11 +191,52 @@ suite "AC5: NEGATIVE -- 2.5-design does not self-grant, and its SKIPPED note doe
 # escape hatch's own precedent would self-grant the Phase 2 review gate it skipped. The
 # 2.5-design row's satisfying set is {2}, so its own token is NOT a member. Two fixtures,
 # because the plain-satisfaction half and the hatch half fail independently.
+#
+# WHY THE HATCH HALF IS NOT THE WHOLE ISSUE-17 RECORD, which is what the spec's AC5 text names.
+# That record carries TWO events resolving to token 2 (2-review and 2-review-r2, both
+# REQUEST_CHANGES), and {2} IS the 2.5-design row's satisfying set, so the whole record is
+# granted through an entry that has nothing to do with the skip. AC9's second cell asserts
+# exactly that pairing GRANTS ("a review that demanded changes still ran"), so demanding
+# `refused` on a superset of AC9's own fixture asks the guard for two answers to one input.
+# Measured, not reasoned: under the prefix mutation A4 the whole-record fixture is `granted`
+# too, so it never discriminated the reading AC5 names -- it was red either way.
+#
+# The two cells below are the discriminating PAIR. They differ in exactly one thing: whether
+# the other entries are present. (i) fixes the confound in place, so the narrowing is recorded
+# in the suite rather than lost; (ii) is AC5's actual property, on the capture's REAL skip
+# entry with its real note, and is the only cell in this suite that a hatch which self-clears
+# the row it names can redden. Cell 3 below cannot: its entry is not SKIPPED.
 assert_eq "the capture still carries the SKIPPED 2.5-design entry this criterion rests on" \
   "$(grep -c '"SKIPPED"' "$REC17" 2>/dev/null | tr -d ' ')" "1"
+# The confound, named. If anyone strips these the pair below stops discriminating, and this
+# fails loudly instead of the criterion quietly retiring.
+assert_eq "and it carries a non-SKIPPED 2-review* entry, which is WHY the whole record grants" \
+  "$(node -e 'const s=require(process.argv[1]);process.stdout.write(String((s.events||[]).filter(e=>/^2-review/.test(e.phase||"")&&e.verdict!=="SKIPPED").length))' "$REC17")" \
+  "2"
 
+# (i) THE CONFOUND, asserted positively rather than deleted: the whole record at 2.5-design is
+#     granted, and the next cell shows what it is granted BY.
 new_case 17 '{}'
 capture "$REC17" "$CASE_DIR/status.json" "{\"current_phase\":\"2.5-design\",\"updated_at\":\"$FRESH_ISO\"}"
+gate "$CASE_ROOT"
+assert_eq "the WHOLE record at 2.5-design is granted -- by its 2-review entries, per AC9" "$GATE_DEC" "granted"
+
+# (ii) the same capture, events narrowed to the REAL skip entry alone (derived from the record,
+#      never hand-written). Nothing else can satisfy the row, so the decision is now a statement
+#      about the hatch and about nothing else.
+AC5_HATCH_PATCH="$(node -e '
+  const fs = require("fs");
+  const s = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const e = (s.events || []).find((x) => x.phase === "2.5-design" && x.verdict === "SKIPPED");
+  process.stdout.write(JSON.stringify({
+    current_phase: "2.5-design", updated_at: process.argv[2], events: e ? [e] : [],
+  }));
+' "$REC17" "$FRESH_ISO")"
+assert_eq "  the narrowed fixture really carries that entry, with its real non-empty note" \
+  "$(printf '%s' "$AC5_HATCH_PATCH" | node -e 'let b="";process.stdin.on("data",d=>b+=d).on("end",()=>{const e=(JSON.parse(b).events||[])[0];process.stdout.write(e&&e.verdict==="SKIPPED"&&String(e.note||"").trim()!==""?"skip-with-note":"MISSING")})')" \
+  "skip-with-note"
+new_case 17 '{}'
+capture "$REC17" "$CASE_DIR/status.json" "$AC5_HATCH_PATCH"
 gate "$CASE_ROOT"
 assert_eq "the SKIPPED 2.5-design entry does NOT fire the hatch for the 2.5-design row" "$GATE_DEC" "refused"
 assert_contains "and the refusal names the review.json it is still missing" "$GATE_OUT" "review.json"
@@ -445,12 +486,41 @@ two_dirs 202601010101 202601010102        # granting dir is newest
   assert_eq "(a) signal unset: the mtime-derived (granting) dir is the one evaluated" "$GATE_DEC" "granted"
   assert_contains "  and the decision names that dir" "$GATE_ISSUE" "6160" )
 
+# gate_signal <root> <VAR=VAL ...> -> GATE_OUT, GATE_RC, GATE_DEC, GATE_ISSUE
+# The env has to be set for the child, so this cannot reuse gate() as written.
+gate_signal() {
+  local root="$1"; shift
+  GATE_OUT="$( cd "$root" && env "$@" node "$GUARD" --root "$root" 2>/dev/null )"
+  GATE_RC=$?
+  GATE_DEC="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"decision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  [[ -n "$GATE_DEC" ]] || GATE_DEC="<no-decision-on-stdout>"
+  GATE_ISSUE="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"issue_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  [[ -n "$GATE_ISSUE" ]] || GATE_ISSUE="<no-issue-dir-on-stdout>"
+}
+
 two_dirs 202601010102 202601010101        # refusing dir is newest; signal points at the granting one
-GATE_OUT="$( cd "$CASE_ROOT" && CLAUDE_PIPELINE_ACTIVE_ISSUE=6160 node "$GUARD" --root "$CASE_ROOT" 2>/dev/null )"
-GATE_RC=$?
-GATE_DEC="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"decision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
-assert_eq "(b) setting the signal to a satisfied dir does NOT disarm the guard" "${GATE_DEC:-<none>}" "refused"
+gate_signal "$CASE_ROOT" CLAUDE_PIPELINE_ACTIVE_ISSUE=6160
+assert_eq "(b) setting the signal to a satisfied dir does NOT disarm the guard" "$GATE_DEC" "refused"
 assert_contains "  and the refusal names WHICH dir refused" "$GATE_OUT" "5150"
+
+# (b') THE OTHER DIRECTION, and the only cell in this suite that requires the signal to be READ
+#      at all. In (a), (b) and (c) the refusing record is always the mtime-newest one, so a
+#      guard that ignores the signal entirely -- resolving only by mtime -- passes every one of
+#      them. Here the signal names the REFUSING dir while the mtime-newest dir GRANTS, so
+#      ignoring the signal answers `granted` and this cell is the thing that says so.
+#      BOTH env names are doors into the same resolver and only one of them was ever opened; a
+#      fix applied to one and not the other passes a suite that tests only the first.
+for signal_var in CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; do
+  two_dirs 202601010101 202601010102      # granting dir (6160) is newest; 5150 refuses
+  # NON-ZERO CONTROL, on this exact fixture: with no signal the answer is `granted`, so the
+  # refusal below is attributable to the signal and to nothing else about the tree.
+  ( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; gate "$CASE_ROOT"
+    assert_eq "  CONTROL ($signal_var): with no signal this same tree GRANTS (mtime picks 6160)" "$GATE_DEC" "granted" )
+  gate_signal "$CASE_ROOT" "$signal_var=5150"
+  assert_eq "(b') $signal_var naming the REFUSING dir is honoured, not discarded for mtime" "$GATE_DEC" "refused"
+  assert_eq "  and the decision names the signal-named dir" "$GATE_ISSUE" "5150"
+  assert_eq "  and it exits 2" "$GATE_RC" "2"
+done
 
 two_dirs 202601010103 202601010103        # the measured tie: three records in this tree share one mtime
 ( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE
@@ -563,10 +633,22 @@ AC19_REPORT="$(cd "$REPO_ROOT" && node --input-type=module -e '
 # shape the sibling drift suite's field() already uses. Applying `${VALUE:-<no-report>}` to the
 # value makes both assertions below unsatisfiable in the direction they assert: an EMPTY strays
 # list -- the passing state -- is exactly what `:-` replaces with the sentinel.
+# BOTH of field()'s branches, not just the first. An empty REPORT is one way to measure
+# nothing; a report that is present but does not carry the key is the other, and sed prints
+# nothing for it, which is byte-identical to "the list was empty" -- the passing state. An
+# absence assertion that cannot tell `nothing wrong` from `nothing measured` is not an
+# assertion, and that is the whole reason the sentinel exists.
 ac19_field() {  # ac19_field <json-key>
   [[ -n "$AC19_REPORT" ]] || { printf '<no-report>'; return; }
+  case "$AC19_REPORT" in *"\"$1\":"*) ;; *) printf '<no-field:%s>' "$1"; return ;; esac
   printf '%s' "$AC19_REPORT" | sed -n "s/.*\"$1\":\\[\\([^]]*\\)\\].*/\\1/p"
 }
+# Witnessed, on this exact function: a non-empty report that lost the key must NOT read as an
+# empty list. Without this the hardening above is a claim rather than a control.
+assert_eq "  CONTROL: a report missing the key reads as <no-field:strays>, never as empty" \
+  "$(AC19_REPORT='{"total":9,"read":9}' ac19_field strays)" "<no-field:strays>"
+assert_eq "  CONTROL: and an absent report still reads as <no-report>" \
+  "$(AC19_REPORT='' ac19_field strays)" "<no-report>"
 AC19_STRAYS="$(ac19_field strays)"
 AC19_UNREAD="$(ac19_field unreadable)"
 assert_eq "every committed record's current_phase is a member of one of the four sets" \

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -169,8 +169,14 @@ assert_eq "issue 17 at 3-impl-complete, no impl-report.json on disk, is GRANTED 
 # ---------------------------------------------------------------------------
 suite "AC4: event labels resolve through the shared resolver and compare by SET MEMBERSHIP"
 # ---------------------------------------------------------------------------
+# DO NOT inline the events array as "[{\"phase\":...}]". Inside "$(...)" the escaped quotes
+# collapse, the braces end up UNQUOTED, and bash brace-expands `{a,b,c}` into three words: the
+# fixture that reaches disk is `"events":["phase":"3b-dev"]`, which is not valid JSON, so the
+# guard reads it as a tooling failure and the case tests silence instead of set membership.
+# Built in a variable, where no brace expansion happens, exactly like AC7's single-quoted form.
 ac4() {  # ac4 <event-label> <expected-decision>
-  new_case 4242 "$(mk_status "4-review" '"architectural"' "[{\"phase\":\"$1\",\"verdict\":\"complete\",\"at\":\"$FRESH_ISO\"}]")"
+  local events='[{"phase":"'"$1"'","verdict":"complete","at":"'"$FRESH_ISO"'"}]'
+  new_case 4242 "$(mk_status "4-review" '"architectural"' "$events")"
   gate "$CASE_ROOT"
   assert_eq "events[] label '$1' against the 4-review row {3,3b} -> $2" "$GATE_DEC" "$2"
 }
@@ -194,7 +200,8 @@ gate "$CASE_ROOT"
 assert_eq "the SKIPPED 2.5-design entry does NOT fire the hatch for the 2.5-design row" "$GATE_DEC" "refused"
 assert_contains "and the refusal names the review.json it is still missing" "$GATE_OUT" "review.json"
 
-new_case 4242 "$(mk_status "2.5-design" '"architectural"' "[{\"phase\":\"2.5-design\",\"verdict\":\"complete\",\"at\":\"$FRESH_ISO\"}]")"
+AC5_EVENTS='[{"phase":"2.5-design","verdict":"complete","at":"'"$FRESH_ISO"'"}]'   # see the ac4 note
+new_case 4242 "$(mk_status "2.5-design" '"architectural"' "$AC5_EVENTS")"
 gate "$CASE_ROOT"
 assert_eq "and a plain 2.5-design event does not satisfy the 2.5-design row either" "$GATE_DEC" "refused"
 
@@ -224,8 +231,8 @@ assert_eq "AC7: a SKIPPED 2.5-design with a written reason clears entry to 3-imp
 # Three cells. A single 'note absent' fixture passes under a truthiness check that a
 # whitespace-only string defeats, which is the whole point of the trim.
 ac8() {  # ac8 <label> <note-json-fragment-or-empty>
-  new_case 4242 "$(mk_status "3-impl" '"architectural"' \
-    "[{\"phase\":\"2.5-design\",\"verdict\":\"SKIPPED\",\"at\":\"2026-01-01T00:00:00Z\"$2}]")"
+  local events='[{"phase":"2.5-design","verdict":"SKIPPED","at":"2026-01-01T00:00:00Z"'"$2"'}]'  # see the ac4 note
+  new_case 4242 "$(mk_status "3-impl" '"architectural"' "$events")"
   gate "$CASE_ROOT"
   assert_eq "AC8: a skip with $1 is REFUSED" "$GATE_DEC" "refused"
 }
@@ -552,12 +559,20 @@ AC19_REPORT="$(cd "$REPO_ROOT" && node --input-type=module -e '
   // zero it did not earn.
   process.stdout.write(JSON.stringify({ total: files.length, read, unreadable, strays }));
 ' "$GUARD" $CORPUS 2>/dev/null)"
-AC19_STRAYS="$(printf '%s' "$AC19_REPORT" | sed -n 's/.*"strays":\[\(.*\)\]}/\1/p')"
-AC19_UNREAD="$(printf '%s' "$AC19_REPORT" | sed -n 's/.*"unreadable":\[\([^]]*\)\].*/\1/p')"
+# The <no-report> sentinel belongs on the REPORT, never on the extracted value, which is the
+# shape the sibling drift suite's field() already uses. Applying `${VALUE:-<no-report>}` to the
+# value makes both assertions below unsatisfiable in the direction they assert: an EMPTY strays
+# list -- the passing state -- is exactly what `:-` replaces with the sentinel.
+ac19_field() {  # ac19_field <json-key>
+  [[ -n "$AC19_REPORT" ]] || { printf '<no-report>'; return; }
+  printf '%s' "$AC19_REPORT" | sed -n "s/.*\"$1\":\\[\\([^]]*\\)\\].*/\\1/p"
+}
+AC19_STRAYS="$(ac19_field strays)"
+AC19_UNREAD="$(ac19_field unreadable)"
 assert_eq "every committed record's current_phase is a member of one of the four sets" \
-  "${AC19_STRAYS:-<no-report>}" ""
+  "$AC19_STRAYS" ""
 assert_eq "and the walk ACCOUNTS for every record rather than continuing past it" \
-  "${AC19_UNREAD:-<no-report>}" ""
+  "$AC19_UNREAD" ""
 
 # ---------------------------------------------------------------------------
 suite "AC24: no committed record is REFUSED (a zero, whose non-zero control is AC1's 14)"

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -430,10 +430,18 @@ assert_not_contains "CONTROL: and does not claim a file that is absent IS presen
 # abandoned run is the escape that works -- inFlight is false on a final_verdict, and isTerminal
 # is true on completed_at and on 5-archived, each already asserted by AC12/AC15 -- so this route
 # refuses nothing that was not already refused.
-assert_contains "the refusal offers the abandoned-run route" "$GATE_ERR" "If this run is over"
+assert_contains "the refusal offers the abandoned-run route" "$GATE_ERR" "If this run is YOURS and is over"
 assert_contains "  naming final_verdict" "$GATE_ERR" "final_verdict"
 assert_contains "  and completed_at" "$GATE_ERR" "completed_at"
 assert_contains "  and 5-archived" "$GATE_ERR" "5-archived"
+# The ownership clause is the whole of what the TEXT can do about route 3 being the widest and
+# cheapest disarm the guard has. It cannot withhold the capability -- that belongs to the
+# in-flight predicate, and the spec discloses it in does_not_stop -- but an unqualified "if this
+# run is over" reads to a blocked session as a licence over whatever run the guard happened to
+# resolve, which on this hook is usually the newest status.json in the project rather than
+# theirs. Pinned so a wording refresh cannot drop it back to the unqualified form.
+assert_not_contains "  and does not offer it unqualified, over whatever run got resolved" \
+  "$GATE_ERR" "If this run is over"
 
 # The stated consequence, asserted rather than left as prose: on a fresh checkout the SAME run
 # is granted through path (b), because an event attests DISPATCH and not APPROVAL. This is the

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -351,8 +351,15 @@ suite "R3 kind: content-conditioned rows test CONTENT on path (a), not mere pres
 # artifact-absent-with-event cell is the non-zero control that makes the rest mean anything: it
 # is what proves the event in cells 1 and 2 really does satisfy the row, so a refusal alongside
 # it is the ARTIFACT overriding the event rather than an inert fixture.
-r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <satisfying-event-json> <repair-token>
-  local phase="$1" tier="$2" file="$3" bad="$4" good="$5" ev="$6" repair="$7"
+# The `  1. ` line of the refusal, ALONE. Asserting the repair against the whole of stderr does
+# not work and this was measured: the diagnosis line names the same field the repair does, so
+# `assert_contains "$GATE_ERR" ba_approved_at` passes while route 1 says something else entirely.
+# A mutation that replaced the ba-approved repair with "Re-run the phase and rewrite" SURVIVED on
+# the whole-stderr form. The needle has to be searched where it is supposed to be.
+route1() { printf '%s' "$GATE_ERR" | sed -n 's/^  1\. //p'; }
+
+r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <event-json> <lack> <repair>
+  local phase="$1" tier="$2" file="$3" bad="$4" good="$5" ev="$6" lack="$7" repair="$8" r1
 
   # 1. THE MISSING LEG: present-and-failing, WITH an event that would satisfy the row on its own.
   new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$ev")"
@@ -367,7 +374,11 @@ r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <sat
   assert_not_contains "  and the refusal does not claim the file is missing" \
     "$GATE_ERR" "\`$file\` is not present"
   assert_contains "  it says the file IS present" "$GATE_ERR" "\`$file\` IS present"
-  assert_contains "  and names the repair this row actually needs ($repair)" "$GATE_ERR" "$repair"
+  assert_contains "  and diagnoses what the file lacks ($lack)" "$GATE_ERR" "$lack"
+  r1="$(route1)"
+  assert_eq "  CONTROL: a route 1 line was extracted at all, so the next assertion has a haystack" \
+    "$([[ -n "$r1" ]] && echo found || echo "NO ROUTE 1 LINE")" "found"
+  assert_contains "  and ROUTE 1 ITSELF names the repair this row needs" "$r1" "$repair"
   assert_not_contains "  and does not send them back to the phase that already produced it" \
     "$GATE_ERR" "Run the phase that produces"
 
@@ -395,9 +406,12 @@ r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <sat
 BA_EVENT='[{"phase":"1-ba","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
 P2_EVENT='[{"phase":"2-constraints","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
 
-r3_row 2-review      architectural spec.json      '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" ba_approved_at
-r3_row 2-constraints standard      spec.json      '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" ba_approved_at
-r3_row 3-impl        standard      constraints.md ''                      '# real content' "$P2_EVENT" "is empty"
+r3_row 2-review      architectural spec.json '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" \
+  'carries no `ba_approved_at`' 'set `ba_approved_at` in .pipeline/4242/spec.json'
+r3_row 2-constraints standard      spec.json '{"issue_number":4242}' "$SPEC_APPROVED" "$BA_EVENT" \
+  'carries no `ba_approved_at`' 'set `ba_approved_at` in .pipeline/4242/spec.json'
+r3_row 3-impl standard constraints.md '' '# real content' "$P2_EVENT" \
+  'it is empty' 'into .pipeline/4242/constraints.md'
 
 # NON-ZERO CONTROL for the four message assertions above: the ABSENT case must still say the two
 # things the present case must not. Without it, "does not claim the file is missing" is satisfied

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -1,0 +1,594 @@
+#!/usr/bin/env bash
+# gate-phase-entry.mjs -- the decision function itself, driven through its CLI.
+#
+# WHAT THIS SUITE IS. Phase sequencing in commands/pipeline.md is prose addressed to the
+# orchestrator, and the orchestrator is the component that decides what runs next. This guard
+# is the first thing that REFUSES a turn whose recorded phase has no prerequisite behind it.
+# Every case below drives the real process boundary stop.sh consumes -- `node
+# gate-phase-entry.mjs --root <project>` -- and asserts on the decision and the reason string.
+# Nothing here asserts a private helper, a call order, or the internal shape of the table.
+#
+# TWO THINGS THAT LOOK LIKE MISTAKES AND ARE NOT.
+#   1. AC15(b) COMPUTES its `updated_at` at test time and AC15(c) uses a captured record
+#      exactly as captured (2026-08-04, permanently stale). The same field is pinned in
+#      opposite directions on purpose: hardcode (b) and the criterion rots into a staleness
+#      test; refresh (c) and the staleness check silently stops testing anything.
+#   2. AC12/AC13/AC14 assert on the DECISION STRING and never on an exit code. `granted` and
+#      `not-applicable` both exit 0, so an exit-code assertion for those criteria would be
+#      asserting something other than what it claims. The spec's own falsifiability pass names
+#      this as the ONE mutation expected to survive.
+#
+# Fixture roots are new_tmpdir()s, registered and trap-removed by harness.sh. None is ever
+# committed under .pipeline/, because AC19 and AC24 walk `git ls-files '.pipeline/*/status.json'`
+# and a committed fixture would join their own population.
+
+. "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
+require_node
+
+GUARD="$SCRIPTS_DIR/gate-phase-entry.mjs"
+REPO_ROOT="$(git -C "$PLUGIN_ROOT" rev-parse --show-toplevel 2>/dev/null || printf '')"
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+# iso_hours_ago <hours> -> an ISO timestamp COMPUTED NOW. Never hardcode a date here.
+iso_hours_ago() { node -e 'process.stdout.write(new Date(Date.now()-Number(process.argv[1])*3600e3).toISOString())' "$1"; }
+
+FRESH_ISO="$(iso_hours_ago 1)"     # in flight
+STALE_ISO="$(iso_hours_ago 25)"    # past R6's 24h ceiling
+
+# new_case <issue-dir-name> <status-json> -> CASE_ROOT, CASE_DIR
+new_case() {
+  new_tmpdir || exit 90
+  CASE_ROOT="$NEW_TMPDIR"
+  CASE_DIR="$CASE_ROOT/.pipeline/$1"
+  mkdir -p "$CASE_DIR"
+  printf '%s' "$2" > "$CASE_DIR/status.json"
+}
+
+# mk_status <phase> <tier> <events-json-array> [extra-top-level-json-with-leading-comma]
+mk_status() {
+  printf '{"issue_number":4242,"current_phase":"%s","risk_tier":%s,"updated_at":"%s","events":%s%s}' \
+    "$1" "$2" "${MK_UPDATED:-$FRESH_ISO}" "$3" "${4:-}"
+}
+
+# capture <src-status.json> <dest> <patch-json>   (a null value in the patch DELETES the key)
+capture() {
+  node -e '
+    const fs=require("fs");
+    const s=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));
+    const p=JSON.parse(process.argv[3]);
+    for (const k of Object.keys(p)) { if (p[k]===null) delete s[k]; else s[k]=p[k]; }
+    fs.writeFileSync(process.argv[2], JSON.stringify(s,null,2));
+  ' "$1" "$2" "$3"
+}
+
+# gate <root> -> GATE_RC, GATE_OUT, GATE_ERR, GATE_DEC, GATE_ISSUE
+# The guard prints ONE JSON line on a decision. `decision` and `issue_dir` are bounded values,
+# read with a bounded sed; `reason` is matched by substring so its wording stays Dev's.
+gate() {
+  local root="$1" errf="$1/.gate-stderr.txt"
+  GATE_OUT="$( cd "$root" && node "$GUARD" --root "$root" 2>"$errf" )"
+  GATE_RC=$?
+  GATE_ERR="$(cat "$errf" 2>/dev/null)"
+  GATE_DEC="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"decision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  [[ -n "$GATE_DEC" ]] || GATE_DEC="<no-decision-on-stdout>"
+  GATE_ISSUE="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"issue_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  [[ -n "$GATE_ISSUE" ]] || GATE_ISSUE="<no-issue-dir-on-stdout>"
+}
+
+NO_EVENTS='[]'
+SPEC_APPROVED='{"ba_approved_at":"2026-01-01T00:00:00Z"}'
+
+# The 15 guarded rows: <phase>|<tier fixture uses>|<prerequisite filename>|<artifact body>
+# `-` in the filename column is the ONE row with no prerequisite (0.5-map). See FINDING-2 in
+# tasks.json: AC1 says all 15 refuse, the prerequisite table says this row always grants. The
+# table wins, and the exception is asserted positively below rather than quietly dropped.
+GUARDED_ROWS=(
+  "0.5-map|architectural|-|-"
+  "1-ba|architectural|map.json|{}"
+  "2-constraints|standard|spec.json|$SPEC_APPROVED"
+  "2-review|architectural|spec.json|$SPEC_APPROVED"
+  "2.5-design|architectural|review.json|{}"
+  "3-impl|architectural|design.json|{}"
+  "4-review|architectural|impl-report.json|{}"
+  "5-archive|architectural|peer-review.json|{}"
+  "0.5-map-complete|architectural|map.json|{}"
+  "1-ba-complete|architectural|spec.json|{}"
+  "2-constraints-complete|standard|constraints.md|# constraints"
+  "2-review-complete|architectural|review.json|{}"
+  "2.5-design-complete|architectural|design.json|{}"
+  "3-impl-complete|architectural|impl-report.json|{}"
+  "4-review-complete|architectural|peer-review.json|{}"
+)
+
+# ---------------------------------------------------------------------------
+suite "AC1: every guarded row refuses an empty fixture, and says what is missing"
+# ---------------------------------------------------------------------------
+assert_eq "the table under test has 15 guarded rows (8 entry + 7 exit)" "${#GUARDED_ROWS[@]}" "15"
+
+AC1_REFUSING=0
+for row in "${GUARDED_ROWS[@]}"; do
+  IFS='|' read -r phase tier prereq _body <<< "$row"
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$NO_EVENTS")"
+  gate "$CASE_ROOT"
+  if [[ "$prereq" == "-" ]]; then
+    # The documented exception: the first guarded phase has no prerequisite to be absent.
+    assert_eq "AC1 exception: $phase has no prerequisite and is granted" "$GATE_DEC" "granted"
+    continue
+  fi
+  AC1_REFUSING=$((AC1_REFUSING + 1))
+  assert_eq "$phase ($tier) with no artifact and no events is REFUSED" "$GATE_DEC" "refused"
+  assert_eq "and the refusal exits 2" "$GATE_RC" "2"
+  assert_contains "and the reason names the phase ($phase)" "$GATE_OUT" "$phase"
+  assert_contains "and the reason names the missing prerequisite ($prereq)" "$GATE_OUT" "$prereq"
+  assert_contains "and the reason names the issue dir (4242)" "$GATE_OUT" "4242"
+done
+assert_eq "14 rows can refuse; the 15th is the no-prerequisite exception" "$AC1_REFUSING" "14"
+
+# ---------------------------------------------------------------------------
+suite "AC2: every guarded row grants once ITS OWN prerequisite artifact is present"
+# ---------------------------------------------------------------------------
+AC2_ROWS=0
+for row in "${GUARDED_ROWS[@]}"; do
+  IFS='|' read -r phase tier prereq body <<< "$row"
+  [[ "$prereq" == "-" ]] && continue
+  AC2_ROWS=$((AC2_ROWS + 1))
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$NO_EVENTS")"
+  printf '%s' "$body" > "$CASE_DIR/$prereq"
+  gate "$CASE_ROOT"
+  assert_eq "$phase ($tier) with $prereq present is GRANTED" "$GATE_DEC" "granted"
+  assert_eq "and it exits 0" "$GATE_RC" "0"
+done
+assert_eq "each row exercised its OWN filename, not one shared one" "$AC2_ROWS" "14"
+
+# ---------------------------------------------------------------------------
+suite "AC3: the two-source rule -- a committed events[] grants what a gitignored artifact cannot"
+# ---------------------------------------------------------------------------
+# CAPTURED from the live record, not hand-written: every per-issue artifact except status.json
+# is gitignored, so a resumed run in a fresh checkout has ONLY the committed events[]. The
+# capture keeps issue 17's real suffixed labels (1-ba-rework, 2-review-r2, 3a-qa-tests, 3b-dev).
+REC17="$REPO_ROOT/.pipeline/17/status.json"
+assert_eq "the captured record exists (a missing capture must fail, not skip)" \
+  "$([[ -f "$REC17" ]] && echo present || echo "MISSING: $REC17")" "present"
+# Presence, not an occurrence count: the label appears in events[] AND in flags[], and a count
+# assertion here would be red for a reason that has nothing to do with the criterion.
+assert_eq "and it still carries the suffixed 3b-dev label this criterion rests on" \
+  "$(node -e 'const s=require(process.argv[1]);process.stdout.write((s.events||[]).some(e=>e.phase==="3b-dev")?"present":"MISSING")' "$REC17")" \
+  "present"
+
+new_case 17 '{}'
+# updated_at MUST be rewritten: the record is 2026-08-19T04:15Z and would fall outside R6's
+# in-flight window, so a stale capture would pass this criterion while proving nothing.
+capture "$REC17" "$CASE_DIR/status.json" "{\"updated_at\":\"$FRESH_ISO\"}"
+gate "$CASE_ROOT"
+assert_eq "issue 17 at 3-impl-complete, no impl-report.json on disk, is GRANTED by its 3b-dev event" \
+  "$GATE_DEC" "granted"
+
+# ---------------------------------------------------------------------------
+suite "AC4: event labels resolve through the shared resolver and compare by SET MEMBERSHIP"
+# ---------------------------------------------------------------------------
+ac4() {  # ac4 <event-label> <expected-decision>
+  new_case 4242 "$(mk_status "4-review" '"architectural"' "[{\"phase\":\"$1\",\"verdict\":\"complete\",\"at\":\"$FRESH_ISO\"}]")"
+  gate "$CASE_ROOT"
+  assert_eq "events[] label '$1' against the 4-review row {3,3b} -> $2" "$GATE_DEC" "$2"
+}
+ac4 "3b-dev" granted     # suffixed: a shape regex reads this as nothing (phaseKey's own docstring)
+ac4 "3-impl" granted     # bare token
+ac4 "9-nope" refused     # not in KNOWN_PHASES -> phaseKey returns null -> satisfies nothing
+
+# ---------------------------------------------------------------------------
+suite "AC5: NEGATIVE -- 2.5-design does not self-grant, and its SKIPPED note does not leak"
+# ---------------------------------------------------------------------------
+# Under a prefix implementation '2.5'.startsWith('2') is TRUE, so the record cited as the
+# escape hatch's own precedent would self-grant the Phase 2 review gate it skipped. The
+# 2.5-design row's satisfying set is {2}, so its own token is NOT a member. Two fixtures,
+# because the plain-satisfaction half and the hatch half fail independently.
+assert_eq "the capture still carries the SKIPPED 2.5-design entry this criterion rests on" \
+  "$(grep -c '"SKIPPED"' "$REC17" 2>/dev/null | tr -d ' ')" "1"
+
+new_case 17 '{}'
+capture "$REC17" "$CASE_DIR/status.json" "{\"current_phase\":\"2.5-design\",\"updated_at\":\"$FRESH_ISO\"}"
+gate "$CASE_ROOT"
+assert_eq "the SKIPPED 2.5-design entry does NOT fire the hatch for the 2.5-design row" "$GATE_DEC" "refused"
+assert_contains "and the refusal names the review.json it is still missing" "$GATE_OUT" "review.json"
+
+new_case 4242 "$(mk_status "2.5-design" '"architectural"' "[{\"phase\":\"2.5-design\",\"verdict\":\"complete\",\"at\":\"$FRESH_ISO\"}]")"
+gate "$CASE_ROOT"
+assert_eq "and a plain 2.5-design event does not satisfy the 2.5-design row either" "$GATE_DEC" "refused"
+
+# ---------------------------------------------------------------------------
+suite "AC6: NEGATIVE -- QA authored the contract, Dev never ran, so the run is not panel-ready"
+# ---------------------------------------------------------------------------
+# The generic repair for AC4 (map every 3x -> 3) opens this by construction. What must break
+# is 'a run where Dev never ran is not panel-ready', not 'the string 3a is absent from a list'.
+# TWO cells: 4-review and 3-impl-complete are separate rows that share the set {3,3b}, and
+# asserting one leaves the other's set unmutated.
+QA_ONLY='[{"phase":"3a-qa-tests","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
+for p in "4-review" "3-impl-complete"; do
+  new_case 4242 "$(mk_status "$p" '"architectural"' "$QA_ONLY")"
+  gate "$CASE_ROOT"
+  assert_eq "3a-qa-tests alone does NOT satisfy the $p row (its set excludes 3a)" "$GATE_DEC" "refused"
+  assert_contains "and the refusal names impl-report.json" "$GATE_OUT" "impl-report.json"
+done
+
+# ---------------------------------------------------------------------------
+suite "AC7/AC8: the recorded-deviation hatch, and the written reason it costs"
+# ---------------------------------------------------------------------------
+new_case 4242 "$(mk_status "3-impl" '"architectural"' \
+  '[{"phase":"2.5-design","verdict":"SKIPPED","at":"2026-01-01T00:00:00Z","note":"design space closed; owner informed"}]')"
+gate "$CASE_ROOT"
+assert_eq "AC7: a SKIPPED 2.5-design with a written reason clears entry to 3-impl" "$GATE_DEC" "granted"
+
+# Three cells. A single 'note absent' fixture passes under a truthiness check that a
+# whitespace-only string defeats, which is the whole point of the trim.
+ac8() {  # ac8 <label> <note-json-fragment-or-empty>
+  new_case 4242 "$(mk_status "3-impl" '"architectural"' \
+    "[{\"phase\":\"2.5-design\",\"verdict\":\"SKIPPED\",\"at\":\"2026-01-01T00:00:00Z\"$2}]")"
+  gate "$CASE_ROOT"
+  assert_eq "AC8: a skip with $1 is REFUSED" "$GATE_DEC" "refused"
+}
+ac8 "no note at all"        ""
+ac8 "an empty note"         ',"note":""'
+ac8 "a whitespace-only note" ',"note":"   "'
+
+# ---------------------------------------------------------------------------
+suite "AC9: path (b) needs a token, never a verdict"
+# ---------------------------------------------------------------------------
+# events[].verdict is OPTIONAL in status.schema.json and a committed record carries six
+# verdict-less events, so any verdict-keyed rule rejects a schema-valid record.
+REC_STC="$REPO_ROOT/.pipeline/exp-script-test-coverage/status.json"
+assert_eq "the verdict-less capture exists" \
+  "$([[ -f "$REC_STC" ]] && echo present || echo "MISSING: $REC_STC")" "present"
+assert_eq "and its 4-review event still carries no verdict key" \
+  "$(node -e 'const s=require(process.argv[1]);const e=(s.events||[]).find(x=>x.phase==="4-review");process.stdout.write(e&&!("verdict" in e)?"verdictless":"CHANGED")' "$REC_STC")" \
+  "verdictless"
+
+new_case exp-script-test-coverage '{}'
+capture "$REC_STC" "$CASE_DIR/status.json" "{\"updated_at\":\"$FRESH_ISO\",\"final_verdict\":null}"
+gate "$CASE_ROOT"
+assert_eq "a verdict-LESS 4-review event satisfies the 4-review-complete row" "$GATE_DEC" "granted"
+
+# The other direction: a REJECTING verdict must also satisfy. The artifact a path-(b) event
+# stands in for exists whatever the verdict says, and a review that demanded changes still ran.
+new_case 4242 "$(mk_status "2.5-design" '"architectural"' \
+  '[{"phase":"2-review","verdict":"REQUEST_CHANGES","at":"2026-01-01T00:00:00Z"}]')"
+gate "$CASE_ROOT"
+assert_eq "a REQUEST_CHANGES 2-review event still satisfies the 2.5-design row" "$GATE_DEC" "granted"
+
+# ---------------------------------------------------------------------------
+suite "AC10: 3-impl over the FULL tier x presence cross product (6 cells, own filename each)"
+# ---------------------------------------------------------------------------
+# A representative fixture is insufficient: this is a compound predicate, and every fixture
+# sitting in one cell of the conjunction leaves the other branch unrun.
+ac10() {  # ac10 <tier> <prereq-filename> <body> <present|absent> <expected>
+  new_case 4242 "$(mk_status "3-impl" "\"$1\"" "$NO_EVENTS")"
+  [[ "$4" == "present" ]] && printf '%s' "$3" > "$CASE_DIR/$2"
+  gate "$CASE_ROOT"
+  assert_eq "3-impl at $1 with $2 $4 -> $5" "$GATE_DEC" "$5"
+  [[ "$5" == "refused" ]] && assert_contains "  and it names $2, not another tier's file" "$GATE_OUT" "$2"
+  return 0
+}
+ac10 trivial       spec.json      '{}'             present granted
+ac10 trivial       spec.json      '{}'             absent  refused
+ac10 standard      constraints.md '# real content' present granted
+ac10 standard      constraints.md '# real content' absent  refused
+ac10 architectural design.json    '{}'             present granted
+ac10 architectural design.json    '{}'             absent  refused
+
+# ---------------------------------------------------------------------------
+suite "R3 kind: content-conditioned rows test CONTENT on path (a), not mere presence"
+# ---------------------------------------------------------------------------
+# NOT AN AC OF ITS OWN, and named here because the spec's own criteria do not cover it: three
+# rows are marked `kind: content-conditioned` and R3 states outright that path (a) tests file
+# CONTENT while path (b) tests only that the phase was DISPATCHED. Without these, an
+# existsSync-only implementation satisfies every criterion in the spec while the `kind` column
+# means nothing, and the guard's strength silently depends on which machine it runs on.
+new_case 4242 "$(mk_status "2-review" '"architectural"' "$NO_EVENTS")"
+printf '{"issue_number":4242}' > "$CASE_DIR/spec.json"        # present, but never BA-approved
+gate "$CASE_ROOT"
+assert_eq "2-review: a spec.json with no ba_approved_at does NOT satisfy the row" "$GATE_DEC" "refused"
+
+new_case 4242 "$(mk_status "2-constraints" '"standard"' "$NO_EVENTS")"
+printf '{"issue_number":4242}' > "$CASE_DIR/spec.json"
+gate "$CASE_ROOT"
+assert_eq "2-constraints: same, at the standard tier" "$GATE_DEC" "refused"
+
+new_case 4242 "$(mk_status "3-impl" '"standard"' "$NO_EVENTS")"
+printf '' > "$CASE_DIR/constraints.md"                        # present, and empty
+gate "$CASE_ROOT"
+assert_eq "3-impl at standard: an EMPTY constraints.md does not satisfy the row" "$GATE_DEC" "refused"
+
+# The stated consequence, asserted rather than left as prose: on a fresh checkout the SAME run
+# is granted through path (b), because an event attests DISPATCH and not APPROVAL. This is the
+# weakness R3 names and declines to defend against; a test that pins it is what stops it being
+# quietly "fixed" into a rejecting-verdict blocklist over free text.
+new_case 4242 "$(mk_status "2-review" '"architectural"' \
+  '[{"phase":"1-ba","verdict":"REWORK_REQUIRED","at":"2026-01-01T00:00:00Z"}]')"
+gate "$CASE_ROOT"
+assert_eq "with no spec.json at all, a 1-ba event grants entry to 2-review (path (b) is weaker)" \
+  "$GATE_DEC" "granted"
+
+# ---------------------------------------------------------------------------
+suite "AC11: an unusable risk_tier resolves to the STRICTEST row, never the loosest"
+# ---------------------------------------------------------------------------
+# The discriminating fixture: spec.json present (the trivial row's prerequisite), design.json
+# absent (the architectural row's). A trivial default grants; the strictest default refuses.
+ac11() {  # ac11 <label> <risk_tier-json-or-omit>
+  local body
+  if [[ "$2" == "omit" ]]; then
+    body="$(printf '{"issue_number":4242,"current_phase":"3-impl","updated_at":"%s","events":[]}' "$FRESH_ISO")"
+  else
+    body="$(mk_status "3-impl" "$2" "$NO_EVENTS")"
+  fi
+  new_case 4242 "$body"
+  printf '{}' > "$CASE_DIR/spec.json"
+  gate "$CASE_ROOT"
+  assert_eq "AC11: risk_tier $1 is evaluated at the architectural row" "$GATE_DEC" "refused"
+  assert_contains "  and it names design.json, not spec.json" "$GATE_OUT" "design.json"
+}
+ac11 "absent"           omit
+ac11 "null"             null
+ac11 "an unknown string" '"deep"'
+
+# ---------------------------------------------------------------------------
+suite "AC12: terminal states decline to judge (asserted on the DECISION, never the exit code)"
+# ---------------------------------------------------------------------------
+for p in "5-archived" "halted-error" "3-impl-error"; do
+  new_case 4242 "$(mk_status "$p" '"architectural"' "$NO_EVENTS")"
+  gate "$CASE_ROOT"
+  assert_eq "$p -> not-applicable" "$GATE_DEC" "not-applicable"
+  assert_eq "  and stop.sh's side of it exits 0" "$GATE_RC" "0"
+done
+# A DIFFERENT predicate: a non-terminal phase that would otherwise refuse, carrying completed_at.
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS" ',"completed_at":"2026-01-02T00:00:00Z"')"
+gate "$CASE_ROOT"
+assert_eq "a non-terminal phase carrying completed_at -> not-applicable" "$GATE_DEC" "not-applicable"
+
+# ---------------------------------------------------------------------------
+suite "AC13: each of the 9 UNGUARDED literals lets a halted run end its turn"
+# ---------------------------------------------------------------------------
+UNGUARDED_LITERALS=(
+  "1-ba-open-questions" "1-ba-rework-required" "2.5-design-owner-decision"
+  "3-impl-frontend-gate-failed" "3-impl-gate-failed" "3-impl-live-verify-unverified"
+  "3-impl-tripwire" "3-impl-tripwire-indeterminate" "4-veto-rework-required"
+)
+assert_eq "the UNGUARDED set under test has 9 literals" "${#UNGUARDED_LITERALS[@]}" "9"
+for p in "${UNGUARDED_LITERALS[@]}"; do
+  new_case 4242 "$(mk_status "$p" '"architectural"' "$NO_EVENTS")"
+  gate "$CASE_ROOT"
+  assert_eq "$p -> not-applicable" "$GATE_DEC" "not-applicable"
+done
+
+# ---------------------------------------------------------------------------
+suite "AC14: fail-OPEN on vocabulary, fail-CLOSED on sequence"
+# ---------------------------------------------------------------------------
+# The live case, not a hypothetical: status.schema.json:13's own description blesses
+# 3-scope-drift-adjudication, and pipeline.md never writes it. Under deny-by-default that
+# record would refuse every stop in the project that holds it.
+for p in "3-scope-drift-adjudication" "3-something-nobody-writes"; do
+  new_case 4242 "$(mk_status "$p" '"architectural"' "$NO_EVENTS")"
+  gate "$CASE_ROOT"
+  assert_eq "unrecognised phase $p -> not-applicable, NOT refused" "$GATE_DEC" "not-applicable"
+done
+
+# ---------------------------------------------------------------------------
+suite "AC15: the in-flight predicate (the Stop hook is project-scoped, not run-scoped)"
+# ---------------------------------------------------------------------------
+# Without this, the guard binds to whatever status.json has the newest mtime and evaluates it
+# at EVERY turn end in the whole project, so an abandoned run at a guarded phase blocks every
+# turn permanently, escapable only by hand-editing a committed record.
+
+MK_UPDATED="$STALE_ISO"
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+MK_UPDATED=""
+gate "$CASE_ROOT"
+assert_eq "(a) 25h old, no final verdict -> not-applicable even at a guarded phase" "$GATE_DEC" "not-applicable"
+
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"   # FRESH_ISO, computed above
+gate "$CASE_ROOT"
+assert_eq "(b) 1h old (COMPUTED at test time) at the same phase -> refused" "$GATE_DEC" "refused"
+
+# (c) the capture AS CAPTURED. This assertion is the tripwire on the capture itself: if anyone
+# refreshes exp-script-test-coverage's updated_at, this fails loudly instead of the staleness
+# check silently retiring.
+assert_eq "the capture is still permanently stale (>24h), which is what (c) tests" \
+  "$(node -e 'const s=require(process.argv[1]);process.stdout.write((Date.now()-new Date(s.updated_at).getTime())>24*3600e3?"stale":"REFRESHED")' "$REC_STC")" \
+  "stale"
+new_case exp-script-test-coverage '{}'
+capture "$REC_STC" "$CASE_DIR/status.json" '{}'
+gate "$CASE_ROOT"
+assert_eq "(c) the capture as captured -> not-applicable" "$GATE_DEC" "not-applicable"
+
+# (c') isolates the ceiling. As captured the record is not-applicable for TWO reasons at once
+# (stale AND final_verdict), so (c) alone cannot tell which mechanism fired. Same capture,
+# final_verdict deleted, updated_at untouched.
+new_case exp-script-test-coverage '{}'
+capture "$REC_STC" "$CASE_DIR/status.json" '{"final_verdict":null}'
+gate "$CASE_ROOT"
+assert_eq "(c') stale ALONE, with no final verdict, is still not-applicable" "$GATE_DEC" "not-applicable"
+
+# (d) a final verdict, at a phase that would otherwise refuse, regardless of age.
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS" ',"final_verdict":"APPROVE"')"
+gate "$CASE_ROOT"
+assert_eq "(d) a fresh record carrying a final verdict -> not-applicable" "$GATE_DEC" "not-applicable"
+
+# ---------------------------------------------------------------------------
+suite "AC16: the active-issue SIGNAL must not NARROW the guard's subject"
+# ---------------------------------------------------------------------------
+# Q3 rejected a config knob and an env var, and R6 reintroduced one by inheritance: pointing
+# CLAUDE_PIPELINE_ACTIVE_ISSUE at a satisfied dir yields exit 0 for every turn with no trace
+# in the archived record. Resolve BOTH dirs; refuse if EITHER refuses.
+
+# two_dirs <refusing-mtime> <granting-mtime> -> CASE_ROOT with 5150 (refuses) and 6160 (grants)
+two_dirs() {
+  new_tmpdir || exit 90
+  CASE_ROOT="$NEW_TMPDIR"
+  mkdir -p "$CASE_ROOT/.pipeline/5150" "$CASE_ROOT/.pipeline/6160"
+  printf '%s' "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")" > "$CASE_ROOT/.pipeline/5150/status.json"
+  printf '%s' "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")" > "$CASE_ROOT/.pipeline/6160/status.json"
+  printf '{}' > "$CASE_ROOT/.pipeline/6160/design.json"
+  touch -t "$1" "$CASE_ROOT/.pipeline/5150/status.json"
+  touch -t "$2" "$CASE_ROOT/.pipeline/6160/status.json"
+}
+
+two_dirs 202601010101 202601010102        # granting dir is newest
+( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; gate "$CASE_ROOT"
+  assert_eq "(a) signal unset: the mtime-derived (granting) dir is the one evaluated" "$GATE_DEC" "granted"
+  assert_contains "  and the decision names that dir" "$GATE_ISSUE" "6160" )
+
+two_dirs 202601010102 202601010101        # refusing dir is newest; signal points at the granting one
+GATE_OUT="$( cd "$CASE_ROOT" && CLAUDE_PIPELINE_ACTIVE_ISSUE=6160 node "$GUARD" --root "$CASE_ROOT" 2>/dev/null )"
+GATE_RC=$?
+GATE_DEC="$(printf '%s' "$GATE_OUT" | sed -n 's/.*"decision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+assert_eq "(b) setting the signal to a satisfied dir does NOT disarm the guard" "${GATE_DEC:-<none>}" "refused"
+assert_contains "  and the refusal names WHICH dir refused" "$GATE_OUT" "5150"
+
+two_dirs 202601010103 202601010103        # the measured tie: three records in this tree share one mtime
+( unset CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE
+  gate "$CASE_ROOT"; FIRST_DEC="$GATE_DEC"; FIRST_DIR="$GATE_ISSUE"
+  gate "$CASE_ROOT"
+  assert_eq "(c) an mtime tie is DETERMINISTIC across runs (decision)" "$GATE_DEC" "$FIRST_DEC"
+  assert_eq "  and deterministic in the dir it names" "$GATE_ISSUE" "$FIRST_DIR"
+  assert_eq "  and it names one of the two dirs rather than nothing" \
+    "$([[ "$FIRST_DIR" == "5150" || "$FIRST_DIR" == "6160" ]] && echo named || echo "UNNAMED: $FIRST_DIR")" "named" )
+
+# ---------------------------------------------------------------------------
+suite "AC17: exp-<slug> runs are GUARDED, not exempt"
+# ---------------------------------------------------------------------------
+# The recorded failure this mirrors: an experiment run had NO artifact validation at all
+# because the dir pattern did not match, so both halves of a gate went inert on exactly the
+# runs nobody watches.
+new_case exp-guardtest "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+gate "$CASE_ROOT"
+assert_eq "an in-flight exp- run at a guarded phase with no prerequisite is REFUSED" "$GATE_DEC" "refused"
+assert_contains "and the refusal names the exp- dir" "$GATE_OUT" "exp-guardtest"
+
+# ---------------------------------------------------------------------------
+suite "AC20: prerequisites are evaluated for the phase NAMED by current_phase"
+# ---------------------------------------------------------------------------
+# pipeline.md:71 wins over :22. Under the successor reading, a run interrupted mid-Phase-3
+# resumes at Phase 4 having never finished Phase 3 -- the exact failure this issue exists to
+# stop. Here: at 1-ba with map.json present, entry semantics grants; successor semantics would
+# look for Phase 2's prerequisite and refuse.
+new_case 4242 "$(mk_status "1-ba" '"architectural"' "$NO_EVENTS")"
+printf '{}' > "$CASE_DIR/map.json"
+gate "$CASE_ROOT"
+assert_eq "1-ba with map.json present is granted (entry semantics, not successor)" "$GATE_DEC" "granted"
+
+# ---------------------------------------------------------------------------
+suite "AC29: a /phase re-run that did real work can clear the guard"
+# ---------------------------------------------------------------------------
+# phaseKey('phase-rerun') is null today, so the bare label can never clear the guard. A
+# token-prefixed label resolves through the shared resolver with no new vocabulary.
+new_case 4242 "$(mk_status "2-review" '"architectural"' \
+  '[{"phase":"1-ba-rerun","verdict":"complete","at":"2026-01-01T00:00:00Z"}]')"
+gate "$CASE_ROOT"
+assert_eq "a 1-ba-rerun event resolves to token 1 and satisfies the 2-review row" "$GATE_DEC" "granted"
+
+new_case 4242 "$(mk_status "2-review" '"architectural"' \
+  '[{"phase":"phase-rerun","verdict":"complete","at":"2026-01-01T00:00:00Z"}]')"
+gate "$CASE_ROOT"
+assert_eq "the bare 'phase-rerun' label still resolves to nothing and satisfies nothing" "$GATE_DEC" "refused"
+
+# ---------------------------------------------------------------------------
+suite "AC30: the checkpoint-first window, where the guard is CORRECT and the convention is the fix"
+# ---------------------------------------------------------------------------
+# 'Checkpoint first, then append the exit event' is compliant with pipeline.md as written and
+# leaves a window in which the record says 'entering 3-impl' with neither design.json (absent
+# in a fresh checkout) nor a closing 2.5 event. The guard's answer in that window is right:
+# the record genuinely does not show the phase closed. R14's one-write convention is the fix.
+new_case 4242 "$(mk_status "3-impl" '"architectural"' \
+  '[{"phase":"2-review","verdict":"complete","at":"2026-01-01T00:00:00Z"}]')"
+gate "$CASE_ROOT"
+assert_eq "checkpointed into 3-impl with no design.json and no 2.5 event -> refused" "$GATE_DEC" "refused"
+assert_contains "and the reason names design.json" "$GATE_OUT" "design.json"
+
+# ---------------------------------------------------------------------------
+suite "AC25: no resolvable active issue dir is SILENT, not a refusal"
+# ---------------------------------------------------------------------------
+new_tmpdir || exit 90
+gate "$NEW_TMPDIR"
+assert_eq "no .pipeline/ at all -> exit 0" "$GATE_RC" "0"
+assert_eq "  and no stdout" "$GATE_OUT" ""
+assert_eq "  and no stderr" "$GATE_ERR" ""
+
+new_tmpdir || exit 90
+mkdir -p "$NEW_TMPDIR/.pipeline/schemas" "$NEW_TMPDIR/.pipeline/_archived"
+printf '%s' "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")" > "$NEW_TMPDIR/.pipeline/schemas/status.json"
+gate "$NEW_TMPDIR"
+assert_eq "only non-issue-shaped siblings -> exit 0" "$GATE_RC" "0"
+assert_eq "  and no stdout" "$GATE_OUT" ""
+assert_eq "  and no stderr" "$GATE_ERR" ""
+
+# ---------------------------------------------------------------------------
+suite "AC19: a SECOND ground truth, derived from the committed RECORDS rather than from prose"
+# ---------------------------------------------------------------------------
+# Prose alone is provably insufficient: status.schema.json:13 blesses two phases pipeline.md
+# never writes, which is live evidence that a vocabulary in this repo has ALREADY rotted in the
+# one file a prose-derived test does not read.
+CORPUS="$(git -C "$REPO_ROOT" ls-files '.pipeline/*/status.json' 2>/dev/null)"
+CORPUS_N="$(printf '%s\n' "$CORPUS" | grep -c . | tr -d ' ')"
+assert_eq "VACUITY CONTROL: the corpus walk found at least 4 committed records" \
+  "$([[ "${CORPUS_N:-0}" -ge 4 ]] && echo enough || echo "ONLY $CORPUS_N")" "enough"
+
+AC19_REPORT="$(cd "$REPO_ROOT" && node --input-type=module -e '
+  import { readFileSync } from "node:fs";
+  const mod = await import(process.argv[1]);
+  const known = new Set([...mod.ENTRY, ...mod.EXIT, ...mod.UNGUARDED, ...mod.TERMINAL]);
+  const files = process.argv.slice(2);
+  let read = 0; const unreadable = []; const strays = [];
+  for (const f of files) {
+    let s;
+    try { s = JSON.parse(readFileSync(f, "utf8")); }
+    catch (e) { unreadable.push(f + " (" + e.message.slice(0, 40) + ")"); continue; }
+    read++;
+    const p = s.current_phase;
+    if (typeof p !== "string") { unreadable.push(f + " (no current_phase)"); continue; }
+    if (!known.has(p)) strays.push(f + " -> " + p);
+  }
+  // ACCOUNTED FOR, not skipped: a walk that continues past what it could not read reports a
+  // zero it did not earn.
+  process.stdout.write(JSON.stringify({ total: files.length, read, unreadable, strays }));
+' "$GUARD" $CORPUS 2>/dev/null)"
+AC19_STRAYS="$(printf '%s' "$AC19_REPORT" | sed -n 's/.*"strays":\[\(.*\)\]}/\1/p')"
+AC19_UNREAD="$(printf '%s' "$AC19_REPORT" | sed -n 's/.*"unreadable":\[\([^]]*\)\].*/\1/p')"
+assert_eq "every committed record's current_phase is a member of one of the four sets" \
+  "${AC19_STRAYS:-<no-report>}" ""
+assert_eq "and the walk ACCOUNTS for every record rather than continuing past it" \
+  "${AC19_UNREAD:-<no-report>}" ""
+
+# ---------------------------------------------------------------------------
+suite "AC24: no committed record is REFUSED (a zero, whose non-zero control is AC1's 14)"
+# ---------------------------------------------------------------------------
+# Each record is evaluated in its OWN temp project with its dir name preserved and updated_at
+# rewritten to test time, so R6's staleness cannot mask the table. Artifacts are NOT copied:
+# only status.json is tracked, so this is the fresh-checkout case the two-source rule exists for.
+AC24_REFUSED=""
+AC24_EVALUATED=0
+while IFS= read -r rec; do
+  [[ -n "$rec" ]] || continue
+  name="$(basename "$(dirname "$rec")")"
+  new_case "$name" '{}'
+  if ! capture "$REPO_ROOT/$rec" "$CASE_DIR/status.json" "{\"updated_at\":\"$FRESH_ISO\"}" 2>/dev/null; then
+    AC24_REFUSED="$AC24_REFUSED $name(UNREADABLE)"      # accounted for, never skipped
+    continue
+  fi
+  AC24_EVALUATED=$((AC24_EVALUATED + 1))
+  gate "$CASE_ROOT"
+  # A zero must be earned. `refused` is the failure this criterion names, but ANYTHING that is
+  # not one of the two acceptable decisions is also recorded: without this, a guard that emits
+  # no decision at all (because it does not exist yet, or threw) would satisfy "no record was
+  # refused" while having evaluated nothing. That is the vacuous form of this exact assertion.
+  case "$GATE_DEC" in
+    granted|not-applicable) ;;
+    refused)                AC24_REFUSED="$AC24_REFUSED $name(refused)" ;;
+    *)                      AC24_REFUSED="$AC24_REFUSED $name(NO-DECISION:$GATE_DEC)" ;;
+  esac
+done <<< "$CORPUS"
+assert_eq "VACUITY CONTROL: at least 4 committed records were actually evaluated" \
+  "$([[ "$AC24_EVALUATED" -ge 4 ]] && echo enough || echo "ONLY $AC24_EVALUATED")" "enough"
+assert_eq "no committed record is refused by the table" "${AC24_REFUSED# }" ""
+
+finish

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -333,25 +333,68 @@ suite "R3 kind: content-conditioned rows test CONTENT on path (a), not mere pres
 # CONTENT while path (b) tests only that the phase was DISPATCHED. Without these, an
 # existsSync-only implementation satisfies every criterion in the spec while the `kind` column
 # means nothing, and the guard's strength silently depends on which machine it runs on.
-new_case 4242 "$(mk_status "2-review" '"architectural"' "$NO_EVENTS")"
-printf '{"issue_number":4242}' > "$CASE_DIR/spec.json"        # present, but never BA-approved
-gate "$CASE_ROOT"
-assert_eq "2-review: a spec.json with no ba_approved_at does NOT satisfy the row" "$GATE_DEC" "refused"
+#
+# A FIXTURE MATRIX, NOT A REPRESENTATIVE FIXTURE, and that distinction is what this block was
+# missing. `prerequisiteSatisfied` is a COMPOUND predicate -- the artifact decides the row BY
+# ITSELF when it is present, and events[] are consulted only when it is absent -- and every cell
+# here used to build the artifact-present half with NO_EVENTS. So every fixture sat in one cell
+# of the conjunction, and the branch that makes the whole `content` column dead was never run:
+# `if (existsSync(p)) return contentSatisfies(p,row)` could be rewritten to
+# `if (existsSync(p) && contentSatisfies(p,row)) return true` -- falling through to the events
+# path on a content FAILURE -- with zero failures across all three suites. That rewrite is the
+# implementation's own docstring inverted: a dispatch event for the phase is always present by
+# the time its artifact is, so an unapproved spec.json would be waved through by the very event
+# that recorded the BA dispatch.
+#
+# The cross product is therefore {absent, present-and-failing, present-and-satisfying} x {no
+# events, a SATISFYING event}. Cell (absent, no events) is AC1 and is not repeated. The
+# artifact-absent-with-event cell is the non-zero control that makes the rest mean anything: it
+# is what proves the event in cells 1 and 2 really does satisfy the row, so a refusal alongside
+# it is the ARTIFACT overriding the event rather than an inert fixture.
+r3_row() {  # r3_row <phase> <tier> <file> <failing-body> <satisfying-body> <satisfying-event-json>
+  local phase="$1" tier="$2" file="$3" bad="$4" good="$5" ev="$6"
 
-new_case 4242 "$(mk_status "2-constraints" '"standard"' "$NO_EVENTS")"
-printf '{"issue_number":4242}' > "$CASE_DIR/spec.json"
-gate "$CASE_ROOT"
-assert_eq "2-constraints: same, at the standard tier" "$GATE_DEC" "refused"
+  # 1. THE MISSING LEG: present-and-failing, WITH an event that would satisfy the row on its own.
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$ev")"
+  printf '%s' "$bad" > "$CASE_DIR/$file"
+  gate "$CASE_ROOT"
+  assert_eq "$phase ($tier): a failing $file is NOT rescued by a satisfying events[] entry" \
+    "$GATE_DEC" "refused"
+  assert_eq "  and the refusal exits 2" "$GATE_RC" "2"
 
-new_case 4242 "$(mk_status "3-impl" '"standard"' "$NO_EVENTS")"
-printf '' > "$CASE_DIR/constraints.md"                        # present, and empty
-gate "$CASE_ROOT"
-assert_eq "3-impl at standard: an EMPTY constraints.md does not satisfy the row" "$GATE_DEC" "refused"
+  # 2. Same fixture, same event, CONTENT REPAIRED. The twin: without it, cell 1's refusal could
+  #    be about the phase, the tier or the event rather than about the content.
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$ev")"
+  printf '%s' "$good" > "$CASE_DIR/$file"
+  gate "$CASE_ROOT"
+  assert_eq "  CONTROL: the same fixture with a SATISFYING $file is granted" "$GATE_DEC" "granted"
+
+  # 3. The event alone, artifact absent: path (b) is weaker on purpose, and this is the cell that
+  #    proves the event is live. If this ever refuses, cell 1 stops being about priority at all.
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$ev")"
+  gate "$CASE_ROOT"
+  assert_eq "  CONTROL: with no $file at all, that same event GRANTS (path (b) attests dispatch)" \
+    "$GATE_DEC" "granted"
+
+  # 4. Present-and-failing with NO events: the original cell, kept as a cell of the matrix.
+  new_case 4242 "$(mk_status "$phase" "\"$tier\"" "$NO_EVENTS")"
+  printf '%s' "$bad" > "$CASE_DIR/$file"
+  gate "$CASE_ROOT"
+  assert_eq "  and a failing $file with no events at all is refused too" "$GATE_DEC" "refused"
+}
+
+BA_EVENT='[{"phase":"1-ba","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
+P2_EVENT='[{"phase":"2-constraints","verdict":"complete","at":"2026-01-01T00:00:00Z"}]'
+
+r3_row 2-review     architectural spec.json      '{"issue_number":4242}' "$SPEC_APPROVED"  "$BA_EVENT"
+r3_row 2-constraints standard     spec.json      '{"issue_number":4242}' "$SPEC_APPROVED"  "$BA_EVENT"
+r3_row 3-impl       standard      constraints.md ''                      '# real content' "$P2_EVENT"
 
 # The stated consequence, asserted rather than left as prose: on a fresh checkout the SAME run
 # is granted through path (b), because an event attests DISPATCH and not APPROVAL. This is the
 # weakness R3 names and declines to defend against; a test that pins it is what stops it being
-# quietly "fixed" into a rejecting-verdict blocklist over free text.
+# quietly "fixed" into a rejecting-verdict blocklist over free text. A REJECTING verdict is used
+# here on purpose: cell 3 above already covers the ordinary case.
 new_case 4242 "$(mk_status "2-review" '"architectural"' \
   '[{"phase":"1-ba","verdict":"REWORK_REQUIRED","at":"2026-01-01T00:00:00Z"}]')"
 gate "$CASE_ROOT"

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -747,12 +747,26 @@ assert_eq "  CONTROL: a report missing the key reads as <no-field:strays>, never
   "$(AC19_REPORT='{"total":9,"read":9}' ac19_field strays)" "<no-field:strays>"
 assert_eq "  CONTROL: and an absent report still reads as <no-report>" \
   "$(AC19_REPORT='' ac19_field strays)" "<no-report>"
+ac19_scalar() {  # ac19_scalar <json-key> -> the number, or a sentinel
+  [[ -n "$AC19_REPORT" ]] || { printf '<no-report>'; return; }
+  case "$AC19_REPORT" in *"\"$1\":"*) ;; *) printf '<no-field:%s>' "$1"; return ;; esac
+  printf '%s' "$AC19_REPORT" | sed -n "s/.*\"$1\":\\([0-9]*\\).*/\\1/p"
+}
 AC19_STRAYS="$(ac19_field strays)"
 AC19_UNREAD="$(ac19_field unreadable)"
 assert_eq "every committed record's current_phase is a member of one of the four sets" \
   "$AC19_STRAYS" ""
 assert_eq "and the walk ACCOUNTS for every record rather than continuing past it" \
   "$AC19_UNREAD" ""
+# The `unreadable` zero above is EARNED here rather than assumed. Both `total` and `read` were
+# already computed and already carried in the report, and neither was asserted -- so an empty
+# `unreadable` list was equally consistent with a walk that read every record and with one that
+# read none. A POSITIVE assertion over the same population, against the count the shell derived
+# independently, turns that zero into a derived result. No temp tree, no planted record.
+assert_eq "the walk READ every record the corpus listed (which is what makes the zero above a result)" \
+  "$(ac19_scalar read)" "$CORPUS_N"
+assert_eq "and it was handed the whole corpus in the first place" \
+  "$(ac19_scalar total)" "$CORPUS_N"
 
 # ---------------------------------------------------------------------------
 suite "AC24: no committed record is REFUSED (a zero, whose non-zero control is AC1's 14)"

--- a/plugins/pipeline/tests/test-harness.sh
+++ b/plugins/pipeline/tests/test-harness.sh
@@ -152,6 +152,62 @@ assert_eq "no new script suite hand-rolls rm -rf" "${RM_VIOLATORS:-none}" "none"
 assert_eq "and the rm -rf check actually examined the script suites" \
   "$([[ "$RM_EXAMINED" -ge 8 ]] && echo ok || echo "only $RM_EXAMINED examined")" "ok"
 
+suite "harness: an UNCOUNTED assertion fails the suite"
+
+# The defect this guards, measured: seven assertions in test-gate-phase-entry.sh sat inside
+# `( unset ...; assert_eq ... )` subshells. Their increments died with the subshell and assert_*
+# returns 0 either way, so a FAIL among them printed and the suite still reported failed=0 and
+# exited 0. Two of the seven were the non-zero CONTROLs for the criterion above them.
+#
+# The child below is that exact shape, reduced: ONE assertion in the parent shell, ONE inside a
+# subshell. Every assertion in it PASSES, so nothing but the count guard can fail it -- which is
+# what makes this a test of the guard rather than of the assertion.
+cat > "$SCRATCH/child-subshell.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+assert_eq "counted normally" "a" "a"
+( assert_eq "evaluated where the counters do not survive" "b" "b" )
+finish
+CHILD
+run_child "$SCRATCH/child-subshell.sh"
+assert_eq "a suite with an uncounted assertion exits non-zero" "$RC" "1"
+# The discriminating assertion: the child's OWN tally says nothing is wrong. Without this, the
+# red above is satisfied by a child that simply had a failing assertion.
+assert_contains "  even though its own tally reports no failures" "$OUT" "passed=1 failed=0"
+assert_contains "the guard says how many ran versus how many counted" "$ERR" "2 assertion(s) ran but 1 were counted"
+assert_contains "  and names the assertion that could not fail the build" "$ERR" \
+  "evaluated where the counters do not survive"
+assert_contains "  and says why an uncounted assertion matters" "$ERR" "cannot fail the build"
+assert_not_contains "  and does not accuse the one that WAS counted" "$ERR" "counted normally"
+
+# NON-ZERO CONTROL, on the same child minus the parentheses. Without it, the red above could be
+# produced by a guard that fails every suite, and the 32 green suites in this directory would be
+# the thing disagreeing with it.
+cat > "$SCRATCH/child-nosubshell.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+assert_eq "counted normally" "a" "a"
+assert_eq "evaluated where the counters do not survive" "b" "b"
+finish
+CHILD
+run_child "$SCRATCH/child-nosubshell.sh"
+assert_eq "CONTROL: the identical assertions OUTSIDE the subshell exit 0" "$RC" "0"
+assert_contains "CONTROL: and both are counted" "$OUT" "passed=2 failed=0"
+assert_eq "CONTROL: and the guard stays silent" "$ERR" ""
+
+# A subshell around an assertion that FAILS is the case the seven actually threatened: the FAIL
+# is printed, the tally still says zero, and only the guard is left to notice.
+cat > "$SCRATCH/child-subshell-fail.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+( assert_eq "a real failure, thrown away" "actual" "expected" )
+finish
+CHILD
+run_child "$SCRATCH/child-subshell-fail.sh"
+assert_contains "a FAIL inside a subshell is still PRINTED" "$OUT" "FAIL  a real failure, thrown away"
+assert_contains "  and still uncounted by the tally" "$OUT" "passed=0 failed=0"
+assert_eq "  but the suite no longer exits 0" "$RC" "1"
+
 suite "harness: node is REQUIRED, never skipped (AC3)"
 
 # Build a PATH with the few externals harness.sh itself needs and, pointedly, no node. This is

--- a/plugins/pipeline/tests/test-harness.sh
+++ b/plugins/pipeline/tests/test-harness.sh
@@ -84,20 +84,28 @@ STUB
 chmod +x "$SCRATCH/stub-bin/mktemp"
 mkdir -p "$SCRATCH/sentinel"
 touch "$SCRATCH/sentinel/must-survive"
+# The registry is no longer empty at source time -- harness.sh registers its own ledger dir --
+# so this compares the registry ACROSS the failed call instead of against []. That is the
+# property that was meant all along: a failed mktemp adds nothing. The line count is asserted
+# too, so a registry that silently grew somewhere else cannot satisfy "unchanged" vacuously.
 cat > "$SCRATCH/child-mktemp-fail.sh" <<CHILD
 export PATH="$SCRATCH/stub-bin:\$PATH"
 . "$TESTS_DIR/harness.sh"
+REGISTRY_BEFORE="\$TMP_REGISTRY"
 new_tmpdir
 printf 'rc=%s\n' "\$?"
 printf 'NEW_TMPDIR=[%s]\n' "\$NEW_TMPDIR"
-printf 'registry=[%s]\n' "\$TMP_REGISTRY"
+printf 'registry_unchanged=[%s]\n' "\$([[ "\$TMP_REGISTRY" == "\$REGISTRY_BEFORE" ]] && echo yes || echo no)"
+printf 'registry_lines=[%s]\n' "\$(printf '%s' "\$TMP_REGISTRY" | grep -c . | tr -d ' ')"
 CHILD
 run_child "$SCRATCH/child-mktemp-fail.sh"
 assert_contains "a failed mktemp returns non-zero from new_tmpdir" "$OUT" "rc=90"
 assert_contains "a failed mktemp says so, loudly" "$ERR" "mktemp -d failed"
 assert_contains "the message explains why an empty path is refused" "$ERR" "destructive-cleanup hazard"
 assert_contains "a failed mktemp hands back NO path" "$OUT" "NEW_TMPDIR=[]"
-assert_contains "a failed mktemp registers NOTHING for removal" "$OUT" "registry=[]"
+assert_contains "a failed mktemp registers NOTHING for removal" "$OUT" "registry_unchanged=[yes]"
+assert_contains "  and the registry holds only the ledger dir harness.sh registered for itself" \
+  "$OUT" "registry_lines=[1]"
 assert_eq "a failed mktemp removes nothing: an unrelated dir survives" \
   "$([[ -f "$SCRATCH/sentinel/must-survive" ]] && echo present || echo gone)" "present"
 
@@ -151,6 +159,133 @@ done
 assert_eq "no new script suite hand-rolls rm -rf" "${RM_VIOLATORS:-none}" "none"
 assert_eq "and the rm -rf check actually examined the script suites" \
   "$([[ "$RM_EXAMINED" -ge 8 ]] && echo ok || echo "only $RM_EXAMINED examined")" "ok"
+
+suite "harness: the ledger cannot truncate a name it did not create (SEC-D1)"
+
+# THE DEFECT, measured before the fix: the ledger path was `${TMPDIR:-/tmp}/.pipeline-test-
+# harness-ledger.$$`, opened with `: >`. TMPDIR is unset on ubuntu-latest, so that is literally
+# /tmp; with a symlink pre-placed at that name a 49-byte file elsewhere went to 9 bytes holding
+# this harness's own ledger line, and the same run with no symlink left it byte-identical.
+#
+# The two legs below are split on purpose. The PRIMITIVE leg is deterministic -- it holds the
+# path fixed and changes only the opening call -- because the end-to-end attack is not: the
+# harness now picks its name with $$ AND $RANDOM, so squatting the real name is a race, and a
+# race makes a poor gate on a suite stop.sh runs at every turn end. The SHAPE leg then pins that
+# harness.sh is holding the refusing primitive, so a regression to `: >` goes red here.
+new_tmpdir || exit 90
+SQUAT="$NEW_TMPDIR"
+printf 'IMPORTANT-VICTIM-DATA-that-must-not-be-truncated\n' > "$SQUAT/victim"
+VICTIM_BYTES_BEFORE=$(wc -c < "$SQUAT/victim" | tr -d ' ')
+ln -s "$SQUAT/victim" "$SQUAT/squatted-name"
+
+# The old primitive, run against the squatted name. This is the CONTROL that makes the leg below
+# a measurement: without it, "the victim survived" is satisfied by a symlink that never resolved.
+( : > "$SQUAT/squatted-name" ) 2>/dev/null
+assert_eq "CONTROL: the OLD truncating open really does follow the symlink and empty the victim" \
+  "$(wc -c < "$SQUAT/victim" | tr -d ' ')" "0"
+
+# The new primitive, same squatted name. mkdir is atomic, fails on an existing path, and does
+# not follow a symlink to create at its target.
+printf 'IMPORTANT-VICTIM-DATA-that-must-not-be-truncated\n' > "$SQUAT/victim"
+mkdir -m 700 "$SQUAT/squatted-name" 2>/dev/null; MKDIR_RC=$?
+assert_eq "the NEW create REFUSES a pre-placed name instead of opening it" "$MKDIR_RC" "1"
+assert_eq "  and the victim behind the symlink is byte-for-byte untouched" \
+  "$(wc -c < "$SQUAT/victim" | tr -d ' ')" "$VICTIM_BYTES_BEFORE"
+assert_eq "  and the squatted name is still the attacker's symlink, not a dir this run owns" \
+  "$([[ -L "$SQUAT/squatted-name" ]] && echo symlink || echo replaced)" "symlink"
+
+# SHAPE. Comment lines are stripped: the rationale above the code says `: >` and
+# `.pipeline-test-harness-ledger` on purpose, and counting those would measure the prose.
+assert_not_contains "harness.sh no longer opens the ledger with a truncating redirect" \
+  "$(code_only "$TESTS_DIR/harness.sh")" ': > "$_ASSERT_LEDGER"'
+assert_not_contains "  and the predictable pid-only ledger name is gone from the code" \
+  "$(code_only "$TESTS_DIR/harness.sh")" '.pipeline-test-harness-ledger'
+assert_contains "  the ledger dir is created with mkdir, whose failure on an existing path is the guard" \
+  "$(code_only "$TESTS_DIR/harness.sh")" 'mkdir -m 700 "$_LEDGER_DIR"'
+
+# WHERE IT LANDS, on the real harness rather than on the primitive. A child reports the two
+# paths it was actually given.
+cat > "$SCRATCH/child-ledger-paths.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+printf '%s' "\$_LEDGER_DIR" > "$SCRATCH/ledger.dir"
+suite "scratch"
+assert_eq "passing case" "a" "a"
+printf 'LEDGER=[%s]\n' "\$_ASSERT_LEDGER"
+printf 'MODE=[%s]\n' "\$(ls -ld "\$_LEDGER_DIR" | cut -c1-10)"
+printf 'INSIDE=[%s]\n' "\$([[ "\$_ASSERT_LEDGER" == "\$_LEDGER_DIR"/* ]] && echo yes || echo no)"
+finish
+CHILD
+run_child "$SCRATCH/child-ledger-paths.sh"
+assert_eq "a real suite still gets a working ledger" "$RC" "0"
+assert_contains "the ledger file lives INSIDE the dir this process created" "$OUT" "INSIDE=[yes]"
+assert_contains "that dir is owner-only, so no other user can plant inside it either" "$OUT" "MODE=[drwx------]"
+assert_not_contains "the ledger is not sitting directly in the shared temp dir" "$OUT" "LEDGER=[$SCRATCH]"
+
+# SecOps' EXPECTED SURVIVOR, closed. Nothing asserted the ledger was ever cleaned up: deleting
+# the removal left 8 orphaned files per run with the suite still exiting 0. It is removed through
+# the SAME registry as every other temp dir, so this also proves the registration happened.
+assert_eq "the ledger dir is removed when the suite exits" \
+  "$([[ -e "$(cat "$SCRATCH/ledger.dir")" ]] && echo present || echo gone)" "gone"
+
+suite "harness: an unavailable ledger ANNOUNCES its disarm (SEC-D2)"
+
+# THE DEFECT, measured before the fix: with an unwritable TMPDIR the ledger path went empty and
+# _assert_count_guard returned 0 -- the same fail-open-in-silence shape the guard exists to
+# catch. Identical suite, one genuinely uncounted assertion: writable tmp exited 1 naming the
+# offender, unwritable tmp exited 0 with BYTE-IDENTICAL stdout. The only signal was bash's own
+# redirection diagnostic, which never mentions the guard and does not appear at all for a later
+# append failure.
+#
+# ANNOUNCE rather than FATAL, deliberately, and QA dissented. QA read require_node's exit 91 as
+# the precedent and would fail hard. require_node gates a PREREQUISITE (without node the .mjs
+# scripts go wholly unexercised); this gates a GUARD over assertions that still run and still
+# print either way, and TMPDIR is writable on every common path. The precedent taken is the
+# once-per-session disarm notice in hooks/session-start.sh, which is also a guard reporting its
+# own absence rather than wedging the operator over their tooling.
+new_tmpdir || exit 90
+RO_PARENT="$NEW_TMPDIR"
+RO_TMP="$RO_PARENT/unwritable"
+mkdir -p "$RO_TMP"
+chmod 500 "$RO_TMP"
+# PRECONDITION. Running as root ignores the mode bits, and then every assertion below would be
+# measuring a writable dir while claiming an unwritable one.
+touch "$RO_TMP/probe" 2>/dev/null
+assert_eq "  precondition: the fixture TMPDIR really is unwritable to this user" \
+  "$([[ -e "$RO_TMP/probe" ]] && echo writable || echo unwritable)" "unwritable"
+
+# The child from the count-guard suite below, reused verbatim: one counted assertion, one
+# evaluated in a subshell where the counter cannot survive. Every assertion in it PASSES, so
+# only the guard can fail it. TMPDIR is exported INSIDE each child rather than prefixed onto the
+# run_child call: a `VAR=x func` assignment leaks past a shell FUNCTION in bash, which would
+# silently carry the unwritable dir into the control below and into every later suite here.
+write_uncounted_child() {
+  cat > "$1" <<CHILD
+export TMPDIR="$2"
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+assert_eq "counted normally" "a" "a"
+( assert_eq "evaluated where the counters do not survive" "b" "b" )
+finish
+CHILD
+}
+
+write_uncounted_child "$SCRATCH/child-uncounted-ro.sh" "$RO_TMP"
+run_child "$SCRATCH/child-uncounted-ro.sh"
+RO_RC="$RC"; RO_OUT="$OUT"; RO_ERR="$ERR"
+assert_contains "an unavailable ledger SAYS the guard is disabled" "$RO_ERR" \
+  "the uncounted-assertion guard is DISABLED for this suite"
+assert_contains "  and names the path it could not use" "$RO_ERR" "$RO_TMP/.pipeline-harness."
+assert_contains "  the suite still RUNS: assertions are announced, not refused" "$RO_OUT" "passed=1 failed=0"
+
+# NON-ZERO CONTROL, on the same child with the only difference being a writable TMPDIR. Without
+# it, the announce above is satisfied by a harness that announces unconditionally, and the
+# disarm it reports would be indistinguishable from the normal case.
+write_uncounted_child "$SCRATCH/child-uncounted-rw.sh" "$SCRATCH"
+run_child "$SCRATCH/child-uncounted-rw.sh"
+assert_not_contains "CONTROL: a writable TMPDIR announces NOTHING" "$ERR" \
+  "the uncounted-assertion guard is DISABLED"
+assert_eq "CONTROL: and the guard bites there, so the announce marks a REAL loss of coverage" "$RC" "1"
+assert_eq "  which is the loss: the identical suite exits 0 once the ledger is unavailable" "$RO_RC" "0"
 
 suite "harness: an UNCOUNTED assertion fails the suite"
 
@@ -213,7 +348,10 @@ suite "harness: node is REQUIRED, never skipped (AC3)"
 # Build a PATH with the few externals harness.sh itself needs and, pointedly, no node. This is
 # the inversion of the hooks' fail-open posture: see require_node's comment before changing it.
 mkdir -p "$SCRATCH/nonode-bin"
-for tool in dirname basename mktemp rm; do
+# mkdir is on this list because harness.sh creates its ledger DIRECTORY at source time. Leave it
+# off and the fixture also constructs "no mkdir", which fires the ledger-unavailable notice and
+# makes this cell test two conditions while claiming one.
+for tool in dirname basename mktemp mkdir rm; do
   ln -sf "$(command -v "$tool")" "$SCRATCH/nonode-bin/$tool"
 done
 cat > "$SCRATCH/child-nonode.sh" <<CHILD


### PR DESCRIPTION
Closes #39.

Phase entry is granted by a script now, instead of being assumed by the orchestrator. `scripts/gate-phase-entry.mjs` decides whether the run recorded in `.pipeline/<issue>/status.json` is allowed to be where it says it is, and `hooks/stop.sh` refuses the turn when it is not.

## What it is, and what it is not

A turn-boundary consistency gate. It cannot prevent a phase being skipped mid-turn; it detects the absence when the turn tries to end, so the cost of a skip is the wasted work in that turn rather than zero. The header carries that limit verbatim, because a stated limit that gets paraphrased becomes a stated guarantee.

## The three decisions that were undefined before

**Satisfaction is set membership.** Both obvious readings were proven wrong on real records before this design existed. Equality fails: `phaseKey("3b-dev")` is `3b`, so a phase-3 prerequisite would never be satisfied by the label this pipeline actually writes, and `.pipeline/17`'s legitimate resume would be refused. Prefix is worse and is corpus-reachable: `"2.5".startsWith("2")`, so `.pipeline/17`'s recorded `2.5-design` SKIPPED entry would self-grant the Phase 2 review gate it skipped. Every row therefore carries an explicit satisfying token set, and two exclusions are load-bearing: `2.5-design` satisfies on `{2}` and not on its own token, and `4-review` / `3-impl-complete` satisfy on `{3, 3b}` and exclude `3a`, so a run where QA authored the contract and Dev was never dispatched is not declared panel-ready.

**Two sources, because everything except `status.json` is gitignored.** The artifact on disk, else a committed `events[]` entry for the phase. Path (b) is knowingly weaker: an event attests dispatch, never approval. A deviation clears the guard through a `SKIPPED` entry that costs a written note, which is the shape the corpus already carried once, at the right price.

**Fail-open on vocabulary, fail-closed on sequence.** An unrecognised phase is a gap in the guard's knowledge, not discretion — and `status.schema.json` blesses two phases `pipeline.md` never writes, so deny-by-default would have refused every turn in a project holding one of those records.

## Fail direction, split

The DECISION is fail-closed. The TOOLING is fail-open: no node, no script, no readable record, any throw — exit 0, silently. Those are events in different environments, which is what makes the split legitimate rather than convenient. Because a tooling fail-open is invisible by construction, `session-start.sh` now says so once per session when a run is in flight and the guard is disarmed.

## Placement is a window

Below the `PAYLOAD=$(cat)` read, because stdin is not re-readable and a guard above it would empty `PAYLOAD` and silently retire the voice lint. Above five early exits, including the two that matter most: a checkpoint commit leaves the tree clean, and an adopting project with no `checkCommand` and no `typecheck` script returns before the clean-tree check is ever reached. `CLAUDE_HOOK_STOP_SKIP` no longer claims to be a blanket opt-out, because it is not one for this step.

## Also here

- `phaseKey` is exported rather than copied, so the guard references the phase registry instead of restating it. The drift suite asserts by module import that every satisfying token is a member of the imported `KNOWN_PHASES`, and that the four phase sets partition the 25 literals `pipeline.md` writes.
- `pipeline.md`: the exit event for phase N and the entry checkpoint for phase N+1 are ONE write. Checkpoint-first-then-append was compliant with the file as written and left a window in which the record says "entering 3-impl" with nothing showing Phase 2.5 closed.
- `phase.md`: a `<phase-token>-rerun` label, because the phase-less one resolved to nothing and could never clear the guard; and the order note now says the guard applies to `/phase` too, which is what the owner ruled.

## Test state, stated honestly

**264 of 266 new assertions pass**, in the worktree and in a fresh detached checkout, identically: 32 suites, 1875 passed, 6 failed. Four of those six are `test-issue17-integration.sh` reporting the other two from inside its own clone.

**Two assertions are left RED on purpose.** `AC5` cell 1 contradicts `AC9` cell 2: its fixture is the whole issue-17 record, which carries two events resolving to token `2`, and `{2}` *is* the `2.5-design` row's satisfying set, so the row is granted through a different entry than the one the criterion is about. `AC9` asserts that same pairing grants. No pure function of (record, artifacts, now) can do both. The property `AC5` wants is covered and green in its own cell 3. Reported rather than silenced.

**A 31-mutation battery** was run (Phase 3a did not build one): 25 caught, 6 survivors, each survivor explained rather than counted. Two survivors are expected — the spec's own named one (`not-applicable` and `granted` are indistinguishable at the hook's exit code, which is why those criteria assert on the decision string) and the `-error` template's single-literal test. Four are coverage gaps found by mutation: `AC26(a)` cannot fail because the harness's own stderr file dirties the fixture tree before `stop.sh` reads it; nothing requires the signal-named dir to be evaluated at all; and no `AC23` cell reaches the hook's exit-code test, so a broken install (node runs, the guard throws) is unasserted — probed directly, and the shipped hook exits 0 where blocking on any non-zero would wedge every turn in an adopting project with a partial install.

**One commit repairs QA's own fixtures** and is isolated so it can be reverted alone. Nine assertions could not fail in the direction they asserted: seven built their `events[]` through a brace-expanding shell literal and were testing the guard's silence on invalid JSON, and two applied a `<no-report>` sentinel to the extracted value, where `:-` substitutes on the empty string that *is* the passing state. No assertion, expectation or population changed. Both repairs now have working non-zero controls.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
