### PR TITLE
test: the self-test wrapper says which cases failed (#27)

### DIFF
--- a/plugins/pipeline/tests/test-validate-pipeline-artifact.sh
+++ b/plugins/pipeline/tests/test-validate-pipeline-artifact.sh
@@ -60,6 +60,18 @@ suite "validate-pipeline-artifact: the shipped 56-case self-test runs under chec
   > "$TEMP_PROJECT/selftest.out" 2>&1
 SELFTEST_RC=$?
 SELFTEST_OUT=$(cat "$TEMP_PROJECT/selftest.out")
+
+# The self-test names every case it runs, but this wrapper captured that output and threw it
+# away, so a red here said only "4 failed" and never which four. That is issue #27: a gate that
+# reddens without saying why is the gate that eventually gets switched off, and it cost a
+# main-is-red investigation that could not proceed past the summary line. Echo the failing
+# cases -- and ONLY on failure, so the ~60 ok lines do not drown the transcript.
+if [ "$SELFTEST_RC" != "0" ]; then
+  printf '%s\n' "--- self-test failing cases (issue #27) ---" >&2
+  printf '%s\n' "$SELFTEST_OUT" | grep -iE '^[[:space:]]*(FAIL|not ok)' >&2 || \
+    printf '%s\n' "(no FAIL-shaped line found; full output follows)" "$SELFTEST_OUT" >&2
+  printf '%s\n' "--- end self-test failing cases ---" >&2
+fi
 assert_eq "node validate-pipeline-artifact.mjs --self-test exits 0" "$SELFTEST_RC" "0"
 
 # This wrapper delegates 56 of the suite's cases, so it has to be able to tell 56 from ZERO.


### PR DESCRIPTION
Diagnostic only, one file, no behaviour change to any script.

**`main` is currently red** and I could not diagnose it. `test-validate-pipeline-artifact.sh` captured the self-test's output into a variable and threw it away, so a failure reported only `expected: 0 / actual: 4` and never which four of the 61 cases failed. That is #27 exactly, and it is now the thing standing between a red `main` and a fix.

The self-test already names every case. This echoes the failing ones to stderr **on failure only**, so the ~60 `ok` lines do not drown the transcript, with a fallback that dumps the whole output when nothing FAIL-shaped is found (which is what happens when the script crashes rather than failing a case).

**Witnessed control**, both branches: planting a defect that crashes the script produced

```
--- self-test failing cases (issue #27) ---
(no FAIL-shaped line found; full output follows)
  ok   valid spec
  ...
--- end self-test failing cases ---
```

and the suite stays 25/0 unplanted.

## Why this is worth its own PR

The failure is platform-specific and I cannot reproduce it locally: `node validate-pipeline-artifact.mjs --self-test` gives **61 passed, 0 failed** on macOS, and **4 failed** on `ubuntu-latest`, twice, including a rerun of an identical tree. So this is no longer the intermittent flake #25/#27 describe — it is reproducible on Linux and invisible to me without this change.

Expect this PR's own CI to go red for the same reason. That is the point: its log will name the four cases.