### PR TITLE
Bound the archived verdict fields, and de-rot the phase list in status.schema.json

### DIFF
--- a/.pipeline/34/status.json
+++ b/.pipeline/34/status.json
@@ -2,9 +2,16 @@
   "issue_number": 34,
   "current_phase": "1-ba",
   "started_at": "2026-08-20T13:32:41Z",
-  "updated_at": "2026-08-20T13:32:41Z",
+  "updated_at": "2026-08-20T13:37:14Z",
   "branch": "claude/mechanical-group-impl-bfb9ce",
   "ask_text": "Bound events[].verdict with a maxLength in status.schema.json (#34) and correct the rotted current_phase description example list at line 13 (#42). Both are single-file edits to plugins/pipeline/schemas/status.schema.json.",
-  "events": [],
+  "events": [
+    {
+      "phase": "0.5-map",
+      "verdict": "SKIPPED",
+      "at": "2026-08-20T13:37:14Z",
+      "note": "No separate 0.5-map dispatch: pipeline.md folds the map into the Phase 1 BA dispatch below the architectural tier, and BA (in flight) writes map.json alongside spec.json. Recorded as a skip rather than waited on because this record carries no risk_tier yet -- the tier is BA output, while pipeline.md mandates checkpointing 1-ba BEFORE dispatching BA -- so gate-phase-entry.mjs:133 normalizes the absent tier to architectural and switches on the architectural-only 1-ba row. That is issue #45 reproduced live. Revisit if BA promotes the tier, which needs the deep three-layer map as its own dispatch."
+    }
+  ],
   "flags": []
 }

--- a/.pipeline/34/status.json
+++ b/.pipeline/34/status.json
@@ -1,8 +1,8 @@
 {
   "issue_number": 34,
-  "current_phase": "2-constraints",
+  "current_phase": "4-review-complete",
   "started_at": "2026-08-20T13:32:41Z",
-  "updated_at": "2026-08-20T13:47:36Z",
+  "updated_at": "2026-08-20T16:34:45Z",
   "branch": "claude/mechanical-group-impl-bfb9ce",
   "ask_text": "Bound events[].verdict with a maxLength in status.schema.json (#34) and correct the rotted current_phase description example list at line 13 (#42). Both are single-file edits to plugins/pipeline/schemas/status.schema.json.",
   "events": [
@@ -16,6 +16,22 @@
       "phase": "1-ba",
       "verdict": "complete",
       "at": "2026-08-20T13:47:36Z"
+    },
+    {
+      "phase": "2-constraints",
+      "verdict": "complete",
+      "at": "2026-08-20T13:48:59Z",
+      "note": "dba 12 / devops 11 / secops 13 lines, each verified non-empty separately; extracted from the repo agents dir, not the stale plugin cache."
+    },
+    {
+      "phase": "3-impl",
+      "verdict": "complete",
+      "at": "2026-08-20T15:02:13Z"
+    },
+    {
+      "phase": "4-review",
+      "verdict": "APPROVE_WITH_NOTES",
+      "at": "2026-08-20T15:50:58Z"
     }
   ],
   "flags": [
@@ -25,7 +41,177 @@
       "verdict": "complete",
       "summary": "spec+map written, tier standard; nothing validates status.json against this schema, so the cap needs a corpus check (R4) to bite",
       "at": "2026-08-20T13:47:36Z"
+    },
+    {
+      "phase": "3-impl",
+      "agent": "dev",
+      "verdict": "complete",
+      "summary": "PR #51: both verdict fields capped 32, phase list de-rotted; new suite 67 assertions, total 2056 (was 1989)",
+      "at": "2026-08-20T15:02:13Z"
+    },
+    {
+      "phase": "3-impl",
+      "agent": "orchestrator",
+      "verdict": "NOTE",
+      "summary": "TRIPWIRE-NOTE: the mis-tier tripwire effective glob set matches zero tracked files in this repo, so it cannot fire here",
+      "at": "2026-08-20T15:02:13Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "orchestrator",
+      "verdict": "NOTE",
+      "summary": "SecOps dispatch 1 lost to a connection drop after announcing the write; shard absent, re-dispatched write-first. Round not lost.",
+      "at": "2026-08-20T15:33:08Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "ba",
+      "verdict": "APPROVE_WITH_NOTES",
+      "summary": "0-setup divergence: a third phase derivation, unreconciled; map.json 26/25 is wrong (27/26 correct); AC2 floor is >=1 not >=6",
+      "at": "2026-08-20T15:50:58Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "dev",
+      "verdict": "APPROVE_WITH_NOTES",
+      "summary": "third derivation of the phase vocabulary; a false one-site-holds-32 comment; AC10 needle matches only the verb blesses",
+      "at": "2026-08-20T15:50:58Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "qa",
+      "verdict": "APPROVE_WITH_NOTES",
+      "summary": "G1 demonstrated: AC10 pinned floor >=8 over 33 files, violation escaped green; events[].note max 616 chars beside a 32 cap",
+      "at": "2026-08-20T15:50:58Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "secops",
+      "verdict": "APPROVE_WITH_NOTES",
+      "summary": "detects rather than prevents, but in the right environment; S1: schema claims a writer rule that does not exist; filed #52",
+      "at": "2026-08-20T15:50:58Z"
+    },
+    {
+      "phase": "4-review",
+      "agent": "orchestrator",
+      "verdict": "NOTE",
+      "summary": "deferral ledger discharged: #52 (secops), #53 (0-setup), #54 (cap-vs-config + AC2 floor), #47 comment (assertion totals)",
+      "at": "2026-08-20T16:34:45Z"
     }
   ],
-  "risk_tier": "standard"
+  "risk_tier": "standard",
+  "pr_url": "https://github.com/nsmedia-io/agent-pipeline/pull/51",
+  "panel_roles": [
+    "ba",
+    "dev",
+    "qa",
+    "secops"
+  ],
+  "review_rounds": 1,
+  "telemetry": {
+    "phase_elapsed_ms": {
+      "1": 622000,
+      "2": 83000,
+      "3": 4394000
+    },
+    "total_lead_time_ms": 5099000,
+    "unattributed_ms": 0,
+    "unattributed_events": 0,
+    "untimed_events": 0,
+    "review_rounds": 1,
+    "events_counted": 4,
+    "attribution": "exit"
+  },
+  "effective_config": {
+    "migration_globs_tripwire": [
+      "**/migrations/**",
+      "**/Migrations/**",
+      "**/db/migrate/**",
+      "**/db/migration/**",
+      "**/db/changelog/**",
+      "**/alembic/versions/**",
+      "**/schema.prisma",
+      "**/prisma/schema/**",
+      "**/drizzle/**",
+      "**/db/schema.ts",
+      "**/db/schema/**",
+      "**/supabase/schemas/**",
+      "**/policies/**.sql",
+      "**/supabase/policies/**",
+      "**/schema.sql"
+    ],
+    "migration_globs_gate": [
+      "**/migrations/**",
+      "**/Migrations/**",
+      "**/db/migrate/**",
+      "**/db/migration/**",
+      "**/db/changelog/**",
+      "**/alembic/versions/**",
+      "**/schema.prisma",
+      "**/prisma/schema/**",
+      "**/drizzle/**",
+      "**/db/schema.ts",
+      "**/db/schema/**",
+      "**/supabase/schemas/**",
+      "**/policies/**.sql",
+      "**/supabase/policies/**",
+      "**/schema.sql"
+    ],
+    "data_layer_globs": [
+      "**/migrations/**",
+      "**/Migrations/**",
+      "**/db/migrate/**",
+      "**/db/migration/**",
+      "**/db/changelog/**",
+      "**/alembic/versions/**",
+      "**/schema.prisma",
+      "**/prisma/schema/**",
+      "**/drizzle/**",
+      "**/db/schema.ts",
+      "**/db/schema/**",
+      "**/supabase/schemas/**",
+      "**/policies/**.sql",
+      "**/supabase/policies/**",
+      "**/schema.sql",
+      "**/db/**",
+      "**/queries/**",
+      "**/policies/**",
+      "**/repositories/**",
+      "**/prisma/**",
+      "**/supabase/**",
+      "**/alembic/**",
+      "**/schema.ts",
+      "**/database.types.ts",
+      "**/*.generated.types.ts"
+    ],
+    "infra_globs": [
+      "**/.github/workflows/**",
+      ".github/**",
+      "**/infra/**",
+      "**/terraform/**",
+      "**/k8s/**",
+      "**/helm/**",
+      "**/deploy/**",
+      "**/deploy.sh",
+      "**/deploy.config",
+      "**/*.tf",
+      "**/*.tfvars",
+      "**/Dockerfile",
+      "**/docker-compose.yml",
+      "**/docker-compose.yaml"
+    ],
+    "models": {
+      "ba": "sonnet",
+      "dev": "sonnet"
+    },
+    "rejected_absolute_globs": 0
+  },
+  "final_verdict": "APPROVE_WITH_NOTES",
+  "peer_review_verdict_counts": {
+    "approve": 0,
+    "approve_with_notes": 4,
+    "request_changes": 0,
+    "request_refactor": 0,
+    "veto": 0
+  }
 }

--- a/.pipeline/34/status.json
+++ b/.pipeline/34/status.json
@@ -1,0 +1,10 @@
+{
+  "issue_number": 34,
+  "current_phase": "1-ba",
+  "started_at": "2026-08-20T13:32:41Z",
+  "updated_at": "2026-08-20T13:32:41Z",
+  "branch": "claude/mechanical-group-impl-bfb9ce",
+  "ask_text": "Bound events[].verdict with a maxLength in status.schema.json (#34) and correct the rotted current_phase description example list at line 13 (#42). Both are single-file edits to plugins/pipeline/schemas/status.schema.json.",
+  "events": [],
+  "flags": []
+}

--- a/.pipeline/34/status.json
+++ b/.pipeline/34/status.json
@@ -1,8 +1,8 @@
 {
   "issue_number": 34,
-  "current_phase": "1-ba",
+  "current_phase": "2-constraints",
   "started_at": "2026-08-20T13:32:41Z",
-  "updated_at": "2026-08-20T13:37:14Z",
+  "updated_at": "2026-08-20T13:47:36Z",
   "branch": "claude/mechanical-group-impl-bfb9ce",
   "ask_text": "Bound events[].verdict with a maxLength in status.schema.json (#34) and correct the rotted current_phase description example list at line 13 (#42). Both are single-file edits to plugins/pipeline/schemas/status.schema.json.",
   "events": [
@@ -11,7 +11,21 @@
       "verdict": "SKIPPED",
       "at": "2026-08-20T13:37:14Z",
       "note": "No separate 0.5-map dispatch: pipeline.md folds the map into the Phase 1 BA dispatch below the architectural tier, and BA (in flight) writes map.json alongside spec.json. Recorded as a skip rather than waited on because this record carries no risk_tier yet -- the tier is BA output, while pipeline.md mandates checkpointing 1-ba BEFORE dispatching BA -- so gate-phase-entry.mjs:133 normalizes the absent tier to architectural and switches on the architectural-only 1-ba row. That is issue #45 reproduced live. Revisit if BA promotes the tier, which needs the deep three-layer map as its own dispatch."
+    },
+    {
+      "phase": "1-ba",
+      "verdict": "complete",
+      "at": "2026-08-20T13:47:36Z"
     }
   ],
-  "flags": []
+  "flags": [
+    {
+      "phase": "1-ba",
+      "agent": "ba",
+      "verdict": "complete",
+      "summary": "spec+map written, tier standard; nothing validates status.json against this schema, so the cap needs a corpus check (R4) to bite",
+      "at": "2026-08-20T13:47:36Z"
+    }
+  ],
+  "risk_tier": "standard"
 }

--- a/plugins/pipeline/commands/pipeline.md
+++ b/plugins/pipeline/commands/pipeline.md
@@ -93,6 +93,9 @@ Rules for `summary`:
 - Quote the agent's own concern, do not editorialize.
 - Verdict-only ("APPROVE") agents still get an entry with `summary: ""`.
 
+Rules for `verdict` (the same rule governs `events[].verdict`):
+- A TOKEN, not prose: strict 32-char cap, matching the `maxLength` on both verdict fields in `schemas/status.schema.json`. Write the agent's verdict word and nothing else; the reasoning goes in `summary`. Nothing validates status.json against that schema, so this restatement IS the write-time honorer.
+
 When dispatching Phase 4 reviewer prompts (see the Phase 4 section below), include the line `Prior flags: see status.json flags array; the digest is authoritative for what earlier agents already raised.` This avoids each Phase 4 reviewer re-parsing review.json and impl-report.json from cold.
 
 ### Risk-tiered orchestration depth

--- a/plugins/pipeline/schemas/status.schema.json
+++ b/plugins/pipeline/schemas/status.schema.json
@@ -10,7 +10,7 @@
     "current_phase": {
       "type": "string",
       "pattern": "^([0-5](\\.5)?-[a-z0-9-]+|halted-error)$",
-      "description": "Examples: 0-setup, 0.5-map, 1-ba, 1-ba-complete, 1-ba-rework-required, 2-constraints, 2-constraints-complete, 2-review, 2-review-complete, 2.5-design, 2.5-design-complete, 3-impl, 3-impl-complete, 3-impl-tripwire, 3-impl-gate-failed, 3-impl-verification-unverified, 3-scope-drift-adjudication, 4-review, 4-review-complete, 4-veto-rework-required, 5-archive, 5-archived, halted-error."
+      "description": "Examples: 0-setup, 0.5-map, 0.5-map-complete, 1-ba, 1-ba-open-questions, 1-ba-complete, 1-ba-rework-required, 2-constraints, 2-constraints-complete, 2-review, 2-review-complete, 2.5-design, 2.5-design-owner-decision, 2.5-design-complete, 3-impl, 3-impl-tripwire, 3-impl-tripwire-indeterminate, 3-impl-gate-failed, 3-impl-frontend-gate-failed, 3-impl-live-verify-unverified, 3-impl-complete, 4-review, 4-review-complete, 4-veto-rework-required, 5-archive, 5-archived, halted-error. The <phase>-error family is a SHAPE and not a literal -- commands/pipeline.md writes <phase>-error for whichever phase failed -- so it is deliberately not enumerated above. The list is exactly the literals commands/pipeline.md writes, PLUS halted-error, which pipeline.md writes nowhere yet the pattern above alternates by name and scripts/gate-phase-entry.mjs returns true for: deriving this list from pipeline.md alone would delete correct work. This is prose in a file nothing validates status.json against, and it rotted once already (#42, which blessed two phases nobody wrote and omitted six that were); it is kept honest now by tests/test-status-schema-contract.sh, which asserts set equality against pipeline.md in BOTH directions."
     },
     "started_at": {"type": "string", "format": "date-time"},
     "updated_at": {"type": "string", "format": "date-time"},
@@ -53,7 +53,7 @@
         "required": ["phase", "at"],
         "properties": {
           "phase": {"type": "string"},
-          "verdict": {"type": "string"},
+          "verdict": {"type": "string", "maxLength": 32, "description": "A TOKEN, not prose: the verdict of the phase this event closes. NOTHING VALIDATES status.json AGAINST THIS SCHEMA -- the file is in no AGENT_RULES entry in scripts/validate-pipeline-artifact.mjs, and that walker does not implement maxLength at all, so this cap refuses nothing on its own. It is honored by the writer and by tests/test-status-schema-contract.sh, which checks every committed record against the value read FROM here. Do not mistake the cap for an enforced control and skip writing the enforcement. The bound exists because status.json is committed AND archived verbatim, so an unbounded string here reaches a public tree at full length; 32 is 1.78x the longest declared verdict (APPROVE_WITH_NOTES, 18) and sits below the length of the sentence this refuses. Optional: an event with no verdict is valid."},
           "at": {"type": "string", "format": "date-time"},
           "note": {"type": "string"}
         }
@@ -108,8 +108,8 @@
         "properties": {
           "phase": {"type": "string"},
           "agent": {"type": "string"},
-          "verdict": {"type": "string"},
-          "summary": {"type": "string", "maxLength": 140},
+          "verdict": {"type": "string", "maxLength": 32, "description": "The same TOKEN-not-prose rule and the same 32-char bound as events[].verdict, and unenforced in exactly the same way: nothing validates status.json against this schema, so the cap is honored by the writer and by tests/test-status-schema-contract.sh rather than by a validator. Capped alongside its twin rather than deferred because it carries the LONGEST verdict in the committed corpus (APPROVE_WITH_NOTES, 18 chars) while events[] tops out at 15. Optional: a flag with no verdict is valid."},
+          "summary": {"type": "string", "maxLength": 140, "description": "ALSO unenforced by any validator: this cap predates the two above and is honored only because commands/pipeline.md restates it as a writer rule."},
           "at": {"type": "string", "format": "date-time"}
         }
       }

--- a/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
@@ -10,9 +10,13 @@
 # LINES and would silently lower a count if two occurrences shared one.
 #
 # AND WHY THERE IS A SECOND GROUND TRUTH (in the sibling suite, AC19). Prose alone is provably
-# insufficient: status.schema.json:13's own description blesses `3-scope-drift-adjudication`
-# and `3-impl-verification-unverified`, and pipeline.md writes NEITHER. A vocabulary in this
-# repo has already rotted, in the one file a prose-derived test does not read.
+# insufficient, and this repo paid for the lesson: until #42, status.schema.json:13's own
+# description named `3-scope-drift-adjudication` and `3-impl-verification-unverified`, which
+# pipeline.md wrote NEITHER of, and omitted six literals it did write. A vocabulary in this repo
+# HAD rotted, in the one file no prose-derived test read. That list is corrected and now carries
+# a set-equality test of its own (test-status-schema-contract.sh), so it is history rather than
+# live evidence -- but the argument it paid for stands: a hand-maintained second copy of a
+# vocabulary rots silently unless something compares it to the first.
 
 . "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
 require_node

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -508,9 +508,11 @@ done
 # ---------------------------------------------------------------------------
 suite "AC14: fail-OPEN on vocabulary, fail-CLOSED on sequence"
 # ---------------------------------------------------------------------------
-# The live case, not a hypothetical: status.schema.json:13's own description blesses
-# 3-scope-drift-adjudication, and pipeline.md never writes it. Under deny-by-default that
-# record would refuse every stop in the project that holds it.
+# Not a hypothetical: until #42, status.schema.json:13's own description named
+# 3-scope-drift-adjudication as an example phase, and pipeline.md never wrote it. Under
+# deny-by-default a record holding it would refuse every stop in the project. The schema no
+# longer names it, but the INPUT below stays exactly as it is -- pipeline.md still writes it
+# nowhere, so it remains a phase this guard can genuinely meet and must not refuse.
 for p in "3-scope-drift-adjudication" "3-something-nobody-writes"; do
   new_case 4242 "$(mk_status "$p" '"architectural"' "$NO_EVENTS")"
   gate "$CASE_ROOT"
@@ -708,9 +710,11 @@ assert_eq "  and no stderr" "$GATE_ERR" ""
 # ---------------------------------------------------------------------------
 suite "AC19: a SECOND ground truth, derived from the committed RECORDS rather than from prose"
 # ---------------------------------------------------------------------------
-# Prose alone is provably insufficient: status.schema.json:13 blesses two phases pipeline.md
-# never writes, which is live evidence that a vocabulary in this repo has ALREADY rotted in the
-# one file a prose-derived test does not read.
+# Prose alone is provably insufficient, and it was measured rather than argued: until #42,
+# status.schema.json:13 named two phases pipeline.md never wrote and omitted six it did. A
+# vocabulary in this repo HAD rotted, in the one file no prose-derived test read. The list is
+# corrected and now has its own set-equality test, so that is history -- but a second ground
+# truth derived from the committed RECORDS is still the point of this suite.
 CORPUS="$(git -C "$REPO_ROOT" ls-files '.pipeline/*/status.json' 2>/dev/null)"
 CORPUS_N="$(printf '%s\n' "$CORPUS" | grep -c . | tr -d ' ')"
 assert_eq "VACUITY CONTROL: the corpus walk found at least 4 committed records" \

--- a/plugins/pipeline/tests/test-status-schema-contract.sh
+++ b/plugins/pipeline/tests/test-status-schema-contract.sh
@@ -12,10 +12,11 @@
 # population #34 cares about -- status.json is committed AND archived verbatim into the
 # knowledge store, so whatever lands in it lands in a public tree at full length.
 #
-# THE CAP IS READ FROM THE SCHEMA, NEVER COPIED. One site below holds the literal 32, and it is
-# the pin on the value the spec ruled (q2). Every assertion OVER THE CORPUS uses the value read
-# out of the schema, so changing the schema alone moves this suite's verdict. A test carrying
-# its own copy of 32 would stay green while the schema drifted away underneath it.
+# THE CAP IS READ FROM THE SCHEMA, NEVER COPIED. TWO sites below hold the literal 32 -- one pin
+# per capped field, because AC1 requires each field pinned SEPARATELY -- and both pin the value
+# the spec ruled (q2). Every assertion OVER THE CORPUS uses the value read out of the schema, so
+# changing the schema alone moves this suite's verdict. A test carrying its own copy of 32 would
+# stay green while the schema drifted away underneath it.
 
 . "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
 require_node
@@ -176,9 +177,12 @@ SCHEMA_FACTS="$(node -e '
 assert_eq "status.schema.json parses as JSON at all" \
   "$([[ -n "$SCHEMA_FACTS" ]] && echo parsed || echo "UNPARSEABLE or unreadable: $SCHEMA")" "parsed"
 
-# THE ONE SITE THAT HOLDS THE LITERAL. This is the pin on the ruled value (spec q2: 32 = the
-# 18-char longest DECLARED verdict plus headroom for a longer token, below the length of the
-# prose sentence the bound refuses). Every corpus assertion below reads the schema instead.
+# THE TWO SITES THAT HOLD THE LITERAL, one pin per capped field. Two, not one, because AC1's
+# whole point is that "the schema contains maxLength" is satisfied by the events[] copy while
+# flags[] sits bare; a single shared pin cannot tell those apart. Both pin the ruled value (spec
+# q2: 32 = the 18-char longest DECLARED verdict plus headroom for a longer token, below the
+# length of the prose sentence the bound refuses). Every corpus assertion below reads the schema
+# instead, so a cap change moves this suite's verdict through the corpus, not through the pins.
 assert_eq "AC1: events[].verdict is capped at the ruled 32" "$(rfield "$SCHEMA_FACTS" events_cap)" "32"
 assert_eq "AC1: flags[].verdict is capped at the ruled 32 (folded in by R2; #34 names only events[])" \
   "$(rfield "$SCHEMA_FACTS" flags_cap)" "32"
@@ -196,6 +200,19 @@ assert_contains "R6: flags[].verdict says the same" \
   "$(rfield "$SCHEMA_FACTS" flags_desc)" "nothing validates status.json against this schema"
 assert_eq "flags[].summary's pre-existing 140 cap is untouched" \
   "$(rfield "$SCHEMA_FACTS" summary_cap)" "140"
+
+# THE WRITER RULE THE DESCRIPTIONS NAME. Both verdict descriptions say the cap "is honored by the
+# writer", and commands/pipeline.md is the only document the writer reads. A rule nobody reads is
+# a comment, so the claim is asserted rather than trusted -- and asserted against the number read
+# out of the SCHEMA, not a literal repeated here, so raising the cap in the schema alone reddens
+# this until the writer's copy follows.
+PIPELINE_VERDICT_RULE="$(sed -n '/^Rules for `verdict`/,/^$/p' "$PIPELINE_MD")"
+assert_contains "R6: commands/pipeline.md restates the verdict cap to the WRITER, beside the 140 summary rule" \
+  "$PIPELINE_VERDICT_RULE" "$(rfield "$SCHEMA_FACTS" events_cap)-char cap"
+assert_contains "R6: ...and says what the field is for, so the cap is not read as a truncation budget" \
+  "$PIPELINE_VERDICT_RULE" "TOKEN, not prose"
+assert_eq "CONTROL: the extraction is SCOPED -- the range stops at the blank line and does not run on into the next section" \
+  "$(printf '%s' "$PIPELINE_VERDICT_RULE" | grep -c 'When dispatching Phase 4' | tr -d ' ')" "0"
 
 # ---------------------------------------------------------------------------
 suite "AC2: VACUITY CONTROL over the corpus, asserted BEFORE any property of it"
@@ -436,26 +453,45 @@ suite "AC10: the three rot comments read as HISTORY, not as a live claim"
 # it" is deliberately NOT part of the needle: that sentence is still TRUE, and still load-bearing,
 # for the control input at test-gate-phase-entry.sh:514.
 #
+# THE VERB IS A CLASS, NOT AN EXAMPLE. The needle used to enumerate one spelling, `blesses`, while
+# the assertion below claimed the whole class -- and the escape was not hypothetical: a planted
+# `status.schema.json:13 names 3-scope-drift-adjudication` passed green, in the very wording the
+# sibling suite at test-gate-phase-entry.sh:511 uses for this subject. Each verb gets its own
+# control cell below, because a class proven through one member is an example again. PRESENT
+# tense only: `named`/`blessed` are how the re-anchored comments correctly state the history, and
+# a needle that swallowed the past tense would refuse the fix it exists to enforce.
+#
+# The `bl[e]sses`/`n[a]mes` brackets are not decoration: this file is exempt from the walk, but
+# the CONTROL cells below grep hand-written strings, and a needle that matched its own definition
+# would report the checker instead of the repo.
+#
 # DISCOVERY IS THE test-*.sh GLOB, with ONE exemption. This suite is exempt because it is the file
 # that has to carry the needle and the pre-change wording in order to check them at all -- an
 # unexempted walk reports its own source and can never go green, which measures the checker rather
 # than the repo. The exemption is by basename and is the only one; a new suite is covered the day
 # it lands.
-AC10_NEEDLE='schema\.json.*bl[e]sses'
+AC10_VERBS='bl[e]sses|n[a]mes|lists|claims'
+AC10_NEEDLE="schema\.json.*\b($AC10_VERBS)\b"
 AC10_VIOLATORS=""
 AC10_EXAMINED=0
 for f in "$TESTS_DIR"/test-*.sh; do
   [[ -f "$f" ]] || continue
   [[ "$(basename "$f")" == "test-status-schema-contract.sh" ]] && continue
   AC10_EXAMINED=$((AC10_EXAMINED + 1))
-  if grep -qn "$AC10_NEEDLE" "$f"; then
-    AC10_VIOLATORS="$AC10_VIOLATORS $(basename "$f"):$(grep -n "$AC10_NEEDLE" "$f" | head -1 | cut -d: -f1)"
+  if grep -qEn "$AC10_NEEDLE" "$f"; then
+    AC10_VIOLATORS="$AC10_VIOLATORS $(basename "$f"):$(grep -En "$AC10_NEEDLE" "$f" | head -1 | cut -d: -f1)"
   fi
 done
 assert_eq "AC10: no suite still claims in the present tense that the schema names an unwritten phase" \
   "${AC10_VIOLATORS:-none}" "none"
-assert_eq "AC10: and the walk examined the suites rather than passing against an empty glob" \
-  "$([[ "$AC10_EXAMINED" -ge 8 ]] && echo ok || echo "only $AC10_EXAMINED examined")" "ok"
+# THE POPULATION IS DERIVED, NOT PINNED -- the same rule this suite applies to AC2's corpus floor,
+# applied to its own walk. The floor used to be `-ge 8` against a real population of 33, which is
+# room for 24 suites to fall out of the glob in silence: a planted violation in an excluded file
+# passed green with 9 walked. Enumerating the glob independently of the loop closes that, and it
+# is non-vacuous by construction -- an empty glob yields -1 here against 0 examined, which is red.
+AC10_EXPECTED=$(( $(ls "$TESTS_DIR"/test-*.sh 2>/dev/null | grep -c . | tr -d ' ') - 1 ))  # -1 = the single self-exemption
+assert_eq "AC10: and the walk examined EVERY suite but its own (population DERIVED from the glob, not pinned)" \
+  "$AC10_EXAMINED" "$AC10_EXPECTED"
 # The control is the three sites' ACTUAL pre-change wording, one cell each, because a needle
 # proven against one hand-written line proves nothing about the other two.
 AC10_WAS_1="# insufficient: status.schema.json:13's own description blesses \`3-scope-drift-adjudication\`"
@@ -463,10 +499,22 @@ AC10_WAS_2="# The live case, not a hypothetical: status.schema.json:13's own des
 AC10_WAS_3="# Prose alone is provably insufficient: status.schema.json:13 blesses two phases pipeline.md"
 for w in "$AC10_WAS_1" "$AC10_WAS_2" "$AC10_WAS_3"; do
   assert_eq "AC10 CONTROL: the needle fires on the pre-change wording -- ${w:0:44}..." \
-    "$(printf '%s\n' "$w" | grep -c "$AC10_NEEDLE" | tr -d ' ')" "1"
+    "$(printf '%s\n' "$w" | grep -cE "$AC10_NEEDLE" | tr -d ' ')" "1"
 done
+# ONE CELL PER VERB, over the same sentence, so no member of the class rides on another's cell.
+# The `names` cell is the demonstrated escape: this exact line passed green before the widening.
+while IFS= read -r verb; do
+  assert_eq "AC10 CONTROL: the needle fires on the claim spelled '$verb' (one cell per verb in the class)" \
+    "$(printf '%s\n' "# status.schema.json:13 $verb 3-scope-drift-adjudication, and pipeline.md writes it nowhere." \
+      | grep -cE "$AC10_NEEDLE" | tr -d ' ')" "1"
+done < <(printf '%s\n' "$AC10_VERBS" | tr '|' '\n' | tr -d '[]')
 assert_eq "AC10 CONTROL: and it does NOT fire on the surviving true sentence about the control input" \
-  "$(printf '%s\n' "# pipeline.md still writes 3-scope-drift-adjudication nowhere, so it stays a valid input" | grep -c "$AC10_NEEDLE" | tr -d ' ')" "0"
+  "$(printf '%s\n' "# pipeline.md still writes 3-scope-drift-adjudication nowhere, so it stays a valid input" | grep -cE "$AC10_NEEDLE" | tr -d ' ')" "0"
+# The PAST tense is the shape the fix itself uses (test-gate-phase-entry.sh:511 "until #42 ...
+# named"). A needle that swallowed it would redden on the corrected comments, which is why the
+# verb class is anchored on both sides rather than left as a bare substring.
+assert_eq "AC10 CONTROL: nor on the re-anchored HISTORY wording, which is the corrected form" \
+  "$(printf '%s\n' "# Not a hypothetical: until #42, status.schema.json:13's own description named two phases" | grep -cE "$AC10_NEEDLE" | tr -d ' ')" "0"
 for f in test-gate-phase-entry-drift.sh test-gate-phase-entry.sh; do
   assert_eq "AC10: $f restates the rot as history naming #42" \
     "$([[ "$(grep -c 'until #42\|#42' "$TESTS_DIR/$f" | tr -d ' ')" -ge 1 ]] && echo anchored || echo "no #42 reference: the comment was deleted rather than re-anchored")" "anchored"

--- a/plugins/pipeline/tests/test-status-schema-contract.sh
+++ b/plugins/pipeline/tests/test-status-schema-contract.sh
@@ -297,28 +297,79 @@ assert_eq "AC3: and the walk actually inspected verdict strings (which is what m
 C17="$(verdict_report "$REPO_ROOT" 17)"
 assert_contains "AC3 NON-ZERO CONTROL: at cap 17 the check goes red and NAMES the file" \
   "$(rfield "$C17" violations)" ".pipeline/17/status.json"
-assert_contains "AC3 NON-ZERO CONTROL: ...names the FLAGS entry, not an events entry" \
+assert_contains "AC3 NON-ZERO CONTROL: ...names the FLAGS entry that carries the 18-char value" \
   "$(rfield "$C17" violations)" "flags["
 assert_contains "AC3 NON-ZERO CONTROL: ...and quotes the offending value" \
   "$(rfield "$C17" violations)" "APPROVE_WITH_NOTES"
 assert_eq "AC3 NON-ZERO CONTROL: the corpus maximum is still the 18-char value this control rests on" \
   "$(rfield "$LIVE" longestvalue)/$(rfield "$LIVE" longest)" "APPROVE_WITH_NOTES/18"
 
-# BOTH FIELDS, mutated independently. At cap 17 only flags[] fires: events[] tops out at
-# REQUEST_CHANGES (15) and sits in the passing cell of the conjunction, so a control drawn from
-# the 17-cap alone never exercises the events[] branch at all.
+# BOTH FIELDS, mutated independently: a control drawn from one cap over the live corpus can leave
+# a whole branch unexercised, so "the check fired" would not say WHICH branch fired.
+#
+# DIRECTION decides what may rest on the live corpus. This FIRES cell may: the corpus only ever
+# grows by a run committing its own record, and an added record cannot remove a long verdict, so
+# no correct future run can silence it. Its old partner asserted the opposite direction -- that
+# the events[] branch was SILENT at cap 17 -- and a silence over a growing population is broken by
+# any record that adds a long value. One did, correctly: pipeline.md makes each events[] entry the
+# EXIT marker of the phase it closes, so a panel returning APPROVE_WITH_NOTES writes those 18
+# characters into events[], and #34's own completed record did exactly that. That cell is now
+# re-founded on the crafted pair below, where the population is fixed by this file.
 C14="$(verdict_report "$REPO_ROOT" 14)"
-assert_contains "AC3 FIXTURE MATRIX: at cap 14 the events[] branch fires too" \
+assert_contains "AC3 FIXTURE MATRIX: at cap 14 the events[] branch fires on the LIVE corpus" \
   "$(rfield "$C14" violations)" "events["
-assert_eq "AC3 FIXTURE MATRIX: and the events[] branch was silent at cap 17 (so the two cells differ)" \
-  "$(printf '%s' "$(rfield "$C17" violations)" | grep -c 'events\[' | tr -d ' ')" "0"
+
+# THE DISCRIMINATION, on trees this file builds. Each holds one crafted violator in ONE field and
+# one record shaped like a real completed run -- events[] AND flags[] both carrying the 18-char
+# APPROVE_WITH_NOTES that broke the old cell -- so the population already contains the case that
+# comes for it. One branch fires, the other is silent, in both directions: neither can be the
+# other's output mislabelled, and neither can mask the other.
+LONG_VERDICT="$(node -e 'process.stdout.write("A".repeat(Number(process.argv[1])+1))' "$LIVE_CAP")"
+assert_eq "CONTROL: the crafted violator is one character OVER the cap read from the schema (the fixture is the fixture it claims to be)" \
+  "${#LONG_VERDICT}" "$(( LIVE_CAP + 1 ))"
+new_tmpdir || exit 90
+SPLIT_EV="$NEW_TMPDIR"
+new_tmpdir || exit 90
+SPLIT_FL="$NEW_TMPDIR"
+COMPLETED_RUN='{"current_phase":"4-review-complete","events":[{"phase":"4-review","at":"x","verdict":"APPROVE_WITH_NOTES"}],"flags":[{"phase":"4-review","agent":"qa","at":"x","verdict":"APPROVE_WITH_NOTES"}]}'
+for split_root in "$SPLIT_EV" "$SPLIT_FL"; do
+  mkdir -p "$split_root/.pipeline/run"
+  printf '%s' "$COMPLETED_RUN" > "$split_root/.pipeline/run/status.json"
+done
+mkdir -p "$SPLIT_EV/.pipeline/ev" "$SPLIT_FL/.pipeline/fl"
+printf '{"current_phase":"3-impl","events":[{"phase":"3-impl","at":"x","verdict":"%s"}],"flags":[{"phase":"3-impl","agent":"dev","at":"x","verdict":"APPROVE"}]}' \
+  "$LONG_VERDICT" > "$SPLIT_EV/.pipeline/ev/status.json"
+printf '{"current_phase":"3-impl","events":[{"phase":"3-impl","at":"x","verdict":"APPROVE"}],"flags":[{"phase":"3-impl","agent":"dev","at":"x","verdict":"%s"}]}' \
+  "$LONG_VERDICT" > "$SPLIT_FL/.pipeline/fl/status.json"
+EV_ONLY="$(verdict_report "$SPLIT_EV" "$LIVE_CAP")"
+FL_ONLY="$(verdict_report "$SPLIT_FL" "$LIVE_CAP")"
+
+assert_contains "AC3 FIXTURE MATRIX: with the over-long value in events[], the events[] branch fires and NAMES it" \
+  "$(rfield "$EV_ONLY" violations)" ".pipeline/ev/status.json events[0]"
+assert_eq "AC3 FIXTURE MATRIX: ...and the flags[] branch is silent on that same tree" \
+  "$(printf '%s' "$(rfield "$EV_ONLY" violations)" | grep -c 'flags\[' | tr -d ' ')" "0"
+assert_contains "AC3 FIXTURE MATRIX: with the over-long value in flags[], the flags[] branch fires and NAMES it" \
+  "$(rfield "$FL_ONLY" violations)" ".pipeline/fl/status.json flags[0]"
+assert_eq "AC3 FIXTURE MATRIX: ...and the events[] branch is silent on that same tree (the two cells differ)" \
+  "$(printf '%s' "$(rfield "$FL_ONLY" violations)" | grep -c 'events\[' | tr -d ' ')" "0"
+# Each silence above is EARNED, not unvisited: four verdict strings per tree were read, and the
+# 18-char pair among them is the value a completed APPROVE_WITH_NOTES run writes. A walk that
+# stopped inspecting a branch would report the same silence and a smaller count -- which is the
+# one mutation the silence cells cannot see by themselves. The literal 4 is safe BECAUSE this
+# file owns the population outright: no pipeline run can add a record to these trees, so unlike
+# the corpus-anchored cell this replaced, only an edit HERE can move it.
+assert_eq "AC3 FIXTURE MATRIX: both branches were INSPECTED in the events[] tree (4 verdicts read)" \
+  "$(rfield "$EV_ONLY" verdicts)" "4"
+assert_eq "AC3 FIXTURE MATRIX: and in the flags[] tree too" \
+  "$(rfield "$FL_ONLY" verdicts)" "4"
+assert_eq "AC3 FIXTURE MATRIX: the completed-run record conforms in BOTH fields, so a real APPROVE_WITH_NOTES run cannot break these cells" \
+  "$(printf '%s' "$(rfield "$EV_ONLY" violations)$(rfield "$FL_ONLY" violations)" | grep -c 'pipeline/run/' | tr -d ' ')" "0"
 
 # The same two branches against CRAFTED records at the REAL cap, so the matrix does not depend on
 # lowering the cap to reach a cell.
 new_tmpdir || exit 90
 OVER_ROOT="$NEW_TMPDIR"
 mkdir -p "$OVER_ROOT/.pipeline/ev" "$OVER_ROOT/.pipeline/fl" "$OVER_ROOT/.pipeline/ok"
-LONG_VERDICT="$(node -e 'process.stdout.write("A".repeat(Number(process.argv[1])+1))' "$LIVE_CAP")"
 printf '{"current_phase":"3-impl","events":[{"phase":"3-impl","at":"x","verdict":"%s"}]}' "$LONG_VERDICT" \
   > "$OVER_ROOT/.pipeline/ev/status.json"
 printf '{"current_phase":"3-impl","events":[],"flags":[{"phase":"3-impl","agent":"dev","at":"x","verdict":"%s"}]}' "$LONG_VERDICT" \

--- a/plugins/pipeline/tests/test-status-schema-contract.sh
+++ b/plugins/pipeline/tests/test-status-schema-contract.sh
@@ -1,0 +1,475 @@
+#!/usr/bin/env bash
+# status.schema.json's own contract: the verdict cap (#34) and the current_phase example
+# list (#42).
+#
+# WHY THIS FILE EXISTS. status.schema.json has exactly ONE runtime reader -- voice-lint.mjs:224,
+# which reads properties.current_phase.pattern and nothing else. The file appears in no
+# AGENT_RULES entry in validate-pipeline-artifact.mjs, and that walker does not implement
+# maxLength at all, so a maxLength written into this schema refuses nothing by itself. Both
+# defects this suite pins are the same condition: a constraint nobody reads can be absent
+# (#34's unbounded verdict) or wrong (#42's rotted phase list) indefinitely with nothing going
+# red. So the reader is HERE. The population is the committed corpus, because that is the
+# population #34 cares about -- status.json is committed AND archived verbatim into the
+# knowledge store, so whatever lands in it lands in a public tree at full length.
+#
+# THE CAP IS READ FROM THE SCHEMA, NEVER COPIED. One site below holds the literal 32, and it is
+# the pin on the value the spec ruled (q2). Every assertion OVER THE CORPUS uses the value read
+# out of the schema, so changing the schema alone moves this suite's verdict. A test carrying
+# its own copy of 32 would stay green while the schema drifted away underneath it.
+
+. "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
+require_node
+
+make_temp_project || exit 90
+
+PLUGIN_DIR="$PLUGIN_ROOT"
+SCHEMA="$PLUGIN_DIR/schemas/status.schema.json"
+PIPELINE_MD="$PLUGIN_DIR/commands/pipeline.md"
+GUARD="$SCRIPTS_DIR/gate-phase-entry.mjs"
+VALIDATOR="$SCRIPTS_DIR/validate-pipeline-artifact.mjs"
+VOICE_LINT="$SCRIPTS_DIR/voice-lint.mjs"
+TESTS_DIR="$PLUGIN_DIR/tests"
+REPO_ROOT="$(cd "$PLUGIN_DIR/../.." && pwd)"
+
+# The corpus build is NOT reimplemented here. test-pipeline-telemetry.sh owns the one
+# marker-delimited helper (#30 D1) and test-corpus-union.sh drives it; a second build would be a
+# second population that can silently disagree with the first. The UNION matters for the same
+# reason it mattered there: a tracked-only walk cannot see an untracked in-flight record, and
+# the union can only ever WIDEN the population, never narrow it.
+BEGIN_MARK='# --- BEGIN corpus helper (issue #30 D1) ---'
+END_MARK='# --- END corpus helper ---'
+HELPER_SRC="$TEMP_PROJECT/corpus-helper.sh"
+awk -v b="$BEGIN_MARK" -v e="$END_MARK" '
+  index($0,b){inblk=1;next} index($0,e){inblk=0} inblk{print}' \
+  "$TESTS_DIR/test-pipeline-telemetry.sh" > "$HELPER_SRC"
+if [[ -s "$HELPER_SRC" ]]; then
+  # shellcheck disable=SC1090
+  . "$HELPER_SRC"
+fi
+
+# ---------------------------------------------------------------------------
+# The walker. Parameterised by CAP and by the file list, so the same code runs against the live
+# corpus and against crafted temp trees -- the cells are the only way to watch each conjunct
+# fail, and a conjunct nobody has watched fail is a claim.
+# ---------------------------------------------------------------------------
+WALKER="$TEMP_PROJECT/verdict-walk.cjs"
+cat > "$WALKER" <<'NODE'
+const fs = require("fs");
+const cap = Number(process.argv[2]);
+const files = process.argv.slice(3);
+if (!Number.isInteger(cap) || cap <= 0) {
+  process.stdout.write("caperror=" + JSON.stringify(process.argv[2]) + "\n");
+  process.exit(3);
+}
+const out = {
+  files: files.length, read: 0, verdicts: 0, longest: 0, longestvalue: "",
+  unreadable: [], badevents: [], badflags: [], violations: [],
+};
+for (const f of files) {
+  let s;
+  try { s = JSON.parse(fs.readFileSync(f, "utf8")); }
+  catch (e) {
+    // ACCOUNTED FOR, not skipped: `read` is asserted against the shell's own count, so a walk
+    // that continued past what it could not read cannot report a zero it did not earn.
+    out.unreadable.push(f + " (" + String(e.message).slice(0, 40) + ")");
+    continue;
+  }
+  out.read++;
+  if (!Array.isArray(s.events)) {
+    out.badevents.push(f + " (events is " + (s.events === undefined ? "absent" : typeof s.events) + ")");
+  }
+  if (s.flags !== undefined && !Array.isArray(s.flags)) {
+    out.badflags.push(f + " (flags is " + typeof s.flags + ")");
+  }
+  for (const field of ["events", "flags"]) {
+    const arr = s[field];
+    if (!Array.isArray(arr)) continue;
+    arr.forEach((entry, i) => {
+      const v = entry && entry.verdict;
+      // An ABSENT verdict is schema-valid and stays valid: the cap must not become a
+      // requirement. test-gate-phase-entry.sh:287 pins one live record whose event carries no
+      // verdict key at all, and a walk that counted absence as a violation would refuse it.
+      if (typeof v !== "string") return;
+      out.verdicts++;
+      if (v.length > out.longest) { out.longest = v.length; out.longestvalue = v; }
+      if (v.length > cap) {
+        out.violations.push(f + " " + field + "[" + i + "].verdict=" + JSON.stringify(v) +
+          " len=" + v.length + " cap=" + cap);
+      }
+    });
+  }
+}
+const flat = (v) => (Array.isArray(v) ? v.join(" ;; ") : String(v)).replace(/[\r\n]+/g, " ");
+let text = "";
+for (const k of ["files", "read", "verdicts", "longest", "longestvalue",
+                 "unreadable", "badevents", "badflags", "violations"]) {
+  text += k + "=" + flat(out[k]) + "\n";
+}
+process.stdout.write(text);
+NODE
+
+# verdict_report <root> <cap> -> KEY=VALUE lines
+verdict_report() {
+  local root="$1" cap="$2" files
+  files="$(corpus_files "$root" '.pipeline/*/status.json')"
+  # Word splitting on $files is deliberate: it is a newline-separated path list.
+  # shellcheck disable=SC2086
+  ( cd "$root" 2>/dev/null && node "$WALKER" "$cap" $files ) 2>/dev/null
+}
+
+# rfield <report> <key> -> the value, or a SENTINEL.
+# The sentinel goes on the REPORT and on the missing KEY, never on the value: every list this
+# suite asserts is asserted EMPTY, and empty is the passing state, so a `${x:-fallback}` on the
+# value would make those assertions unsatisfiable in the direction they assert. This is the
+# ac19_field discipline from test-gate-phase-entry.sh, and it is controlled below on this
+# function rather than assumed.
+rfield() {
+  local rep="$1" key="$2"
+  [[ -n "$rep" ]] || { printf '<no-report>'; return; }
+  printf '%s\n' "$rep" | grep -q "^$key=" || { printf '<no-field:%s>' "$key"; return; }
+  printf '%s\n' "$rep" | sed -n "s/^$key=//p"
+}
+
+# ---------------------------------------------------------------------------
+suite "the walker's own reporting (controls on the instrument, before any measurement)"
+# ---------------------------------------------------------------------------
+assert_eq "the corpus helper was extracted and is callable" \
+  "$(declare -f corpus_files >/dev/null 2>&1 && echo yes || echo no)" "yes"
+assert_eq "CONTROL: an absent report reads as <no-report>, never as an empty list" \
+  "$(rfield '' violations)" "<no-report>"
+assert_eq "CONTROL: a present report missing the key reads as <no-field:violations>" \
+  "$(rfield 'files=6
+read=6' violations)" "<no-field:violations>"
+assert_eq "CONTROL: and a present key with an empty list still reads as empty" \
+  "$(rfield 'violations=
+read=6' violations)" ""
+
+# ---------------------------------------------------------------------------
+suite "AC1: both verdict fields carry the cap, and each is pinned SEPARATELY"
+# ---------------------------------------------------------------------------
+# Separately, because "the schema contains maxLength" is satisfied by the events[] copy alone
+# and never notices that flags[] is bare -- which is the exact hole #34 shipped, since #34 names
+# only events[] while flags[] eight lines below carries the LONGER value.
+SCHEMA_FACTS="$(node -e '
+  const fs = require("fs");
+  const s = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const p = (x) => (x === undefined ? "<absent>" : String(x));
+  const ev = ((s.properties.events.items || {}).properties || {}).verdict || {};
+  const fl = ((s.properties.flags.items || {}).properties || {}).verdict || {};
+  const sum = ((s.properties.flags.items || {}).properties || {}).summary || {};
+  const desc = s.properties.current_phase.description || "";
+  const m = /^Examples:\s*([^]*?)\.\s/.exec(desc);
+  const list = m ? m[1].split(/\s*,\s*/).map((t) => t.trim()).filter(Boolean) : [];
+  process.stdout.write(
+    "events_cap=" + p(ev.maxLength) + "\n" +
+    "events_type=" + p(ev.type) + "\n" +
+    "events_desc=" + p(ev.description).replace(/[\r\n]+/g, " ") + "\n" +
+    "flags_cap=" + p(fl.maxLength) + "\n" +
+    "flags_type=" + p(fl.type) + "\n" +
+    "flags_desc=" + p(fl.description).replace(/[\r\n]+/g, " ") + "\n" +
+    "summary_cap=" + p(sum.maxLength) + "\n" +
+    "pattern=" + p(s.properties.current_phase.pattern) + "\n" +
+    "phaselist=" + list.join(" ") + "\n" +
+    "phasecount=" + list.length + "\n",
+  );
+' "$SCHEMA" 2>/dev/null)"
+assert_eq "status.schema.json parses as JSON at all" \
+  "$([[ -n "$SCHEMA_FACTS" ]] && echo parsed || echo "UNPARSEABLE or unreadable: $SCHEMA")" "parsed"
+
+# THE ONE SITE THAT HOLDS THE LITERAL. This is the pin on the ruled value (spec q2: 32 = the
+# 18-char longest DECLARED verdict plus headroom for a longer token, below the length of the
+# prose sentence the bound refuses). Every corpus assertion below reads the schema instead.
+assert_eq "AC1: events[].verdict is capped at the ruled 32" "$(rfield "$SCHEMA_FACTS" events_cap)" "32"
+assert_eq "AC1: flags[].verdict is capped at the ruled 32 (folded in by R2; #34 names only events[])" \
+  "$(rfield "$SCHEMA_FACTS" flags_cap)" "32"
+assert_eq "AC1: events[].verdict is still typed string" "$(rfield "$SCHEMA_FACTS" events_type)" "string"
+assert_eq "AC1: flags[].verdict is still typed string" "$(rfield "$SCHEMA_FACTS" flags_type)" "string"
+assert_eq "AC1: the two caps agree with each other" \
+  "$(rfield "$SCHEMA_FACTS" events_cap)" "$(rfield "$SCHEMA_FACTS" flags_cap)"
+
+# R6. The sentence is prose and no mutation tells an accurate sentence from an inaccurate one,
+# so what is asserted is that it is PRESENT on both capped fields -- and the machine-checkable
+# half of the claim is asserted separately, as an expiry, further down.
+assert_contains "R6: events[].verdict says plainly that nothing validates this file" \
+  "$(rfield "$SCHEMA_FACTS" events_desc)" "NOTHING VALIDATES status.json AGAINST THIS SCHEMA"
+assert_contains "R6: flags[].verdict says the same" \
+  "$(rfield "$SCHEMA_FACTS" flags_desc)" "nothing validates status.json against this schema"
+assert_eq "flags[].summary's pre-existing 140 cap is untouched" \
+  "$(rfield "$SCHEMA_FACTS" summary_cap)" "140"
+
+# ---------------------------------------------------------------------------
+suite "AC2: VACUITY CONTROL over the corpus, asserted BEFORE any property of it"
+# ---------------------------------------------------------------------------
+# The floor is DERIVED, never pinned to a number. A pinned 6 measures the branch this suite runs
+# on and not the repo: origin/main holds 5 committed records and this branch holds 6, because a
+# run commits its OWN status.json as it goes. The population is enumerated twice by independent
+# means -- git's index and the filesystem -- and the union of the two is the floor, so the floor
+# tracks whatever the tree actually holds and can only grow as runs land. What it refuses is the
+# case this project keeps re-breaking: a walk that found NOTHING and reported no problems.
+CORPUS_TRACKED_N="$(cd "$REPO_ROOT" && git ls-files '.pipeline/*/status.json' 2>/dev/null | grep -c . | tr -d ' ')"
+CORPUS_ONDISK_N="$(cd "$REPO_ROOT" && ls -1 .pipeline/*/status.json 2>/dev/null | grep -c . | tr -d ' ')"
+CORPUS_N="$(corpus_files "$REPO_ROOT" '.pipeline/*/status.json' | grep -c . | tr -d ' ')"
+CORPUS_FLOOR=$(( CORPUS_TRACKED_N > CORPUS_ONDISK_N ? CORPUS_TRACKED_N : CORPUS_ONDISK_N ))
+
+assert_eq "VACUITY CONTROL: git's index enumerates at least one committed status record" \
+  "$([[ "${CORPUS_TRACKED_N:-0}" -ge 1 ]] && echo enough || echo "ZERO tracked records: the walk has nothing to be right about")" "enough"
+assert_eq "VACUITY CONTROL: and the filesystem enumerates at least one too" \
+  "$([[ "${CORPUS_ONDISK_N:-0}" -ge 1 ]] && echo enough || echo "ZERO on-disk records")" "enough"
+assert_eq "VACUITY CONTROL: the union walk is at least as large as both enumerations (it may only WIDEN)" \
+  "$([[ "${CORPUS_N:-0}" -ge "$CORPUS_FLOOR" && "$CORPUS_FLOOR" -ge 1 ]] && echo enough || echo "union=$CORPUS_N floor=$CORPUS_FLOOR")" "enough"
+
+LIVE_CAP="$(rfield "$SCHEMA_FACTS" events_cap)"
+LIVE="$(verdict_report "$REPO_ROOT" "$LIVE_CAP")"
+assert_eq "the walk produced a report at all" \
+  "$([[ -n "$LIVE" ]] && echo reported || echo "NO REPORT: the walker did not run")" "reported"
+assert_eq "AC2: the walk READ every record the corpus listed (which is what makes the zeros below results)" \
+  "$(rfield "$LIVE" read)" "$CORPUS_N"
+assert_eq "AC2: every committed record parses" "$(rfield "$LIVE" unreadable)" ""
+assert_eq "AC2: and every one has events as an ARRAY (the shape conjunct, asserted apart from the count)" \
+  "$(rfield "$LIVE" badevents)" ""
+assert_eq "AC2: and flags, where present, is an array too" "$(rfield "$LIVE" badflags)" ""
+
+# The three cells of AC2's matrix, driven against crafted trees. The count conjunct and the two
+# shape conjuncts are mutated SEPARATELY: a fixture satisfying both hides whichever is broken.
+new_tmpdir || exit 90
+EMPTY_ROOT="$NEW_TMPDIR"
+mkdir -p "$EMPTY_ROOT/.pipeline"
+EMPTY_REPORT="$(verdict_report "$EMPTY_ROOT" "$LIVE_CAP")"
+assert_eq "CELL(zero records): the walk reports files=0 rather than passing green" \
+  "$(rfield "$EMPTY_REPORT" files)" "0"
+assert_eq "CELL(zero records): and the vacuity predicate this suite uses REFUSES that count" \
+  "$([[ "$(rfield "$EMPTY_REPORT" files)" -ge 1 ]] && echo enough || echo refused)" "refused"
+
+new_tmpdir || exit 90
+BAD_ROOT="$NEW_TMPDIR"
+mkdir -p "$BAD_ROOT/.pipeline/a" "$BAD_ROOT/.pipeline/b" "$BAD_ROOT/.pipeline/c"
+printf '{"current_phase":"3-impl","events":[]}' > "$BAD_ROOT/.pipeline/a/status.json"
+printf '{"current_phase":"3-impl","events":[' > "$BAD_ROOT/.pipeline/b/status.json"
+printf '{"current_phase":"3-impl","events":{"phase":"3-impl"}}' > "$BAD_ROOT/.pipeline/c/status.json"
+BAD_REPORT="$(verdict_report "$BAD_ROOT" "$LIVE_CAP")"
+assert_contains "CELL(unparseable record): the walk NAMES it instead of skipping past it" \
+  "$(rfield "$BAD_REPORT" unreadable)" ".pipeline/b/status.json"
+assert_eq "CELL(unparseable record): and read < files, so the shortfall is visible" \
+  "$([[ "$(rfield "$BAD_REPORT" read)" -lt "$(rfield "$BAD_REPORT" files)" ]] && echo short || echo "read=$(rfield "$BAD_REPORT" read) files=$(rfield "$BAD_REPORT" files)")" "short"
+assert_contains "CELL(events is an object, not an array): reported on the shape conjunct" \
+  "$(rfield "$BAD_REPORT" badevents)" ".pipeline/c/status.json"
+assert_eq "CELL: and the well-formed sibling is NOT reported (the control on the control)" \
+  "$(printf '%s' "$(rfield "$BAD_REPORT" badevents)" | grep -c 'pipeline/a/' | tr -d ' ')" "0"
+
+# ---------------------------------------------------------------------------
+suite "AC3/AC4: every committed verdict conforms to the cap READ FROM the schema"
+# ---------------------------------------------------------------------------
+assert_eq "AC4: the cap used below came out of the schema, not out of this file" \
+  "$([[ "$LIVE_CAP" =~ ^[0-9]+$ ]] && echo "read" || echo "NOT A NUMBER: $LIVE_CAP")" "read"
+assert_eq "AC3: no committed events[].verdict or flags[].verdict exceeds the cap" \
+  "$(rfield "$LIVE" violations)" ""
+# The zero above is EARNED here: an empty violations list is equally consistent with a walk that
+# inspected 26 verdicts and with one that inspected none.
+assert_eq "AC3: and the walk actually inspected verdict strings (which is what makes that zero a result)" \
+  "$([[ "$(rfield "$LIVE" verdicts)" -ge 1 ]] && echo inspected || echo "inspected NOTHING: verdicts=$(rfield "$LIVE" verdicts)")" "inspected"
+
+# THE NON-ZERO CONTROL, permanent and in-suite rather than a one-off an author ran once. At a cap
+# of 17 exactly one committed record violates, and the check must NAME it -- a check that reddens
+# without identifying the violator cannot be told apart from one that reddens because the walk
+# broke.
+#
+# EXPIRY, and it is a real one: this control is anchored to a LIVE record, and the correct fate of
+# a live record is that somebody edits or deletes it. If this assertion fails, check FIRST whether
+# .pipeline/17/status.json still carries APPROVE_WITH_NOTES; if it does not, this control has lost
+# its subject and needs re-anchoring to whatever the corpus maximum then is, NOT deleting.
+C17="$(verdict_report "$REPO_ROOT" 17)"
+assert_contains "AC3 NON-ZERO CONTROL: at cap 17 the check goes red and NAMES the file" \
+  "$(rfield "$C17" violations)" ".pipeline/17/status.json"
+assert_contains "AC3 NON-ZERO CONTROL: ...names the FLAGS entry, not an events entry" \
+  "$(rfield "$C17" violations)" "flags["
+assert_contains "AC3 NON-ZERO CONTROL: ...and quotes the offending value" \
+  "$(rfield "$C17" violations)" "APPROVE_WITH_NOTES"
+assert_eq "AC3 NON-ZERO CONTROL: the corpus maximum is still the 18-char value this control rests on" \
+  "$(rfield "$LIVE" longestvalue)/$(rfield "$LIVE" longest)" "APPROVE_WITH_NOTES/18"
+
+# BOTH FIELDS, mutated independently. At cap 17 only flags[] fires: events[] tops out at
+# REQUEST_CHANGES (15) and sits in the passing cell of the conjunction, so a control drawn from
+# the 17-cap alone never exercises the events[] branch at all.
+C14="$(verdict_report "$REPO_ROOT" 14)"
+assert_contains "AC3 FIXTURE MATRIX: at cap 14 the events[] branch fires too" \
+  "$(rfield "$C14" violations)" "events["
+assert_eq "AC3 FIXTURE MATRIX: and the events[] branch was silent at cap 17 (so the two cells differ)" \
+  "$(printf '%s' "$(rfield "$C17" violations)" | grep -c 'events\[' | tr -d ' ')" "0"
+
+# The same two branches against CRAFTED records at the REAL cap, so the matrix does not depend on
+# lowering the cap to reach a cell.
+new_tmpdir || exit 90
+OVER_ROOT="$NEW_TMPDIR"
+mkdir -p "$OVER_ROOT/.pipeline/ev" "$OVER_ROOT/.pipeline/fl" "$OVER_ROOT/.pipeline/ok"
+LONG_VERDICT="$(node -e 'process.stdout.write("A".repeat(Number(process.argv[1])+1))' "$LIVE_CAP")"
+printf '{"current_phase":"3-impl","events":[{"phase":"3-impl","at":"x","verdict":"%s"}]}' "$LONG_VERDICT" \
+  > "$OVER_ROOT/.pipeline/ev/status.json"
+printf '{"current_phase":"3-impl","events":[],"flags":[{"phase":"3-impl","agent":"dev","at":"x","verdict":"%s"}]}' "$LONG_VERDICT" \
+  > "$OVER_ROOT/.pipeline/fl/status.json"
+printf '{"current_phase":"3-impl","events":[{"phase":"3-impl","at":"x","verdict":"APPROVE_WITH_NOTES"}],"flags":[{"phase":"3-impl","agent":"dev","at":"x"}]}' \
+  > "$OVER_ROOT/.pipeline/ok/status.json"
+OVER="$(verdict_report "$OVER_ROOT" "$LIVE_CAP")"
+assert_contains "AC3 FIXTURE MATRIX: an over-long events[].verdict violates at the real cap" \
+  "$(rfield "$OVER" violations)" ".pipeline/ev/status.json events[0]"
+assert_contains "AC3 FIXTURE MATRIX: an over-long flags[].verdict violates at the real cap" \
+  "$(rfield "$OVER" violations)" ".pipeline/fl/status.json flags[0]"
+assert_eq "AC3 FIXTURE MATRIX: a conforming record and a verdict-LESS flag are not violations" \
+  "$(printf '%s' "$(rfield "$OVER" violations)" | grep -c 'pipeline/ok/' | tr -d ' ')" "0"
+assert_eq "the cap must not become a requirement: the verdict-less flag was simply not counted" \
+  "$(rfield "$OVER" verdicts)" "3"
+
+# ---------------------------------------------------------------------------
+suite "R6's machine-checkable half: the sentence's EXPIRY"
+# ---------------------------------------------------------------------------
+# The schema now says in prose that nothing validates status.json against it. Prose cannot be
+# mutated into falsity, but the fact underneath it can: the day someone registers status.json in
+# AGENT_RULES is the day that sentence becomes a lie, and this is the assertion that notices.
+AGENT_RULES_HITS="$(grep -c 'status\.schema\.json' "$VALIDATOR" | tr -d ' ')"
+assert_eq "EXPIRY: status.schema.json is still named nowhere in validate-pipeline-artifact.mjs. If this fails, status.json is now validated and the 'nothing validates this file' sentences in the schema must be DELETED, not this assertion." \
+  "$AGENT_RULES_HITS" "0"
+assert_eq "CONTROL: that grep can find the string when it is there (voice-lint.mjs does read the schema)" \
+  "$([[ "$(grep -c 'status\.schema\.json' "$VOICE_LINT" | tr -d ' ')" -ge 1 ]] && echo finds || echo "the grep finds NOTHING anywhere: it is measuring itself")" "finds"
+
+# ---------------------------------------------------------------------------
+suite "AC5: the current_phase example list, as SET EQUALITY against pipeline.md"
+# ---------------------------------------------------------------------------
+# Set equality in BOTH directions, not a substring grep. voice-lint.mjs's first phase table is the
+# recorded precedent: its drift test was `grep -q "\"$phase\"" src`, which a phase named in a
+# COMMENT satisfies, and the table invented four phases nothing writes and missed two real ones.
+#
+# Direction: the schema FOLLOWS pipeline.md, never the reverse. pipeline.md's current_phase writes
+# are the ground truth; the description is a hand-maintained second copy, which is the whole of
+# #42. `<phase>-error` is dropped because it is a TEMPLATE, not a literal, and is named in the
+# description as a shape instead. halted-error is ADDED because two other authorities bless it by
+# name while pipeline.md writes it nowhere -- see AC6.
+PIPELINE_PHASES="$(grep -o '"\?current_phase"\?: *"[^"]*"' "$PIPELINE_MD" \
+  | sed 's/.*: *"\(.*\)"/\1/' | grep -vx '<phase>-error' | LC_ALL=C sort -u)"
+EXPECTED_PHASES="$(printf '%s\nhalted-error\n' "$PIPELINE_PHASES" | grep -v '^$' | LC_ALL=C sort -u)"
+SCHEMA_PHASES="$(printf '%s' "$(rfield "$SCHEMA_FACTS" phaselist)" | tr ' ' '\n' | grep -v '^$' | LC_ALL=C sort -u)"
+EXPECTED_N="$(printf '%s\n' "$EXPECTED_PHASES" | grep -c . | tr -d ' ')"
+SCHEMA_N="$(printf '%s\n' "$SCHEMA_PHASES" | grep -c . | tr -d ' ')"
+
+# VACUITY, first: two empty sets are equal, and a broken grep on either side would prove nothing.
+assert_eq "VACUITY: pipeline.md yielded a non-empty phase vocabulary" \
+  "$([[ "${EXPECTED_N:-0}" -ge 10 ]] && echo enough || echo "ONLY $EXPECTED_N derived from pipeline.md")" "enough"
+assert_eq "VACUITY: and the description's Examples list parsed to a non-empty set" \
+  "$([[ "${SCHEMA_N:-0}" -ge 10 ]] && echo enough || echo "ONLY $SCHEMA_N parsed out of the description")" "enough"
+
+MISSING_FROM_SCHEMA="$(comm -23 <(printf '%s\n' "$EXPECTED_PHASES") <(printf '%s\n' "$SCHEMA_PHASES") | tr '\n' ' ' | sed 's/ *$//')"
+EXTRA_IN_SCHEMA="$(comm -13 <(printf '%s\n' "$EXPECTED_PHASES") <(printf '%s\n' "$SCHEMA_PHASES") | tr '\n' ' ' | sed 's/ *$//')"
+assert_eq "AC5 (direction 1): the description omits nothing pipeline.md writes" "$MISSING_FROM_SCHEMA" ""
+assert_eq "AC5 (direction 2): and blessed nothing pipeline.md does not write" "$EXTRA_IN_SCHEMA" ""
+
+# Both directions of the equality, controlled. Without these, "the two sets matched" is equally
+# consistent with a comparison that cannot report a difference at all.
+CTRL_ADDED="$(comm -13 <(printf '%s\n' "$EXPECTED_PHASES") <(printf '%s\n9-not-a-phase\n' "$SCHEMA_PHASES" | LC_ALL=C sort -u) | tr '\n' ' ' | sed 's/ *$//')"
+assert_eq "AC5 CONTROL: a bogus literal added to the list is reported in direction 2" \
+  "$CTRL_ADDED" "9-not-a-phase"
+CTRL_DROPPED="$(comm -23 <(printf '%s\n' "$EXPECTED_PHASES") <(printf '%s\n' "$SCHEMA_PHASES" | grep -vx '3-impl-complete') | tr '\n' ' ' | sed 's/ *$//')"
+assert_eq "AC5 CONTROL: a real literal dropped from the list is reported in direction 1" \
+  "$CTRL_DROPPED" "3-impl-complete"
+
+# ---------------------------------------------------------------------------
+suite "AC6: halted-error SURVIVES the de-rot (the negative control on the mechanical fix)"
+# ---------------------------------------------------------------------------
+# The obvious fix derives the list from pipeline.md and therefore DELETES halted-error, because
+# pipeline.md writes it nowhere. That would refuse correct work, and nothing would catch it: the
+# guard does not read the description.
+assert_eq "AC6: halted-error is still named in the description" \
+  "$(printf '%s\n' "$SCHEMA_PHASES" | grep -cx 'halted-error' | tr -d ' ')" "1"
+assert_eq "AC6: because pipeline.md still writes it NOWHERE (which is what makes deleting it tempting)" \
+  "$(printf '%s\n' "$PIPELINE_PHASES" | grep -cx 'halted-error' | tr -d ' ')" "0"
+assert_eq "AC6: and the guard still blesses it by name (gate-phase-entry.mjs)" \
+  "$([[ "$(grep -c 'halted-error' "$GUARD" | tr -d ' ')" -ge 1 ]] && echo blessed || echo "the guard no longer names it: re-open R3 before removing it here")" "blessed"
+assert_contains "AC6: and the schema's own pattern still alternates it" \
+  "$(rfield "$SCHEMA_FACTS" pattern)" "halted-error"
+
+# The description's list and the pattern voice-lint enforces must agree, or the schema blesses a
+# phase its own regex refuses. Asserted over the whole set, not a representative member.
+PATTERN_REJECTS="$(node -e '
+  const re = new RegExp(process.argv[1]);
+  const bad = process.argv.slice(2).filter((p) => !re.test(p));
+  process.stdout.write(bad.join(" "));
+' "$(rfield "$SCHEMA_FACTS" pattern)" $SCHEMA_PHASES 2>/dev/null)"
+assert_eq "every literal the description names is accepted by the pattern beside it" "$PATTERN_REJECTS" ""
+assert_eq "CONTROL: and that check can reject -- a malformed phase is refused by the same pattern" \
+  "$(node -e '
+    const re = new RegExp(process.argv[1]);
+    process.stdout.write(re.test("Phase_Three") ? "accepted" : "refused");
+  ' "$(rfield "$SCHEMA_FACTS" pattern)")" "refused"
+
+# ---------------------------------------------------------------------------
+suite "AC7: the two rotted literals are gone from the SCHEMA FILE"
+# ---------------------------------------------------------------------------
+# On the SCHEMA FILE specifically, never repo-wide: `3-scope-drift-adjudication` legitimately
+# survives at test-gate-phase-entry.sh:514 as a negative-control INPUT (pipeline.md still writes
+# it nowhere, which is exactly what makes it a good input), so a repo-wide grep is red before the
+# fix, red after it, and asserts nothing.
+assert_eq "AC7: 3-impl-verification-unverified appears nowhere in status.schema.json" \
+  "$(grep -c '3-impl-verification-unverified' "$SCHEMA" | tr -d ' ')" "0"
+assert_eq "AC7: 3-scope-drift-adjudication appears nowhere in status.schema.json" \
+  "$(grep -c '3-scope-drift-adjudication' "$SCHEMA" | tr -d ' ')" "0"
+assert_eq "AC7 CONTROL: and that literal is still present as a negative-control INPUT next door, which is why this assertion is file-scoped and not repo-wide" \
+  "$([[ "$(grep -c '3-scope-drift-adjudication' "$TESTS_DIR/test-gate-phase-entry.sh" | tr -d ' ')" -ge 1 ]] && echo present || echo "the input is gone: AC7 could now be repo-wide, and test-gate-phase-entry.sh's AC14 cell has lost its subject")" "present"
+
+# ---------------------------------------------------------------------------
+suite "AC8: UNCHANGED CONSUMER -- current_phase.pattern is byte-identical"
+# ---------------------------------------------------------------------------
+# voice-lint.mjs:224 reads exactly this one key out of this file and nothing else. Pinned by
+# VALUE, not by presence: a presence check survives any edit to the regex, which is the thing the
+# only runtime reader actually consumes. The literal below is the pre-change bytes.
+assert_eq "AC8: the pattern is byte-identical to its pre-change value" \
+  "$(rfield "$SCHEMA_FACTS" pattern)" '^([0-5](\.5)?-[a-z0-9-]+|halted-error)$'
+assert_contains "AC8: and voice-lint still reads it out of the schema rather than copying it" \
+  "$(cat "$VOICE_LINT")" 'schema?.properties?.current_phase?.pattern'
+
+# ---------------------------------------------------------------------------
+suite "AC10: the three rot comments read as HISTORY, not as a live claim"
+# ---------------------------------------------------------------------------
+# R3 makes the present-tense form of these comments false on landing -- evidence.md's "a control
+# anchored to a live defect has a shelf life", arriving on schedule.
+#
+# THE NEEDLE IS THE CLAIM SHAPE, not the phase literal. `3-scope-drift-adjudication` legitimately
+# survives next door as a negative-control input, so keying on it would be red before and after.
+# What dies is the pairing "status.schema.json ... <present tense: it names/blesses X>" on one
+# line, which is the form all three sites used. The counterpart phrase "pipeline.md never writes
+# it" is deliberately NOT part of the needle: that sentence is still TRUE, and still load-bearing,
+# for the control input at test-gate-phase-entry.sh:514.
+#
+# DISCOVERY IS THE test-*.sh GLOB, with ONE exemption. This suite is exempt because it is the file
+# that has to carry the needle and the pre-change wording in order to check them at all -- an
+# unexempted walk reports its own source and can never go green, which measures the checker rather
+# than the repo. The exemption is by basename and is the only one; a new suite is covered the day
+# it lands.
+AC10_NEEDLE='schema\.json.*bl[e]sses'
+AC10_VIOLATORS=""
+AC10_EXAMINED=0
+for f in "$TESTS_DIR"/test-*.sh; do
+  [[ -f "$f" ]] || continue
+  [[ "$(basename "$f")" == "test-status-schema-contract.sh" ]] && continue
+  AC10_EXAMINED=$((AC10_EXAMINED + 1))
+  if grep -qn "$AC10_NEEDLE" "$f"; then
+    AC10_VIOLATORS="$AC10_VIOLATORS $(basename "$f"):$(grep -n "$AC10_NEEDLE" "$f" | head -1 | cut -d: -f1)"
+  fi
+done
+assert_eq "AC10: no suite still claims in the present tense that the schema names an unwritten phase" \
+  "${AC10_VIOLATORS:-none}" "none"
+assert_eq "AC10: and the walk examined the suites rather than passing against an empty glob" \
+  "$([[ "$AC10_EXAMINED" -ge 8 ]] && echo ok || echo "only $AC10_EXAMINED examined")" "ok"
+# The control is the three sites' ACTUAL pre-change wording, one cell each, because a needle
+# proven against one hand-written line proves nothing about the other two.
+AC10_WAS_1="# insufficient: status.schema.json:13's own description blesses \`3-scope-drift-adjudication\`"
+AC10_WAS_2="# The live case, not a hypothetical: status.schema.json:13's own description blesses"
+AC10_WAS_3="# Prose alone is provably insufficient: status.schema.json:13 blesses two phases pipeline.md"
+for w in "$AC10_WAS_1" "$AC10_WAS_2" "$AC10_WAS_3"; do
+  assert_eq "AC10 CONTROL: the needle fires on the pre-change wording -- ${w:0:44}..." \
+    "$(printf '%s\n' "$w" | grep -c "$AC10_NEEDLE" | tr -d ' ')" "1"
+done
+assert_eq "AC10 CONTROL: and it does NOT fire on the surviving true sentence about the control input" \
+  "$(printf '%s\n' "# pipeline.md still writes 3-scope-drift-adjudication nowhere, so it stays a valid input" | grep -c "$AC10_NEEDLE" | tr -d ' ')" "0"
+for f in test-gate-phase-entry-drift.sh test-gate-phase-entry.sh; do
+  assert_eq "AC10: $f restates the rot as history naming #42" \
+    "$([[ "$(grep -c 'until #42\|#42' "$TESTS_DIR/$f" | tr -d ' ')" -ge 1 ]] && echo anchored || echo "no #42 reference: the comment was deleted rather than re-anchored")" "anchored"
+done
+
+finish


### PR DESCRIPTION
Two edits to `plugins/pipeline/schemas/status.schema.json`, plus the test that makes the first one load-bearing.

## What was wrong

`events[].verdict` and `flags[].verdict` were bare `{"type": "string"}` in a file that is committed to git AND archived verbatim into the knowledge store, so any prose an agent wrote into them reached a public tree at full length. Separately, `current_phase`'s hand-maintained example list had rotted: it named two phases `commands/pipeline.md` never writes, and omitted six it does.

Both are the same underlying condition. `status.schema.json` has exactly one runtime reader — `voice-lint.mjs:224`, which reads `properties.current_phase.pattern` and nothing else — so a constraint written into this file can be wrong or absent indefinitely with nothing going red.

## Correcting #34's premise

#34 says of `flags[].summary`'s `maxLength: 140` that "the mechanism exists; it was simply never applied here." It does not exist. `status.schema.json` appears in no `AGENT_RULES` entry in `validate-pipeline-artifact.mjs`, and that walker does not implement `maxLength` at all; `voice-lint.mjs:238` puts it in one sentence — "Nothing else validates this file." The 140-cap is honored only because `pipeline.md` restates it as a writer rule.

So a `maxLength` shipped alone here would be a comment, not a guard. Two consequences in this PR: each capped field's `description` now says outright that nothing validates `status.json` against this schema, so a later reader does not mistake the cap for an enforced control and skip writing the enforcement; and a corpus-conformance test makes the cap load-bearing against the population #34 actually cares about — the committed records that reach the public tree.

## The changes

**The cap: 32 on both verdict fields.** Derived, not round: 18 from the longest member of the DECLARED verdict vocabulary across all four artifact schemas (`APPROVE_WITH_NOTES`), plus headroom for any longer SCREAMING_SNAKE token, sitting below the length of the prose sentence the bound actually refuses. `flags[].verdict` is capped alongside `events[].verdict` rather than deferred: #34 names only `events[]`, but `flags[]` is the same field name in the same file under the same archive-verbatim mechanism and carries the LONGER of the two observed values (18 vs 15), so deferring would have left the bigger half open while closing the smaller. Zero of 6 committed records and zero of 26 verdict-carrying entries are retroactively invalidated. An absent `verdict` stays valid — the cap must not become a requirement, and one live record depends on that.

**The phase list.** Now exactly the literals `pipeline.md` writes, plus `halted-error`, with the `<phase>-error` family named as a SHAPE rather than enumerated. `halted-error` is the trap: `pipeline.md` writes it nowhere, so a list mechanically derived from `pipeline.md` alone deletes it — yet the schema's own `pattern` alternates it and `gate-phase-entry.mjs:241` is `if (phase === "halted-error") return true;`. Removing it would refuse correct work, and nothing would have caught it, because the guard does not read the description.

**`properties.current_phase.pattern` is untouched** and pinned byte-identical, since it is the one key the schema's only runtime reader consumes.

**Three test comments re-anchored.** `test-gate-phase-entry-drift.sh:13`, `test-gate-phase-entry.sh:511` and `:711` cited the rotted list as LIVE present-tense evidence. All three became false on landing, so they are restated as history naming #42. The negative-control INPUT at `test-gate-phase-entry.sh:514` is byte-unchanged: `pipeline.md` still writes `3-scope-drift-adjudication` nowhere, so it remains a phase the guard can genuinely meet and must not refuse.

## The new suite

`plugins/pipeline/tests/test-status-schema-contract.sh`, 67 assertions. It reuses the existing `#30` union corpus helper rather than building a second population.

- **The cap is READ FROM the schema** at every corpus assertion. Exactly one site holds the literal `32`, as the pin on the ruled value. A test carrying its own copy would stay green while the schema drifted away underneath it.
- **A vacuity control runs before any property of the corpus is asserted.** The floor is derived from two independent enumerations (git's index and the filesystem) and is never a pinned integer — `origin/main` holds 5 committed records and this branch holds 6, so a pinned `6` would measure the branch rather than the repo. A walk that returns zero FAILS; it does not pass green.
- **A permanent non-zero control** drops the cap to 17 and requires the check to go red and NAME `.pipeline/17/status.json`'s `APPROVE_WITH_NOTES`. It carries its own expiry in the assertion message, because it is anchored to a live record and the correct fate of a live record is that somebody edits it.
- **Set equality in both directions** against `pipeline.md`, with a control per direction, plus vacuity floors on both sets.

## Evidence

Twelve mutations, applied after the commits landed and restored from git, each printing the changed line as proof it applied (one silently failed to apply on the first attempt and was caught by exactly that step):

| Mutation | Result |
|---|---|
| cap 32 → 17 (schema only) | RED: `.pipeline/17/status.json flags[4].verdict="APPROVE_WITH_NOTES" len=18 cap=17` |
| delete `flags[].verdict` cap only | RED on the flags pin, events pin green |
| delete `events[].verdict` cap only | RED on the events pin, flags pin green |
| add a bogus literal to the list | RED, direction 2 |
| delete a real literal from the list | RED, direction 1 |
| remove `halted-error` | RED (this is the mutation the naive fix performs) |
| re-insert `3-scope-drift-adjudication` | RED, file-scoped |
| `pattern` `[0-5]` → `[0-6]` | RED, byte comparison |
| restore a comment to present tense | RED, names the file:line |
| delete one assertion from the suite | 67 → 66 with `failed=0` — #47's failure mode, caught only by the count |

**One mutation SURVIVES, deliberately:** raising the cap 32 → 64 leaves the corpus-conformance assertion GREEN. It should. The corpus maximum is 18, so no committed record can distinguish 32 from 64 — AC3 constrains the cap from below (via the 17 control) and not from above. A battery in which every mutation reddens cannot tell coverage from a rubber stamp.

`bash plugins/pipeline/tests/run.sh`: **2056 assertions, failed=0, exit 0.** Pre-change was **1989** at `4a6f164`; both measured on the same macOS host (Darwin 25.5.0 x86_64), per #47's real 32-assertion macOS/ubuntu gap. The +67 delta is exactly the new suite's standalone count, so no pre-existing suite lost an assertion. The numbers are recorded in `impl-report.json` with their platform and population rather than pinned into a test, per #33.

`test-voice-lint.sh` (the only runtime consumer's suite) is green at 41/0, and its non-zero control was run rather than assumed: a malformed `current_phase` still exits 2 and still names `status.schema.json`, and well-formed phases stay silent.

## Known limits, stated rather than implied

- The corpus floor does not catch a record deleted from BOTH the index and the disk; both enumerations fall together. The alternative is a pinned integer, which decays (#33) and here would measure the branch.
- The cap is still unenforced at WRITE time. Registering `status.json` in `AGENT_RULES` is a new enforcement surface with its own fail-open/fail-closed design, and implementing `maxLength` in the walker would change every schema at once — both out of scope. What this buys is that such a value cannot survive a run of the checkCommand unnoticed.
- The new suite exempts its own file from the present-tense grep, because it must carry both the needle and the pre-change wording to check them at all.

Closes #34
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)