### PR TITLE
fix: an mtime tie resolves to no active issue, not to readdir order (#27)

### DIFF
--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -29,6 +29,16 @@
  *     able to NARROW the subject: pointing it at a satisfied dir would be the env-var opt-out
  *     the design rejected, and it would leave no trace in the archived record. So both the
  *     signal-named dir and the mtime-derived dir are evaluated, and EITHER may refuse (R6b).
+ *   - A TIE in that mtime fallback resolves to NO subject, and this guard then falls silent.
+ *     Stated as a limitation rather than left to be discovered, because it is a DISARM VECTOR
+ *     that nobody has to choose: a fresh `git clone` writes every tracked status.json inside a
+ *     single coarse-clock tick on Linux, so all of them share one mtime and the seam abstains
+ *     (#27). The alternative was judging a run on a dir picked by readdirSync order, which is
+ *     what this used to do -- and which made the subject a property of the filesystem rather
+ *     than of the tree. Abstaining is the accepted trade: this guard would rather judge nothing
+ *     than judge a run the session does not own. It lands on the fail-open tooling branch R11
+ *     already declares ("no resolvable active issue"), so the fail-direction split is unchanged.
+ *     Pinned by AC14 cell (c) in tests/test-gate-phase-entry.sh, with a control.
  *
  * FAIL-DIRECTION SPLIT (R11), which is a contract change to a hook that declares itself
  * fail-open, so it is stated in both places. The DECISION is fail-CLOSED: a recognised phase

--- a/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
+++ b/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
@@ -295,10 +295,14 @@ function issueDirs(pipelineDir) {
 //       exists in this root; a signal that is non-numeric or names an absent dir is ignored,
 //       so a stale or malformed env var cannot misdirect the sweep (it falls back to (b)).
 //   (b) the newest status.json mtime among the numeric issue dirs in this root -- the "which
-//       issue is active" mechanism, and the path exercised in normal use.
+//       issue is active" mechanism, and the path exercised in normal use. It must be a STRICT
+//       winner: if two dirs share the newest mtime the scan has not identified an issue, it has
+//       only proved it cannot, so a tie resolves to (c) rather than to either candidate.
 //   (c) neither resolves: return null. The caller then validates nothing in this root
 //       (fail-open): an ad-hoc or non-pipeline session owns no issue dir and must never be
-//       blocked by artifacts it did not write.
+//       blocked by artifacts it did not write. A tie under (b) lands here for the same reason
+//       -- the cost of guessing wrong is blocking a stop for an issue this session never
+//       touched, and there is no evidence available to guess from.
 function activeIssueName(input) {
   const raw =
     (input && input.active_issue) ||
@@ -327,6 +331,7 @@ export function activeIssueDir(pipelineDir, input) {
   }
   let newest = null;
   let newestMtime = -Infinity;
+  let tiedAtNewest = false;
   for (const dir of issueDirs(pipelineDir)) {
     let st;
     try {
@@ -337,9 +342,25 @@ export function activeIssueDir(pipelineDir, input) {
     if (st.mtimeMs > newestMtime) {
       newestMtime = st.mtimeMs;
       newest = dir;
+      tiedAtNewest = false;
+    } else if (st.mtimeMs === newestMtime) {
+      tiedAtNewest = true;
     }
   }
-  return newest; // null when no signal and no status.json anywhere: fail-open
+  // A TIE at the newest mtime is the ABSENCE of a signal, not a weaker one, so it resolves the
+  // same way absence does: null. Both are order-independent -- a strict max does not depend on
+  // enumeration order, and a tie is detected whichever order it arrives in -- which is the
+  // point. Previously the winner of a tie was decided by readdirSync order: hash order on ext4,
+  // roughly insertion order on APFS. That made "which issue is active" a property of the
+  // filesystem, and it is reachable in production, not just in theory: a fresh `git clone`
+  // writes every tracked .pipeline/<issue>/status.json within a few milliseconds, and Linux
+  // stamps file times from a clock that ticks coarser than that, so they land on the identical
+  // mtime and RECENT_MS (30min) does not filter them out. Picking one would be inventing
+  // evidence the scan does not have -- and picking the wrong one blocks a stop, or refuses a
+  // phase entry, for work this session never touched, which is the exact harm the scoping in
+  // this function exists to prevent. Precedence (a) is unaffected: an explicit signal still
+  // resolves, ties or no ties.
+  return tiedAtNewest ? null : newest;
 }
 
 function loadJson(file) {
@@ -1034,13 +1055,26 @@ function selfTest() {
       mkdirSync(schemasDir, { recursive: true });
       mkdirSync(archived, { recursive: true });
       writeFileSync(path.join(issue, "status.json"), JSON.stringify({ issue_number: 1965 }));
-      // Give the NON-issue dirs a NEWER status.json so, absent the numeric guard, the mtime scan
-      // would wrongly select them over the real issue dir.
       writeFileSync(path.join(schemasDir, "status.json"), JSON.stringify({ x: 1 }));
       writeFileSync(path.join(archived, "status.json"), JSON.stringify({ x: 1 }));
-      const later = (Date.now() + 5000) / 1000;
-      utimesSync(path.join(schemasDir, "status.json"), later, later);
-      utimesSync(path.join(archived, "status.json"), later, later);
+
+      // EVERY mtime this block's expectations depend on is stamped explicitly, with seconds of
+      // margin, because two files written microseconds apart do NOT reliably differ in mtime:
+      // Linux stamps from a coarse clock that ticks every few milliseconds, so both writes can
+      // land on the IDENTICAL timestamp, while APFS resolves them apart. activeIssueDir breaks a
+      // tie by readdir order, so leaving the ordering to the host meant the exp- rejection cases
+      // below resolved by whatever readdir returned first -- green on macOS, red as a group on
+      // ubuntu-latest, at a fixed commit. That is issue #27. Ordering is a property of this
+      // fixture now, not of the machine it runs on.
+      const now = Date.now();
+      const stamp = (file, ms) => utimesSync(file, ms / 1000, ms / 1000);
+      // The NON-issue dirs are the NEWEST, so absent the numeric guard the mtime scan would
+      // wrongly select them over the real issue dir.
+      stamp(path.join(schemasDir, "status.json"), now + 5000);
+      stamp(path.join(archived, "status.json"), now + 5000);
+      // The numeric issue dir is deliberately the OLDEST dir the guard admits, so that once
+      // exp-two-owner-gates exists below, the fallback target is unambiguous.
+      stamp(path.join(issue, "status.json"), now - 10_000);
 
       delete process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE;
       delete process.env.PIPELINE_ACTIVE_ISSUE;
@@ -1061,22 +1095,133 @@ function selfTest() {
       const expDir = path.join(pipe, "exp-two-owner-gates");
       mkdirSync(expDir, { recursive: true });
       writeFileSync(path.join(expDir, "status.json"), JSON.stringify({ current_phase: "1-ba" }));
+      stamp(path.join(expDir, "status.json"), now);
       check("active-issue: an exp-<slug> marker resolves its dir",
         activeIssueDir(pipe, { active_issue: "exp-two-owner-gates" }) === expDir ? [] : ["expected exp- marker to resolve"], false);
-      // These assert against expDir, not `issue`: expDir's status.json is now the newest in the
-      // root, so it is what the mtime fallback legitimately resolves to. What each case proves
-      // is that the MALFORMED MARKER was rejected and the fallback ran at all, which is why the
-      // basename check below carries the actual claim.
+
+      // A malformed marker must be rejected on BOTH paths, so plant a real directory for each
+      // one that can be a literal name (and, for the traversal case, at the path the marker
+      // would reach if honored: "exp-a/../b" joins to "<pipe>/b"). Each is stamped NEWEST of
+      // all, so a regex widened to admit any of these shapes fails loudly twice over -- the
+      // marker path would resolve to it, and the mtime scan would start selecting it. Without
+      // these, a rejected marker and an honored-but-absent one are indistinguishable: both
+      // fall through to the same mtime result, so the cases could not fail on what they name.
+      for (const planted of ["exp-", "exp-Two-Owner", "exp--bad", "b"]) {
+        const dir = path.join(pipe, planted);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(path.join(dir, "status.json"), JSON.stringify({ x: 1 }));
+        stamp(path.join(dir, "status.json"), now + 8000);
+      }
+
+      // The fixture's mtime ordering, asserted ONCE and on its own. Every rejection case below
+      // needs the fallback to land somewhere predictable, but not one of them is a claim about
+      // WHICH dir that is -- so that claim lives here, where breaking it reddens a single case
+      // saying exactly that. Previously it was welded into all four: the message read
+      // "expected exp- to be rejected ... got <dir>/1965" when 1965 WAS the mtime fallback and
+      // the marker HAD been rejected correctly, so a tiebreak flake read as a rejection bug.
+      check("active-issue: with no marker, the newest admitted dir wins the mtime scan",
+        activeIssueDir(pipe, {}) === expDir
+          ? []
+          : [`expected the mtime fallback to pick ${expDir}, got ${activeIssueDir(pipe, {})}`], false);
+
+      // Stated against the no-marker result rather than against expDir by name, so this claim
+      // holds whatever the mtime scan picks. That independence is the point: this is the half
+      // that was never flaky, and it can no longer be reddened by the half that was.
       const rejects = (marker) => {
         const got = activeIssueDir(pipe, { active_issue: marker });
-        return got === expDir && path.basename(got) !== marker
-          ? []
-          : [`expected "${marker}" to be rejected and fall back to mtime, got ${got}`];
+        const bare = activeIssueDir(pipe, {});
+        if (got !== bare) {
+          return [`marker "${marker}" was HONORED: it steered resolution to ${got}, but with no marker at all resolution is ${bare}`];
+        }
+        if (path.basename(String(got)) === marker) {
+          return [`marker "${marker}" resolved to a directory of its own name: ${got}`];
+        }
+        return [];
       };
       check("active-issue: a bare 'exp-' with no slug is rejected", rejects("exp-"), false);
       check("active-issue: an exp- marker with a separator is rejected (traversal guard)", rejects("exp-a/../b"), false);
       check("active-issue: an uppercase exp- marker is rejected (convention is kebab)", rejects("exp-Two-Owner"), false);
       check("active-issue: a double-hyphen exp- marker is rejected", rejects("exp--bad"), false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      if (prevEnv.a === undefined) delete process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE;
+      else process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE = prevEnv.a;
+      if (prevEnv.b === undefined) delete process.env.PIPELINE_ACTIVE_ISSUE;
+      else process.env.PIPELINE_ACTIVE_ISSUE = prevEnv.b;
+    }
+  }
+
+  // ---- active-issue scoping: an mtime TIE is not a signal ----
+  // The tie rule is a deliberate semantic, so it is pinned here rather than left to emerge from
+  // enumeration order. Every mtime below is stamped explicitly: a fixture that wrote these files
+  // and hoped they landed on different timestamps would be testing the host's clock granularity,
+  // which is the bug this rule exists to answer (#27).
+  {
+    const root = mkdtempSync(path.join(tmpdir(), "vpa-tie-"));
+    const prevEnv = { a: process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE, b: process.env.PIPELINE_ACTIVE_ISSUE };
+    try {
+      delete process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE;
+      delete process.env.PIPELINE_ACTIVE_ISSUE;
+      const now = Date.now();
+      const stamp = (file, ms) => utimesSync(file, ms / 1000, ms / 1000);
+      // Build a root of issue dirs and stamp each status.json to an exact millisecond.
+      const build = (name, spec) => {
+        const pipe = path.join(root, name, ".pipeline");
+        const dirs = {};
+        for (const [issue, offsetMs] of Object.entries(spec)) {
+          const dir = path.join(pipe, issue);
+          mkdirSync(dir, { recursive: true });
+          writeFileSync(path.join(dir, "status.json"), JSON.stringify({ issue_number: Number(issue) }));
+          stamp(path.join(dir, "status.json"), now + offsetMs);
+          dirs[issue] = dir;
+        }
+        return { pipe, dirs };
+      };
+
+      // The production shape: a fresh clone writes every tracked status.json in one go, so on a
+      // host whose timestamps are coarser than the write burst they all land on one mtime.
+      const tie = build("tie", { 1965: 0, 1964: 0 });
+      check("active-issue: two dirs tied at the newest mtime resolve to null (a tie is not a signal)",
+        activeIssueDir(tie.pipe, {}) === null
+          ? []
+          : [`expected null for a tie, got ${activeIssueDir(tie.pipe, {})}`], false);
+
+      // CONTROL for the case above: the same fixture, one dir bumped a single millisecond clear,
+      // must resolve. Without this, a resolver that returned null unconditionally would pass.
+      const strict = build("strict", { 1965: 1, 1964: 0 });
+      check("active-issue: CONTROL a one-millisecond strict winner still resolves",
+        activeIssueDir(strict.pipe, {}) === strict.dirs[1965]
+          ? []
+          : [`expected ${strict.dirs[1965]}, got ${activeIssueDir(strict.pipe, {})}`], false);
+
+      // Only a tie AT THE TOP is ambiguous. Two stale dirs sharing an mtime say nothing about
+      // the one dir that is strictly newer than both.
+      const below = build("below", { 1965: 5000, 1964: 0, 1963: 0 });
+      check("active-issue: a tie BELOW the newest does not suppress a strict winner",
+        activeIssueDir(below.pipe, {}) === below.dirs[1965]
+          ? []
+          : [`expected ${below.dirs[1965]}, got ${activeIssueDir(below.pipe, {})}`], false);
+
+      const three = build("three", { 1965: 0, 1964: 0, 1963: 0 });
+      check("active-issue: a three-way tie at the newest resolves to null",
+        activeIssueDir(three.pipe, {}) === null
+          ? []
+          : [`expected null for a three-way tie, got ${activeIssueDir(three.pipe, {})}`], false);
+
+      // Precedence (a) is untouched by the tie rule: an explicit signal is evidence the scan
+      // does not have, so it resolves through an ambiguity that would otherwise abstain. This is
+      // what keeps the rule from weakening a run that names its issue.
+      check("active-issue: an explicit marker still resolves through an ambiguous mtime scan",
+        activeIssueDir(tie.pipe, { active_issue: "1965" }) === tie.dirs[1965]
+          ? []
+          : [`expected the marker to win, got ${activeIssueDir(tie.pipe, { active_issue: "1965" })}`], false);
+
+      // ...but a marker naming a dir that is not here is not evidence either: it falls through
+      // to the scan, which is still tied, so the answer is still null.
+      check("active-issue: a marker for an absent dir does NOT rescue a tie",
+        activeIssueDir(tie.pipe, { active_issue: "9999" }) === null
+          ? []
+          : [`expected null, got ${activeIssueDir(tie.pipe, { active_issue: "9999" })}`], false);
     } finally {
       rmSync(root, { recursive: true, force: true });
       if (prevEnv.a === undefined) delete process.env.CLAUDE_PIPELINE_ACTIVE_ISSUE;

--- a/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
+++ b/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
@@ -271,7 +271,12 @@ function pipelineDirs(input, rootsOverride) {
 // "experiment runs never block" carve-out for the open-questions gate, that meant BOTH halves
 // of a gate went inert on exactly the runs nobody is watching. The alternation stays anchored
 // and separator-free, so `..`, `a/b`, `schemas` and `_archived` are all still rejected.
-const ISSUE_DIR_RE = /^(\d+|exp-[a-z0-9]+(-[a-z0-9]+)*)$/;
+// EXPORTED so the other consumers of this vocabulary import it rather than restate it.
+// voice-lint.mjs used to carry its own /^\d+$/ copy, which is how `exp-` runs ended up
+// invisible to the voice check long after this alternation was widened to admit them: the
+// second copy could not be widened by widening the first. A shared constant makes that drift
+// structurally impossible rather than merely tested for.
+export const ISSUE_DIR_RE = /^(\d+|exp-[a-z0-9]+(-[a-z0-9]+)*)$/;
 
 function issueDirs(pipelineDir) {
   try {

--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -45,10 +45,16 @@ import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isMain as isMainScript } from "./lib.mjs";
+// IMPORTED, never restated. This file used to declare its own /^\d+$/, which silently exempted
+// `exp-<slug>` experiment runs from the voice check: the pattern did not match, resolveStatus
+// found no active issue, and the lint went quiet on exactly the runs nobody is watching. That
+// is the same defect, in the same shape, that widening the validator's own pattern fixed for
+// artifact validation, and that AC17 in test-gate-phase-entry.sh pins for the phase-entry
+// guard ("exp-<slug> runs are GUARDED, not exempt"). Sharing the constant is what stops a
+// third copy from drifting away again.
+import { ISSUE_DIR_RE } from "./validate-pipeline-artifact.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-
-const ISSUE_DIR_RE = /^\d+$/;
 
 // current_phase -> what voice.md requires of the message that accompanies it.
 //
@@ -112,9 +118,8 @@ function readJson(file) {
  * including its rule that a TIE at the newest mtime resolves to null rather than to either
  * candidate -- see activeIssueDir in validate-pipeline-artifact.mjs for why (#27: readdirSync
  * order is hash order on ext4 and insertion order on APFS, so a tie picked the subject by
- * filesystem). It does NOT mirror the validator's issue-dir VOCABULARY: ISSUE_DIR_RE here is
- * numeric-only, so `exp-<slug>` experiment runs are invisible to the voice check. That
- * divergence predates the tie rule and is not resolved by it.
+ * filesystem), and its issue-dir VOCABULARY, which is now the validator's exported
+ * ISSUE_DIR_RE imported above rather than a second copy that could drift from it.
  */
 export function resolveStatus(projectDir, envIssue) {
   const base = path.join(projectDir, ".pipeline");

--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -105,7 +105,17 @@ function readJson(file) {
   }
 }
 
-/** Newest issue dir holding a status.json, or null. Mirrors the validator's resolution order. */
+/**
+ * Newest issue dir holding a status.json, or null.
+ *
+ * Mirrors the validator's resolution ORDER (explicit signal, then newest mtime, then null),
+ * including its rule that a TIE at the newest mtime resolves to null rather than to either
+ * candidate -- see activeIssueDir in validate-pipeline-artifact.mjs for why (#27: readdirSync
+ * order is hash order on ext4 and insertion order on APFS, so a tie picked the subject by
+ * filesystem). It does NOT mirror the validator's issue-dir VOCABULARY: ISSUE_DIR_RE here is
+ * numeric-only, so `exp-<slug>` experiment runs are invisible to the voice check. That
+ * divergence predates the tie rule and is not resolved by it.
+ */
 export function resolveStatus(projectDir, envIssue) {
   const base = path.join(projectDir, ".pipeline");
   if (!existsSync(base)) return null;
@@ -115,6 +125,7 @@ export function resolveStatus(projectDir, envIssue) {
   }
   let newest = null;
   let newestMs = -1;
+  let tiedAtNewest = false;
   let entries;
   try {
     entries = readdirSync(base, { withFileTypes: true });
@@ -134,8 +145,15 @@ export function resolveStatus(projectDir, envIssue) {
     if (ms > newestMs) {
       newestMs = ms;
       newest = f;
+      tiedAtNewest = false;
+    } else if (ms === newestMs) {
+      tiedAtNewest = true;
     }
   }
+  // A tie is the absence of a signal, not a weaker one: abstain rather than let readdir order
+  // decide whose run gets voice-checked. The caller treats a null status as "no phase", which
+  // is already its fail-open path.
+  if (tiedAtNewest) return null;
   return newest ? readJson(newest) : null;
 }
 

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -375,6 +375,14 @@ suite "AC27: the two suites that already own this hook are UNCHANGED consumers"
 # ---------------------------------------------------------------------------
 # Recorded at f6ba1c4, BEFORE this contract was authored. Exact counts, not just failed=0: a
 # suite that silently stopped running half its cases also reports failed=0.
+#
+# RE-BASELINED ONCE, deliberately, and the reason is recorded because a number bumped without
+# one turns this assertion into a rubber stamp: test-voice-lint.sh went 41 -> 48 when #27 gave
+# voice-lint.mjs the validator's exported ISSUE_DIR_RE, closing the gap where an `exp-<slug>`
+# experiment run resolved to no active issue and was therefore never voice-checked at all. The
+# +7 is one new suite block ("exp-<slug> runs are LINTED, not exempt"): 4 behavioural cases and
+# 3 controls. Nothing existing was removed or renumbered, which is the property this cell is
+# actually guarding -- verify that by diffing the suite, not by trusting this note.
 run_suite_counts() {  # <suite-file> -> SUITE_PASSED, SUITE_FAILED
   local out
   out="$(cd "$TESTS_DIR" && bash "$1" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
@@ -385,7 +393,7 @@ run_suite_counts test-stop-hook.sh
 assert_eq "test-stop-hook.sh still passes exactly its 18 pre-existing assertions" "${SUITE_PASSED:-<none>}" "18"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 run_suite_counts test-voice-lint.sh
-assert_eq "test-voice-lint.sh still passes exactly its 41 pre-existing assertions" "${SUITE_PASSED:-<none>}" "41"
+assert_eq "test-voice-lint.sh still passes exactly its 48 assertions (41 pre-existing + 7 from #27)" "${SUITE_PASSED:-<none>}" "48"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 
 # ---------------------------------------------------------------------------

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -631,13 +631,34 @@ for signal_var in CLAUDE_PIPELINE_ACTIVE_ISSUE PIPELINE_ACTIVE_ISSUE; do
   assert_eq "  and it exits 2" "$GATE_RC" "2"
 done
 
-two_dirs 202601010103 202601010103        # the measured tie: three records in this tree share one mtime
+# (c) THE MTIME TIE. This cell used to assert the opposite -- that a tie still "names one of the
+#     two dirs rather than nothing" -- because activeIssueDir resolved a tie by readdirSync
+#     order, which is stable on one machine and therefore looked deterministic when measured
+#     here. It is not stable ACROSS machines: hash order on ext4, roughly insertion order on
+#     APFS, so the dir this guard judged on a tie was a property of the filesystem (#27).
+#
+#     A tie now resolves to NO subject, and this guard falls silent. That is a DISARM VECTOR and
+#     it is recorded as one, here and in the module header, rather than left for a reader to
+#     discover: a fresh `git clone` writes every tracked status.json inside one coarse-clock
+#     tick on Linux, which is exactly the tie, so the guard can be silenced without anyone
+#     choosing to silence it. It is accepted as the price of never judging a run this session
+#     does not own, and it routes through the fail-open tooling condition R11 already declares
+#     ("no resolvable active issue"), not through a new one.
+two_dirs 202601010103 202601010103        # the measured tie: both records share one mtime
 gate_nosignal "$CASE_ROOT"; FIRST_DEC="$GATE_DEC"; FIRST_DIR="$GATE_ISSUE"
 gate_nosignal "$CASE_ROOT"
 assert_eq "(c) an mtime tie is DETERMINISTIC across runs (decision)" "$GATE_DEC" "$FIRST_DEC"
 assert_eq "  and deterministic in the dir it names" "$GATE_ISSUE" "$FIRST_DIR"
-assert_eq "  and it names one of the two dirs rather than nothing" \
-  "$([[ "$FIRST_DIR" == "5150" || "$FIRST_DIR" == "6160" ]] && echo named || echo "UNNAMED: $FIRST_DIR")" "named"
+assert_eq "  and a tie resolves to NO subject: silent, not an arbitrary pick" \
+  "$FIRST_DEC" "<no-decision-on-stdout>"
+assert_eq "  and the silence is fail-OPEN (exit 0), never a refusal" "$GATE_RC" "0"
+# CONTROL, on this same tree: break the tie by one minute and a decision comes back. Without it
+# the three assertions above would pass just as well against a guard that had stopped working
+# altogether, which is the failure mode this suite exists to catch.
+two_dirs 202601010103 202601010104        # 6160 (granting) now strictly newest
+gate_nosignal "$CASE_ROOT"
+assert_eq "  CONTROL: breaking the tie by one minute restores a decision" "$GATE_DEC" "granted"
+assert_contains "  and that decision names the strictly-newest dir" "$GATE_ISSUE" "6160"
 
 # ---------------------------------------------------------------------------
 suite "AC17: exp-<slug> runs are GUARDED, not exempt"

--- a/plugins/pipeline/tests/test-status-schema-contract.sh
+++ b/plugins/pipeline/tests/test-status-schema-contract.sh
@@ -2,8 +2,9 @@
 # status.schema.json's own contract: the verdict cap (#34) and the current_phase example
 # list (#42).
 #
-# WHY THIS FILE EXISTS. status.schema.json has exactly ONE runtime reader -- voice-lint.mjs:224,
-# which reads properties.current_phase.pattern and nothing else. The file appears in no
+# WHY THIS FILE EXISTS. status.schema.json has exactly ONE runtime reader -- voice-lint.mjs:247 (the
+# readFileSync in phaseShapeFailure), which reads properties.current_phase.pattern at :249 and
+# nothing else. The file appears in no
 # AGENT_RULES entry in validate-pipeline-artifact.mjs, and that walker does not implement
 # maxLength at all, so a maxLength written into this schema refuses nothing by itself. Both
 # defects this suite pins are the same condition: a constraint nobody reads can be absent
@@ -483,7 +484,8 @@ assert_eq "AC7 CONTROL: and that literal is still present as a negative-control 
 # ---------------------------------------------------------------------------
 suite "AC8: UNCHANGED CONSUMER -- current_phase.pattern is byte-identical"
 # ---------------------------------------------------------------------------
-# voice-lint.mjs:224 reads exactly this one key out of this file and nothing else. Pinned by
+# voice-lint.mjs:249 (in phaseShapeFailure) reads exactly this one key out of this file and
+# nothing else. Pinned by
 # VALUE, not by presence: a presence check survives any edit to the regex, which is the thing the
 # only runtime reader actually consumes. The literal below is the pre-change bytes.
 assert_eq "AC8: the pattern is byte-identical to its pre-change value" \

--- a/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
+++ b/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
@@ -270,7 +270,7 @@ suite "AC25: the schema stops forbidding a value its own corpus produces"
 # SUPPORTED SIGNAL. phase_elapsed_ms correctly stays non-negative because the code guards
 # delta >= 0. Asserted as a shape read of the schema, in the idiom this suite already uses.
 # NOTE, so nobody reads more urgency into this than it has: nothing in this repo validates
-# status.json against status.schema.json (voice-lint.mjs:238 says so outright), so no validator
+# status.json against status.schema.json (voice-lint.mjs:261, the phaseShapeFailure message, says so outright), so no validator
 # is about to fire. It is a contract that contradicts its own corpus and its own sibling field.
 assert_eq "AC25: total_lead_time_ms declares no \`minimum\`" \
   "$(SCHEMA="$SCHEMA" node -e '

--- a/plugins/pipeline/tests/test-voice-lint.sh
+++ b/plugins/pipeline/tests/test-voice-lint.sh
@@ -246,4 +246,71 @@ grep -q '"9-does-not-exist"' "$LINT_SRC" \
   && assert_eq "CONTROL: the drift grep can report a miss" "found" "not found" \
   || assert_eq "CONTROL: the drift grep can report a miss" "not found" "not found"
 
+# ---------------------------------------------------------------------------
+suite "voice-lint: exp-<slug> runs are LINTED, not exempt"
+# ---------------------------------------------------------------------------
+# voice-lint.mjs used to declare its OWN issue-dir pattern, /^\d+$/, so resolveStatus could not
+# see an experiment run at all: no active issue, no phase, no lint. The control went quiet on
+# exactly the runs nobody is watching, and it did so silently -- the same defect shape, in a
+# third copy of the same vocabulary, that widening the validator's pattern already fixed for
+# artifact validation and that AC17 in test-gate-phase-entry.sh pins for the phase-entry guard
+# ("exp-<slug> runs are GUARDED, not exempt"). The pattern is now IMPORTED from the validator,
+# so these cases also stand as the behavioural witness that the import is wired up.
+#
+# This block deliberately runs LAST: it repoints TEMP_PROJECT/TEMP_ISSUE_DIR/TRANSCRIPT at a
+# fresh root whose only issue dir is an exp- one, which would break the cases above if it ran
+# before them.
+EXP_SLUG="exp-two-owner-gates"
+make_temp_project "$EXP_SLUG" || exit 90
+TRANSCRIPT="$TEMP_PROJECT/transcript.jsonl"
+
+# NO active-issue signal, because that is the shape production runs in: the Stop payload does
+# not carry one, so the mtime scan is the branch that has to admit an exp- dir. Both signal
+# names are unset around the CHILD, never around the assertion.
+exp_lint_nosignal() {
+  local errf="$TEMP_PROJECT/err.txt"
+  printf '%s' "{\"cwd\":\"$TEMP_PROJECT\",\"transcript_path\":\"$TRANSCRIPT\"}" \
+    | ( cd "$TEMP_PROJECT" && env -u CLAUDE_PIPELINE_ACTIVE_ISSUE -u PIPELINE_ACTIVE_ISSUE \
+        CLAUDE_PROJECT_DIR="$TEMP_PROJECT" node "$LINT" ) 2>"$errf" >/dev/null
+  RC=$?
+  ERR=$(cat "$errf")
+}
+
+# The OTHER branch: the explicit signal is regex-tested against the same vocabulary, so a
+# numeric-only pattern rejected an exp- signal too. Widening one branch and not the other would
+# pass every case above.
+exp_lint_signal() {
+  local errf="$TEMP_PROJECT/err.txt"
+  printf '%s' "{\"cwd\":\"$TEMP_PROJECT\",\"transcript_path\":\"$TRANSCRIPT\"}" \
+    | ( cd "$TEMP_PROJECT" && env CLAUDE_PIPELINE_ACTIVE_ISSUE="$EXP_SLUG" \
+        CLAUDE_PROJECT_DIR="$TEMP_PROJECT" node "$LINT" ) 2>"$errf" >/dev/null
+  RC=$?
+  ERR=$(cat "$errf")
+}
+
+set_phase "2.5-design-owner-decision"
+write_transcript "I picked approach B because it is cleaner. Moving on to implementation."
+exp_lint_nosignal
+assert_eq "an exp- run at a decision moment is LINTED (mtime path) and exits 2" "$RC" "2"
+assert_contains "and names the phase" "$ERR" "2.5-design-owner-decision"
+
+exp_lint_signal
+assert_eq "and the explicit-signal branch admits an exp- slug too" "$RC" "2"
+assert_contains "and names the phase" "$ERR" "2.5-design-owner-decision"
+
+# CONTROL, on the same exp- root: a compliant message is silent. Without it these cases would
+# pass just as well against a lint that had started reddening everything, and "exp- is no
+# longer exempt" would be indistinguishable from "exp- is now always refused".
+write_transcript "$GOOD_DECISION"
+exp_lint_nosignal
+assert_eq "CONTROL: the same exp- moment WITH the decision block exits 0" "$RC" "0"
+assert_eq "CONTROL: and says nothing" "$ERR" ""
+
+# CONTROL: the exemption was phase-blind, so prove the lint still discriminates BY PHASE inside
+# an exp- dir rather than simply biting on every exp- run it can now see.
+set_phase "3-impl"
+write_transcript "Refactored the parser — it now handles the nested case — and tests pass."
+exp_lint_nosignal
+assert_eq "CONTROL: a NON-voice phase in an exp- dir is still silent, em dashes and all" "$RC" "0"
+
 finish


### PR DESCRIPTION
Closes #27. Bears directly on #25 — see the note at the bottom, which is left for the owner to action rather than auto-closed.

## The cause, proven rather than guessed

The four failing cases named on #27 live in the `active-issue scoping: numeric-name convention` block, not the block the earlier hypothesis on that issue suspected. They assert that a malformed `exp-` marker is rejected and that resolution falls back to the newest `status.json` — expected to be `exp-two-owner-gates`.

The fixture wrote `1965/status.json` and `exp-two-owner-gates/status.json` roughly 0.2ms apart and left their ordering to the host clock. `activeIssueDir` compares with a strict `>` and `issueDirs()` returns raw, unsorted `readdirSync` order, so on an **mtime tie** the winner was decided by filesystem enumeration order — which put `1965` first, the exact string in the reported failure.

Linux stamps file timestamps from a coarse clock that ticks every few milliseconds, so both writes land on one timestamp. APFS resolves them apart. That is the entire macOS/ubuntu split.

Measured under a simulated 4ms coarse clock:

| fixture | trials resolving to the wrong dir |
|---|---|
| before | **177 / 200** |
| after | **0 / 200** |

High but not deterministic, which matches the two-consecutive-failures-then-a-pass pattern recorded on the issue.

The failure message was also misleading in the way #27 called out: `.../1965` **was** the mtime fallback and the marker **had** been rejected correctly. The assertion conflated "was the marker rejected" with "did the fallback pick the expected directory", so a tiebreak flake read as a rejection bug.

## What changed

**1. The fixture no longer depends on the host clock.** Every mtime the block relies on is stamped explicitly with seconds of margin.

**2. The conflated assertion is split.** One case now owns the "which dir does mtime pick" claim; the four rejection cases are stated against the no-marker result, so they hold whatever the scan picks. Breaking the ordering now reddens **one** case with an accurate message instead of four with a misleading one.

**3. Real directories are planted for the malformed markers.** Without them a *rejected* marker and an *honored-but-absent* one are indistinguishable — both fall through to the same result — so those four cases could not actually fail on what they name.

**4. The same tie is reachable in production, so a tie now resolves to null.** A fresh `git clone` writes all six tracked `.pipeline/*/status.json` within ~3.5ms (measured), so on Linux they share one mtime and `RECENT_MS` (30min) does not filter them out. A tie is the *absence* of a signal, not a weaker one, so `activeIssueDir` abstains rather than judging a run on a dir picked by readdir order. Both consumers already treat null as fail-open.

**5. `voice-lint.mjs` carried a third copy of both bugs.** Same strict-`>` tie, plus its own `ISSUE_DIR_RE = /^\d+$/` — so `exp-<slug>` runs resolved to no active issue and were **never voice-checked at all**, silently. That is the same defect shape the validator's pattern was widened to fix, and that AC17 pins for the phase-entry guard (*"exp-`<slug>` runs are GUARDED, not exempt"*). `ISSUE_DIR_RE` is now exported and imported rather than restated, so a fourth copy cannot drift.

## The trade-off, stated rather than buried

Abstaining on a tie **disarms the phase-entry guard**, and a fresh clone on Linux triggers that without anyone choosing to. It was accepted deliberately: the guard would rather judge nothing than judge a run the session does not own, which is the harm its scoping exists to prevent. It lands on the fail-open tooling branch R11 already declares (`"no resolvable active issue"`), so the fail-direction split is unchanged. Recorded in the module header as a named disarm vector and pinned by AC14 cell (c) with a control.

This inverted an assertion that deliberately pinned the old behaviour (*"it names one of the two dirs rather than nothing"*). That cell looked deterministic only because it checked self-consistency across two runs **on one machine** — which is exactly what readdir order gives you. It is reworded, not deleted, and its intent (the guard must not go silent unnoticed) is preserved by the added control.

## Verification

Every new assertion was falsified by a planted defect before being trusted:

- Revert the tie rule → only the "NO subject" cell reddens; the control still passes.
- Force permanent abstention → the control reddens (188 failures), so the silence assertions cannot pass for the wrong reason.
- Widen `ISSUE_DIR_RE` → the rejection cases report `marker "exp--bad" was HONORED: it steered resolution to …`, previously undetectable.
- Restore voice-lint's local pattern → the 4 behavioural cases redden while all 3 controls stay green, because under the defect the lint is *silent* and silence is what controls assert.
- End-to-end on a real clone: six tied records → gate silent at exit 0; tie broken by one second → judges `.pipeline/39` again.

Full suite: **33 suites, 2097 assertions, green**, including AC41(c)'s fresh-checkout run.

`AC27`'s exact-count pin for `test-voice-lint.sh` is re-baselined 41 → 48 **with the reason recorded**, since a number bumped without one turns that cell into a rubber stamp. Verified additive: `removed=0`, nothing renumbered.

Three `voice-lint.mjs` line citations in test comments were corrected for the shift these commits caused. Six further citations in `knowledge/` are now stale (`voice-lint.mjs:224/226/238`, `gate-phase-entry.mjs:115/193/241` → `:247/:249/:261`, `:125/:203/:251`) and are deliberately **not** touched here, since the Librarian is the sole writer to that store.

## On #25

Not auto-closed, because #25 was filed as *"cause unknown"* and this proves the **diagnosed** cause is gone, not that no other exists.

What is established: #25's inner failure was this self-test failing inside the clone — the same failure, not a second one — and that cause is now fixed deterministically. AC41(c) passes end-to-end including the real `file://` clone, and a fresh clone with all six records tied leaves the gate silent at exit 0 rather than judging an arbitrary dir. If #25 recurs it is a new cause, and the diagnostics shipped for both issues will name the failing inner suite rather than printing a count.

Recommend closing #25 on that basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
