### PR TITLE
Test-population integrity and CI parity (#47, #37, #33)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,34 @@ jobs:
           # This job is the only place the depth matters, and a repo of markdown and JSON is
           # small enough that a full fetch costs nothing worth measuring.
           fetch-depth: 0
-      # No package.json, no dependencies, no install step, matching manifests.yml's own
+      # THE ONE INSTALL STEP, and it is here because leaving it out was measured to cost 32
+      # assertions. test-mis-tier-tripwire.sh and test-panel-composition-fail-direction.sh each
+      # carry a `[zsh]` column, and that column is the regression test for the #17 VETO: zsh does
+      # not word-split an unquoted parameter expansion, so a multi-file diff reached the surface
+      # probes as one glued argument and the mis-tier tripwire silently failed to halt. zsh is
+      # the shell the orchestrator's own tool runs. ubuntu-latest has no zsh, so those columns
+      # ran on the author's laptop and NOWHERE ELSE -- 70 and 141 assertions here against 78 and
+      # 165 locally, both reporting failed=0, both green (#47). The gate was enforced on the
+      # bash half only.
+      #
+      # This does not reopen what the note below refuses. The constraint there is about a gate
+      # that breaks on SOMEONE ELSE'S package -- a lockfile, a registry, a transitive dep that
+      # moves. zsh is a distro package this workflow names by hand and pins to nothing; if apt
+      # cannot produce it, the honest outcome is a red build, because the alternative is the
+      # silently-narrower suite that made this step necessary.
+      - name: install zsh (the [zsh] columns are the #17 veto's regression test)
+        run: sudo apt-get update && sudo apt-get install -y zsh
+      # No package.json, no dependencies, no npm install step, matching manifests.yml's own
       # deliberate constraint: a gate that can break on someone else's package is a gate that
       # gets disabled the first time it does. run.sh is bash plus the runner's bundled Node.
       # A non-zero exit from run.sh fails the build; that is the whole point of the job.
+      #
+      # PIPELINE_TESTS_REQUIRE_CAPABILITIES turns an absent optional tool from a column that
+      # quietly does not exist into a counted failure naming the tool (see optional_tool in
+      # tests/harness.sh). It is set HERE and only here: a developer's machine may legitimately
+      # lack zsh, the platform the gate is enforced on may not. Without it, uninstalling zsh
+      # above would put this job straight back to a green build over a narrower suite.
       - name: plugin test suite
+        env:
+          PIPELINE_TESTS_REQUIRE_CAPABILITIES: "1"
         run: bash plugins/pipeline/tests/run.sh

--- a/plugins/pipeline/tests/fixtures/labels/test-gate-pre-phase4.labels
+++ b/plugins/pipeline/tests/fixtures/labels/test-gate-pre-phase4.labels
@@ -1,0 +1,95 @@
+BOUNDARY: a MySQL conditional-execution opener counts as an up section
+CONTROL: a real paraphrase of the same long criterion still covers it
+CONTROL: the same criterion passes once one check names AC23
+CONTROL: the same statements unwrapped ARE an up section
+GUARANTEE: an executable (uncommented) down region now halts
+NOT as commented-out: a `*/` past the marker must not vouch for the region
+a block that opens before the marker and closes after it halts
+a block-comment PREAMBLE above live statements is still an up section
+a block-commented up region is NOT an up section
+a custom glob matches ONLY what it names
+a custom glob matches what it names
+a file using only the configured custom marker passes
+a labelled criterion no check names is uncovered, despite heavy token overlap
+a labelled criterion still matches on wording when NO check carries a label
+a migration recorded in top-level files_removed is exempt
+a migration with no down section halts
+a migration with no up section halts
+a non-array migrationGlobs falls back to the defaults
+a non-string glob element falls back to the defaults
+a non-string marker falls back to the default
+a passing gate says so
+a per-commit exemption does not leak to a later commit
+a per-commit files_removed exempts that commit
+a schema violation halts
+a short criterion still matches on three tokens, exactly as before
+a token-overlap match covers the criterion
+a whitespace-only marker falls back to the default
+an AC-label match covers the criterion
+an absent config applies the default globs
+an absent impl-report.json halts
+an absent spec.json halts
+an all-comment head is not an up section
+an empty marker still halts a down-less migration
+an empty requirement_checks halts (minItems)
+an uncovered criterion halts the panel
+an unparseable config does not crash the gate: defaults still apply
+an unparseable impl-report.json halts
+an unterminated block comment before the marker is NOT an up section
+an up section plus a -- DOWN marker passes
+and does not claim the down section is missing
+and is reported by name
+and it reports the up-section failure
+and it reports the up-section failure
+and it reports the up-section failure
+and its own remedy, which is not the commented-out one
+and names the correct work it refuses
+and names the label that went unanswered
+and names the remedy for the block form specifically
+and names the remedy in the convention the report already uses
+and reports that file
+and says token overlap was deliberately not consulted
+and the clean down region is not reported
+and the halt quotes the criterion
+and the message quotes the DEFAULT marker
+and the up region is reported
+as UNTERMINATED, because the closing delimiter is outside the region
+migrationGlobs: [] disarms the INFERENCE path
+migrationGlobs: [] does NOT disarm an explicitly-named migration
+naming the unanswered label
+naming the unterminated block and where it opened
+neither marker present still halts
+nor an incidental schema error
+one labelled check out of three does NOT arm the strict rule
+the builtin -- DOWN still passes while a custom marker is configured
+the coverage halt is not an incidental schema error
+the default globs still find the migration
+the down region of this file is clean and is not reported
+the explicit path is still checked for a down section
+the explicit-path halt is not an incidental schema error
+the gate announces it blocked
+the halt is attributed to the schema
+the halt is the migration rule, not an incidental schema error
+the halt names the minItems rule
+the halt names the missing artifact
+the halt names the missing field
+the halt names the missing spec
+the halt quotes the exact down-section message
+the halt quotes the exact up-section message
+the halt quotes the uncovered criterion
+the halt says it is not valid JSON
+the halt says which rule fired
+the halt says which rule fired
+the indeterminate message is NOT the commented-out message
+the message quotes the CONFIGURED marker
+the message says what the region actually is
+the re-added migration is reported
+the same migration NOT recorded as removed still halts
+the shared fixture is schema-valid and passes on its own
+the token-floor halt is not the label rule wearing its message
+the up-section failure does not claim a missing down section
+the up-section halt is not an incidental schema error
+the up-section halt is not an incidental schema error
+the up-section halt is not an incidental schema error
+three incidental words do not cover a 19-token criterion
+two labelled checks out of three DO arm it, and AC9 goes unanswered

--- a/plugins/pipeline/tests/fixtures/labels/test-pipeline-telemetry.labels
+++ b/plugins/pipeline/tests/fixtures/labels/test-pipeline-telemetry.labels
@@ -1,0 +1,107 @@
+'status' is still an ARCHIVE_ARTIFACTS entry, on the line that defines the list
+3a and 3b are declared, which is what makes them attributable rather than a special case
+3a is a key in its own right, at the elapsed its own event closed
+3b is its own key too, carrying the 4,088,488 ms that used to land on 3a
+AC16(b) CRAFTED CONTROL: finish that write and the same walk reports 0 unreadable, 2 scanned
+AC16(b) CRAFTED: a half-written record is counted as unreadable, not thrown on
+AC16(b) CRAFTED: and the other three land in their own counters
+AC16(b) CRAFTED: and the partition still balances on the record that could be read
+AC16(b) CRAFTED: so all four are accounted for, none fell through
+CONTROL: README.md is not in the trigger list
+CONTROL: a field that IS required reads as required, so the check discriminates
+CONTROL: a label NOT in KNOWN_PHASES is not attributable, so the check above discriminates
+CONTROL: a record with no dropped events reports untimed_events 0
+CONTROL: a sibling object in the same schema is NOT closed, so 'false' means something
+CONTROL: a truncated record is COUNTED unreadable rather than silently exempted
+CONTROL: an invented role is still rejected by the enum
+CONTROL: an ordinary glob is recorded verbatim
+CONTROL: and PASSES a well-formed repo-relative path, so it is not refusing everything
+CONTROL: and on /var/folders/... at depth, inside an array
+CONTROL: and on the English sentence that was actually written into it
+CONTROL: commands/pipeline.md really does append it (the fact the description now states)
+CONTROL: finish that same write and the leak IS reported
+CONTROL: free text in `attribution` still leaks, so the enum widening is closed
+CONTROL: the declared label in the SAME fixture is still attributed normally
+CONTROL: the same accounting reports a shortfall on an archive record it cannot read
+CONTROL: the same check reports 4 on an object carrying a note and a path (two keys, two values)
+CONTROL: the same grep DOES find the field being read somewhere, so the zero is not vacuous
+CONTROL: the same grep reports 0 for an artifact that is NOT archived
+CONTROL: the same walk reddens on /Users/...
+CONTROL: the same walk reddens on an absolute path
+a present shard merges (exit 0), so the halt below is not the script refusing everything
+a shard that exists nowhere HALTS with exit 2
+an UNDECLARED phase label still balances the partition
+an empty status yields a null lead time, not a fabricated zero
+an event with a NON-STRING phase is counted as dropped too, not only a bad timestamp
+and .pipeline/exp-script-test-coverage/status.json is the record that carries it
+and events_counted says how many survived, so the two numbers can be compared
+and it falls back to that directory before declaring a shard missing
+and it saw the field there, so that 0 is a verdict rather than an absence
+and its model values are allowlisted, so the audit record cannot carry a full model ID
+and its time is REPORTED as unattributed rather than dropped
+and nothing it emits is a free-text note, a path, or a command string
+and nothing shipped claims a redaction step exists in code
+and nothing there is unattributed
+and reports zero unattributed time, because the dropped event carried no duration
+and so does the shipped example
+and the corpus is more than one file, so it is a population rather than an example
+and the description says design_review is APPENDED to this array
+and the gate's set is the narrowed one
+and the orchestrator states the rule where the tier is decided
+and the rejection is counted, so it is reportable rather than silent
+and told the only legal alternative is a repo-relative path
+at least one real record carries a suffixed phase key (3a/3b), the shape that used to vanish
+at least one record has no parseable timestamps, so the counter is a verdict
+both keys exist by name
+effective_config is closed (additionalProperties false)
+events with no timestamps yield a null lead time
+every archive record the corpus enumerates is one this walk read
+every corpus file is accounted for by one of the counters: none fell through
+every corpus record is accounted for: scanned + unreadable equals the corpus size
+every key telemetry() returns is declared in the schema
+every role the panel can carry is in the enum
+including on the suffixed 3a/3b shape, whose keys are declared phases and not free text
+it carries a writer prohibition instead
+it is replaced by the rejection token
+it names a distinct subdirectory instead
+no absolute-path string appears in any corpus record this walk could read
+no declared phase label falls through to unattributed
+no phase is credited a negative duration
+no real status.json carries a malformed worktree_path (absolute, or containing spaces)
+no real status.json has unaccounted-for time
+no shipped script reads worktree_path out of a status file
+no time is missing between the phase sum and the lead time
+nothing is unattributed on a run whose every label is declared
+phase 2 elapsed is exactly one hour
+phase 3 elapsed is exactly two and a half hours
+phase 4 absorbs both its boundaries: half an hour plus an hour
+review_rounds is the recorded counter, not a guess
+telemetry is closed (additionalProperties false), so a new field must be declared
+the 'tracked via its own shard' claim is gone
+the absolute glob string does not reach effective_config
+the all-untimed record reports its drops as well
+the backwards boundary is carried as a NEGATIVE unattributed value, which is the signal
+the dropped event is COUNTED, so the balance above is read against what it covered
+the fallback is consulted BEFORE the missing-shard branch
+the first phase gets no key, because nothing recorded when it started
+the keys are exactly the phases the events CLOSED
+the merge block was extracted (without this, the next assertion measures an empty file)
+the mixed record still balances -- which is exactly why the balance alone proves nothing
+the orchestrator is told to omit it
+the partition balances even when events[] runs backwards
+the partition balances on the real 3a/3b shape
+the partition balances on well-formed N- labels too
+the preamble no longer names the worktree .pipeline dir as the fallback
+the real corpus is non-empty (a zero over an empty corpus proves nothing)
+the real corpus is non-empty (a zero over an empty corpus proves nothing)
+the records with no parseable timestamps are counted, not silently dropped from the pass
+the schema declares untimed_events as a bounded integer
+the schema no longer claims worktree_path should be redacted
+the schema says the field is preferably omitted and names where the path really lives
+this repo's own config lists it
+total lead time is exactly five hours
+under a narrowing config the two entries DIFFER
+under no config at all they are equal
+with no counter recorded, the phase-4 entries are counted instead
+with the boundary count that says how many labels it could not read
+worktree_path is not required, so omitting it is legal

--- a/plugins/pipeline/tests/harness.sh
+++ b/plugins/pipeline/tests/harness.sh
@@ -92,6 +92,68 @@ assert_not_contains() {
   fi
 }
 
+# ---- REPORTING lines, which are counted but are not tests --------------------
+#
+# A suite sometimes needs to put a MEASUREMENT in the transcript that has no pass/fail sense:
+# which shell it found, what two constructs returned, that a remote lookup was unavailable. The
+# shape reached for is `assert_eq "<name>" "reported" "reported"` -- an assertion whose two
+# operands are the same literal, so it cannot fail. That reads in a green transcript exactly
+# like a real assertion and reads in the ledger exactly like a real assertion, which is how a
+# skipped column came to be indistinguishable from a passing one (#47).
+#
+# `record` is the honest spelling. It counts (so the ledger and the tally still agree) and it
+# prints, but it claims nothing, and its name is what a reader greps for when asking which lines
+# in this suite could never have gone red. Use it for a measurement; use assert_* for a claim.
+record() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  _ledger ok "$1"
+  printf '  ok    %s\n' "$1"
+}
+
+# ---- OPTIONAL CAPABILITIES: a population that shrinks must say so, and CI must refuse it -----
+#
+# THE DEFECT THIS EXISTS FOR (#47). Two suites carry a `[zsh]` column because zsh does not
+# word-split an unquoted parameter expansion, and zsh is the shell the orchestrator runs -- that
+# column is the regression test for the #17 VETO. Both opened the column with a bare
+# `command -v zsh` and closed the else branch with a self-equal assertion. On ubuntu-latest,
+# which has no zsh, the two suites ran 70 and 141 assertions against 78 and 165 locally: 32
+# assertions vanished, both platforms printed failed=0, and both were green. The guarantee CI
+# reported green on was the bash half only. Nothing compared the two totals, and the printed and
+# counted numbers agreed on each platform, so the harness's own count guard could not see it
+# either -- the POPULATION differed, not the accounting.
+#
+# THE RULE. A suite may run with a capability absent on a developer's machine. CI may not. So
+# the answer is always RECORDED (the transcript names the tool and its state either way), and
+# under PIPELINE_TESTS_REQUIRE_CAPABILITIES=1 -- which .github/workflows/tests.yml sets -- an
+# absent capability becomes a counted FAILURE naming the tool, instead of a column that quietly
+# does not exist.
+#
+# WHY NOT AN ASSERTED PER-PLATFORM COUNT, which is the other option #47 lists. An integer floor
+# is the instrument #33 is open against: it decays every time the suite it guards legitimately
+# grows, silently, because nothing forces the literal up -- measured twice already in this repo.
+# A capability NAME does not decay, and it fails with the tool named rather than with a delta a
+# reader has to interpret. With zsh installed on the runner the population no longer depends on
+# the platform at all, which is the precondition #33's label-set pin needs to be stated once for
+# every platform rather than once per platform.
+CAPABILITY_STRICT="${PIPELINE_TESTS_REQUIRE_CAPABILITIES:-0}"
+
+# optional_tool <name> -> 0 when <name> is on PATH, 1 when it is not.
+# Emits exactly one line either way, so `if optional_tool zsh; then RUNNERS+=(zsh); fi` reads
+# the way the bare `command -v` did and cannot skip in silence.
+optional_tool() {
+  local name="$1" state=absent
+  command -v "$name" >/dev/null 2>&1 && state=present
+  if [[ "$CAPABILITY_STRICT" == "1" ]]; then
+    # The label carries the tool, not the verdict: this is the line that must be readable in a
+    # CI log as "the column that covers the zsh half of the #17 veto did not run".
+    assert_eq "CAPABILITY \`$name\` is present (strict: an absent tool SHRINKS this suite's population)" \
+      "$state" "present"
+  else
+    record "CAPABILITY \`$name\` is $state (PIPELINE_TESTS_REQUIRE_CAPABILITIES=1, as CI sets, refuses an absent one)"
+  fi
+  [[ "$state" == "present" ]]
+}
+
 # Create a throwaway git repo. Echoes its path; caller removes it.
 # Pre-existing helper, used by the three hook suites. Left exactly as it was: those suites
 # keep their own inline rm -rf and are NOT refactored onto the guarded helper below.

--- a/plugins/pipeline/tests/test-claims-consumers.sh
+++ b/plugins/pipeline/tests/test-claims-consumers.sh
@@ -166,7 +166,7 @@ assert_contains "AC29: named as a per-line substitution, not a one-line edit" "$
 assert_contains "AC29: and states that the marker fix does not cover a \`#\`-written down BODY" \
   "$UPGRADE" "down BODY"
 
-suite "AC30: no commit subject on this branch collides with R17's frozen delimiters"
+suite "AC30: no commit subject anywhere in history collides with R17's frozen delimiters"
 
 # test-issue17-integration.sh resolves R17's frozen series anchors by exact-substring match on
 # commit SUBJECT, NEWEST MATCH FIRST, and its own header records that this delimiter has gone
@@ -195,37 +195,44 @@ DELIM_COUNT=$(printf '%s\n' "$DELIMS" | grep -c . | tr -d ' ')
 assert_eq "AC30 CONTROL: the delimiter set was actually extracted" \
   "$([[ "$DELIM_COUNT" -ge 10 ]] && echo ok || echo "found=$DELIM_COUNT")" "ok"
 
-BRANCH_SUBJECTS=$(cd "$REPO_ROOT" && git log --format=%s origin/main..HEAD 2>/dev/null)
-COLLISIONS=""
-while IFS= read -r d; do
-  [[ -n "$d" ]] || continue
-  while IFS= read -r s; do
-    [[ -n "$s" ]] || continue
-    [[ "$s" == *"$d"* ]] && COLLISIONS="$COLLISIONS[$s <- $d]"
-  done <<< "$BRANCH_SUBJECTS"
-done <<< "$DELIMS"
-# On the INTEGRATION BRANCH itself `origin/main..HEAD` is empty, and that is not a failure --
-# it is the same "population derived from a ref that moves" defect that broke the R17 series
-# delimiters once already, arriving in a newer assertion. An empty range here is not "nothing
-# to check": every delimiter IS a real commit subject, so over full history each one matches
-# its own commit, and the property "no OTHER commit contains a delimiter" is exactly what the
-# resolves-to-exactly-one assertion below already enforces over full history. So on the
-# integration branch this half is SUBSUMED, and says so, rather than asserting over an empty
-# set (which passes for the wrong reason) or demanding a population that cannot exist.
-assert_eq "AC30: no subject on this branch contains a frozen delimiter" "$COLLISIONS" ""
-assert_eq "AC30 CONTROL: the population was real, or is subsumed on the integration branch" \
-  "$(if [[ -n "$BRANCH_SUBJECTS" ]]; then echo ok; \
-     elif [[ -z "$(cd "$REPO_ROOT" && git log --format=%s origin/main..HEAD 2>/dev/null)" ]]; then echo ok; \
-     else echo "no subjects and not on the integration branch"; fi)" "ok"
+# THE POPULATION IS FULL HISTORY, NEVER A RANGE AGAINST A MOVING REF (#37).
+#
+# This block used to ask its question twice: once of `git log <moving-ref>..HEAD`, and once of
+# full history. The first half was the very defect #37 ratchets against -- it broke `main` at
+# #32's merge, was patched in #36 with a control that read "the population was real, OR is
+# subsumed on the integration branch", and that control could not fail: its `elif` re-ran the
+# identical command whose emptiness had already put it there, so an empty range answered `ok`
+# and a non-empty one answered `ok`. Both halves of a two-sided control cannot be the same side.
+#
+# What is left is the half that was always doing the work, and it is STRICTLY STRONGER. A
+# delimiter is a commit subject, so over full history it matches its own commit exactly once. If
+# a new commit's subject contained one as a substring -- the collision that would silently shift
+# which sha `head -1` returns for a frozen anchor -- that delimiter would resolve to 2. That
+# holds on a branch, on `main`, after a rebase merge, and on a pull_request build whose HEAD is a
+# merge commit this branch never authored. The range-based half could only ever see a branch it
+# had not landed yet.
+ALL_SUBJECTS=$(git -C "$REPO_ROOT" log --format=%s)
+assert_eq "AC30 CONTROL: full history was actually read (an empty log reaches nothing, forever)" \
+  "$([[ "$(printf '%s\n' "$ALL_SUBJECTS" | grep -c .)" -ge 10 ]] && echo ok || echo "read nothing")" "ok"
 
-# The other half: each delimiter must still resolve to EXACTLY ONE commit. A collision that
-# shifts `head -1` shows up here as a 2.
 AMBIGUOUS=""
 while IFS= read -r d; do
   [[ -n "$d" ]] || continue
-  n=$( (cd "$REPO_ROOT" && git log --format=%s) | grep -cF "$d" | tr -d ' ')
+  n=$(printf '%s\n' "$ALL_SUBJECTS" | grep -cF "$d" | tr -d ' ')
   [[ "$n" == "1" ]] || AMBIGUOUS="$AMBIGUOUS[$d => $n]"
 done <<< "$DELIMS"
-assert_eq "AC30: every frozen delimiter still resolves to exactly one commit" "$AMBIGUOUS" ""
+assert_eq "AC30: every frozen delimiter still resolves to exactly one commit, over FULL history" \
+  "$AMBIGUOUS" ""
+
+# NON-ZERO CONTROL for the resolver itself. Without it, the empty result above is equally
+# satisfied by a counter that answers 1 to everything -- and "every delimiter is unique" is a
+# claim about discrimination, so the discrimination is what has to be shown. `chore(` is a
+# conventional-commit prefix this repo writes constantly, so it resolves to many; a string no
+# subject carries resolves to none. Both are computed, neither is a pinned integer.
+assert_eq "CONTROL: the same resolver reports MANY for a substring many subjects carry" \
+  "$([[ "$(printf '%s\n' "$ALL_SUBJECTS" | grep -cF 'chore(' | tr -d ' ')" -gt 1 ]] && echo many || echo "not many")" \
+  "many"
+assert_eq "CONTROL: and NONE for a substring no subject carries" \
+  "$(printf '%s\n' "$ALL_SUBJECTS" | grep -cF 'zzz-no-commit-subject-contains-this' | tr -d ' ')" "0"
 
 finish

--- a/plugins/pipeline/tests/test-claims-consumers.sh
+++ b/plugins/pipeline/tests/test-claims-consumers.sh
@@ -63,63 +63,103 @@ assert_contains "AC6: the #16 title resolution survives as a live check" "$R17_T
 # integration.sh takes about four minutes and is run by run.sh and by CI. Running it inside
 # another suite would double that on every checkCommand invocation for no new information.
 
-suite "AC19: both suites are green, and neither lost an assertion"
+suite "AC19: both suites are green, and the assertion SET is pinned BY NAME (#33)"
 
-# The floors are the TRUE current values, not one below. A floor one below the current value
-# lets exactly one assertion be deleted through the guard that exists to stop assertions being
-# deleted -- which is precisely how requirement C could be "satisfied" by removing the ten
-# assertions that defend the wrong convention.
+# WHAT A COUNT COULD NOT DO, MEASURED TWICE BEFORE THIS WAS WRITTEN.
 #
-# A BARE FLOOR DRIFTS, AND IT HAS DRIFTED TWICE. r1 set telemetry at 95 against a true 96; r3
-# raised it to 96, and commits C6/C7 then took the suite to 99 without deleting anything, so
-# three assertions could again be deleted in silence. Nothing about a legitimate addition makes
-# a `>=` literal move: the guard degrades every time the thing it guards grows, and it degrades
-# QUIETLY, which is the same claim-more-than-you-measured defect this issue is about.
+# AC19 asks that neither guarded suite lose an assertion. That was a `>=` floor against a
+# literal, and a bare floor DECAYS every time the suite it guards legitimately grows -- quietly,
+# because nothing forces the literal up. It happened at 95 against a true 96, and again at 96
+# against a true 99, at which point three assertions could have been deleted in silence: exactly
+# the defect the floor exists to prevent, arriving through the floor. #30 landed a two-sided pin
+# as an interim patch -- the `>=` half caught deletion, a `<=` DRIFT ALARM caught growth -- and
+# QA's position on it was that the alarm is "a patch on the symptom, not the cause" and must not
+# be removed until the real fix exists. This is the real fix, so the four literals are gone.
 #
-# So each floor is pinned from BOTH sides. The `>=` half is the deletion guard and is what
-# AC19 asks for. The `<=` half carries no safety claim at all -- it exists so that the next
-# legitimate addition FAILS HERE, loudly, with the new number in the message, instead of
-# silently opening a deletion window. Its failure is a two-character edit and a re-read of what
-# was added; that is the price of a floor that tracks reality rather than the last person who
-# remembered it. If this ever becomes an obstruction rather than a prompt, replace the literals
-# with a mechanism, do not widen them.
-# 56 -> 95 closing #31 (the up section is classified, not line-prefix matched) and #48 (an AC
-# label is authoritative, and the token floor is proportional). Nothing was deleted: three
-# suites were added, 22 + 11 + 6, each rule pinned in both directions with its own non-zero
-# control. The alarm below is what forced this line to be re-read rather than the deletion
-# window being opened by thirty-nine.
-GATE_FLOOR=95
-# 99 -> 106 in the Phase 4 fix round: one `unreadable == 0` pin over the LIVE corpus was
-# REPLACED (a concurrent phase-transition write makes it a transient, not a defect) by five
-# crafted cells that construct the half-written record on demand, plus two accounting
-# assertions on the absolute-path walk. Net +7, and the alarm below is what forced this line to
-# be re-read rather than the window being opened by one.
+# THE SET, NOT THE COUNT. An integer says something changed. A label set says WHAT: a deletion is
+# reported by the name of the assertion that vanished, and an addition is a diff a reviewer
+# reads. Nothing here is a number a future author has to remember to raise.
 #
-# 106 -> 107 for the archive redaction fix: the `the archive corpus is ... empty today` pin,
-# a deliberate one-shot tripwire, fired when the first archive landed and was re-founded on the
-# derived relation (every archive record enumerated is one the walk read), which is one cell
-# for one cell -- plus a non-zero control, because that relation reads 0-of-0 while the archive
-# directory is empty and a vacuous pass is what the pin was there to prevent. Net +1.
-TELEM_FLOOR=107
-run_suite() { bash "$1" 2>&1 | tail -1; }
+# TO REFRESH A PIN after adding or renaming assertions -- and READ THE DIFF, that is the point:
+#   bash tests/test-gate-pre-phase4.sh 2>/dev/null \
+#     | sed -n -e 's/^  ok    //p' -e 's/^  FAIL  //p' | LC_ALL=C sort \
+#     > tests/fixtures/labels/test-gate-pre-phase4.labels
+#
+# WHY fixtures/ AND NOT A HERE-DOC. The pins are read by this suite in a FRESH CHECKOUT too
+# (AC41(c) clones the repo and runs run.sh inside it), so they have to be tracked files. Nothing
+# under fixtures/ is reachable by run.sh's `test-*.sh` glob, which test-issue17-integration.sh
+# asserts in both directions, so a pin is never mistaken for a suite.
+#
+# LC_ALL=C IS LOAD-BEARING. macOS and ubuntu-latest disagree about collation for anything but the
+# C locale, and a pin sorted one way and compared the other reports every line as both missing
+# and extra. Both sides of every comparison below are C-sorted.
 
-GATE_LINE=$(run_suite "$GATE_SUITE")
-GATE_PASSED=$(printf '%s' "$GATE_LINE" | sed -n 's/.*passed=\([0-9]*\).*/\1/p')
-GATE_FAILED=$(printf '%s' "$GATE_LINE" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
-assert_eq "AC19: the gate suite reports failed=0" "$GATE_FAILED" "0"
-assert_eq "AC19: and its assertion count has not decreased from $GATE_FLOOR" \
-  "$([[ "${GATE_PASSED:-0}" -ge "$GATE_FLOOR" ]] && echo ok || echo "passed=$GATE_PASSED")" "ok"
-assert_eq "AC19 DRIFT ALARM: the gate suite still measures $GATE_FLOOR -- raise GATE_FLOOR here if it grew" \
-  "$([[ "${GATE_PASSED:-0}" -le "$GATE_FLOOR" ]] && echo ok || echo "grew to $GATE_PASSED, floor is $GATE_FLOOR")" "ok"
+new_tmpdir || exit 90
+SCRATCH="$NEW_TMPDIR"
+LABELS_DIR="$TESTS_DIR/fixtures/labels"
 
-TELEM_LINE=$(run_suite "$TELEM_SUITE")
-TELEM_PASSED=$(printf '%s' "$TELEM_LINE" | sed -n 's/.*passed=\([0-9]*\).*/\1/p')
-TELEM_FAILED=$(printf '%s' "$TELEM_LINE" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
-assert_eq "AC19: the telemetry suite reports failed=0" "$TELEM_FAILED" "0"
-assert_eq "AC19: and its assertion count has not decreased from $TELEM_FLOOR" \
-  "$([[ "${TELEM_PASSED:-0}" -ge "$TELEM_FLOOR" ]] && echo ok || echo "passed=$TELEM_PASSED")" "ok"
-assert_eq "AC19 DRIFT ALARM: the telemetry suite still measures $TELEM_FLOOR -- raise TELEM_FLOOR here if it grew" \
-  "$([[ "${TELEM_PASSED:-0}" -le "$TELEM_FLOOR" ]] && echo ok || echo "grew to $TELEM_PASSED, floor is $TELEM_FLOOR")" "ok"
+# The extraction is only possible because the harness prints one assertion per line in a fixed
+# shape, so that shape is pinned HERE. Change it and this whole check would extract nothing and
+# pass over an empty set -- a guard that reports success because it can no longer see anything.
+HARNESS_SRC="$(cat "$TESTS_DIR/harness.sh")"
+assert_contains "AC19: the harness still prints a passing assertion as '  ok    <label>'" \
+  "$HARNESS_SRC" "'  ok    %s\n'"
+assert_contains "AC19: and a failing one as '  FAIL  <label>'" \
+  "$HARNESS_SRC" "'  FAIL  %s\n"
+
+extract_labels() { sed -n -e 's/^  ok    //p' -e 's/^  FAIL  //p' "$1" | LC_ALL=C sort; }
+
+pin_labels() {  # $1 = suite path
+  local name out pin got missing extra
+  name="$(basename "$1")"
+  out="$SCRATCH/$name.out"
+  got="$SCRATCH/$name.labels"
+  pin="$LABELS_DIR/${name%.sh}.labels"
+  bash "$1" > "$out" 2>/dev/null
+  extract_labels "$out" > "$got"
+
+  # Two vacuity controls, because every claim below is an EMPTY-difference claim and an empty
+  # difference between two empty files is the easiest pass in the world to write by accident.
+  assert_eq "AC19 CONTROL [$name]: the run produced labels (an empty extraction pins nothing)" \
+    "$([[ -s "$got" ]] && echo ok || echo "extracted nothing from $out")" "ok"
+  assert_eq "AC19 CONTROL [$name]: the pinned set exists and is non-empty" \
+    "$([[ -s "$pin" ]] && echo ok || echo "MISSING: ${pin#"$TESTS_DIR/"}")" "ok"
+  assert_eq "AC19 [$name]: the suite reports failed=0" \
+    "$(sed -n 's/^passed=[0-9]* failed=\([0-9]*\)$/\1/p' "$out" | tail -1)" "0"
+
+  # THE DELETION GUARD, which is what AC19 actually asks for -- and it now answers with a NAME.
+  missing="$(LC_ALL=C comm -23 "$pin" "$got" | tr '\n' '|')"
+  assert_eq "AC19 [$name]: no pinned assertion was DELETED" "$missing" ""
+  # THE OTHER SIDE, which is what the DRIFT ALARM was standing in for: an addition is not a
+  # failure of the suite, it is a prompt to read what was added and re-pin. The refresh command
+  # is in the comment above this block.
+  extra="$(LC_ALL=C comm -13 "$pin" "$got" | tr '\n' '|')"
+  assert_eq "AC19 [$name]: and nothing was ADDED without the pin being re-read" "$extra" ""
+}
+
+pin_labels "$GATE_SUITE"
+pin_labels "$TELEM_SUITE"
+
+# NON-ZERO CONTROLS, IN BOTH DIRECTIONS, on a copy of a real pin. Without them the two empty
+# differences above are equally satisfied by a comparison that cannot tell any two sets apart --
+# which is the failure mode the count had, restated in a different instrument.
+REAL_PIN="$LABELS_DIR/test-gate-pre-phase4.labels"
+REAL_GOT="$SCRATCH/test-gate-pre-phase4.sh.labels"
+DELETED_ONE="$SCRATCH/pin-minus-one.txt"
+LC_ALL=C sort "$REAL_PIN" | tail -n +2 > "$DELETED_ONE"
+FIRST_LABEL="$(head -1 "$REAL_PIN")"
+assert_eq "CONTROL: the mutated pin really lost exactly one line" \
+  "$(( $(grep -c . "$REAL_PIN") - $(grep -c . "$DELETED_ONE") ))" "1"
+assert_contains "CONTROL: an ADDED assertion is reported by name, not as a delta" \
+  "$(LC_ALL=C comm -13 "$DELETED_ONE" "$REAL_GOT")" "$FIRST_LABEL"
+ADDED_ONE="$SCRATCH/pin-plus-one.txt"
+{ cat "$REAL_PIN"; printf 'zzz an assertion the suite no longer emits\n'; } | LC_ALL=C sort > "$ADDED_ONE"
+assert_contains "CONTROL: and a DELETED assertion is reported by name too" \
+  "$(LC_ALL=C comm -23 "$ADDED_ONE" "$REAL_GOT")" "zzz an assertion the suite no longer emits"
+# ...and the same comparison is SILENT on the unmutated pair, so the two controls above are
+# discriminations rather than a comparison that reports everything.
+assert_eq "CONTROL: and it reports nothing at all when the two sets agree" \
+  "$(LC_ALL=C comm -3 "$REAL_PIN" "$REAL_GOT")" ""
 
 suite "AC23: the halt-cause enumeration is complete after A and B"
 

--- a/plugins/pipeline/tests/test-harness.sh
+++ b/plugins/pipeline/tests/test-harness.sh
@@ -343,6 +343,96 @@ assert_contains "a FAIL inside a subshell is still PRINTED" "$OUT" "FAIL  a real
 assert_contains "  and still uncounted by the tally" "$OUT" "passed=0 failed=0"
 assert_eq "  but the suite no longer exits 0" "$RC" "1"
 
+suite "harness: a REPORTING line is counted, ledgered, and cannot claim anything (#47)"
+
+# `record` exists so that a measurement stops being spelled as an assertion that cannot fail.
+# The two properties that make it safe to have at all: it COUNTS (so the tally and the ledger
+# still agree, and the uncounted-assertion guard above keeps working), and it is a distinct
+# word, so "which lines here could never have gone red" is a grep rather than a reading.
+cat > "$SCRATCH/child-record.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+record "a measurement, not a claim"
+finish
+CHILD
+run_child "$SCRATCH/child-record.sh"
+assert_eq "a suite whose only line is a record() exits 0" "$RC" "0"
+assert_contains "  and the line is printed in the ok column, like any other" "$OUT" \
+  "  ok    a measurement, not a claim"
+assert_contains "  and it is COUNTED, so the tally still describes the transcript" "$OUT" "passed=1 failed=0"
+
+# THE CONTROL that makes "counted" mean counted: record() must reach the LEDGER too, or the
+# uncounted-assertion guard would stop being able to see a suite that reports from a subshell.
+# Same shape as the assert_eq case above, with the same expected diagnostic.
+cat > "$SCRATCH/child-record-subshell.sh" <<CHILD
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+record "counted normally"
+( record "reported where the counters do not survive" )
+finish
+CHILD
+run_child "$SCRATCH/child-record-subshell.sh"
+assert_eq "CONTROL: a record() in a subshell trips the same guard an assertion would" "$RC" "1"
+assert_contains "  and the guard names the reporting line, not the counted one" "$ERR" \
+  "reported where the counters do not survive"
+
+suite "harness: an OPTIONAL TOOL is declared, and CI refuses an absent one (#47)"
+
+# The defect being closed: `if command -v zsh` opened a whole column on one machine and closed
+# it with a self-equal assertion on another, so 32 assertions existed locally and did not exist
+# on ubuntu-latest, with failed=0 printed on both. The four cells below hold everything fixed
+# except the two variables that produced that -- whether the tool is there, and whether the run
+# is the one CI makes.
+mk_cap_child() {  # $1 = dest, $2 = PIPELINE_TESTS_REQUIRE_CAPABILITIES, $3 = tool
+  cat > "$1" <<CHILD
+export PIPELINE_TESTS_REQUIRE_CAPABILITIES=$2
+. "$TESTS_DIR/harness.sh"
+suite "scratch"
+if optional_tool "$3"; then printf 'COLUMN_OPENED\n'; else printf 'COLUMN_SKIPPED\n'; fi
+finish
+CHILD
+}
+ABSENT_TOOL="definitely-not-a-real-tool-9f3a"
+assert_eq "precondition: the absent-tool fixture really names a tool that is not installed" \
+  "$(command -v "$ABSENT_TOOL" >/dev/null 2>&1 && echo FOUND || echo absent)" "absent"
+
+mk_cap_child "$SCRATCH/child-cap-present-lax.sh" 0 bash
+run_child "$SCRATCH/child-cap-present-lax.sh"
+assert_eq "(a) present, ordinary run -> exits 0" "$RC" "0"
+assert_contains "  and the caller's column OPENS" "$OUT" "COLUMN_OPENED"
+assert_contains "  and the tool and its state are both in the transcript" "$OUT" "\`bash\` is present"
+
+mk_cap_child "$SCRATCH/child-cap-absent-lax.sh" 0 "$ABSENT_TOOL"
+run_child "$SCRATCH/child-cap-absent-lax.sh"
+assert_eq "(b) absent, ordinary run -> still exits 0: a laptop may lack the tool" "$RC" "0"
+assert_contains "  and the caller's column is SKIPPED" "$OUT" "COLUMN_SKIPPED"
+assert_contains "  but the skip is NAMED rather than silent" "$OUT" "\`$ABSENT_TOOL\` is absent"
+
+mk_cap_child "$SCRATCH/child-cap-absent-strict.sh" 1 "$ABSENT_TOOL"
+run_child "$SCRATCH/child-cap-absent-strict.sh"
+assert_eq "(c) absent, CI run -> the suite FAILS" "$RC" "1"
+assert_contains "  and the failure names the tool, not a count delta" "$OUT" \
+  "FAIL  CAPABILITY \`$ABSENT_TOOL\` is present"
+assert_contains "  and it is a COUNTED failure, so run.sh's exit reflects it" "$OUT" "passed=0 failed=1"
+
+# NON-ZERO CONTROL for (c): without it, the red above is equally satisfied by a strict mode that
+# fails every run. Same env, same harness, only the tool changes.
+mk_cap_child "$SCRATCH/child-cap-present-strict.sh" 1 bash
+run_child "$SCRATCH/child-cap-present-strict.sh"
+assert_eq "CONTROL: present, CI run -> exits 0, so strict mode refuses the ABSENCE and not the check" \
+  "$RC" "0"
+assert_contains "  and the column opens exactly as it does off-CI" "$OUT" "COLUMN_OPENED"
+
+# THE PROPERTY #47 IS ABOUT, asserted directly: the number of lines a declared capability
+# contributes does not depend on the answer. The COLUMN behind it may still be absent -- that is
+# what strict mode is for -- but the declaration itself can no longer be the thing that
+# disappears, which is how the shrink stayed invisible to both the tally and the count guard.
+cap_total() { printf '%s' "$1" | sed -n 's/.*passed=\([0-9]*\) failed=\([0-9]*\).*/\1+\2/p' | head -1; }
+OUT_PRESENT=$(bash "$SCRATCH/child-cap-present-lax.sh" 2>/dev/null)
+OUT_ABSENT=$(bash "$SCRATCH/child-cap-absent-lax.sh" 2>/dev/null)
+assert_eq "a declared capability contributes the same one line whether present or absent" \
+  "$(cap_total "$OUT_PRESENT")/$(cap_total "$OUT_ABSENT")" "1+0/1+0"
+
 suite "harness: node is REQUIRED, never skipped (AC3)"
 
 # Build a PATH with the few externals harness.sh itself needs and, pointedly, no node. This is

--- a/plugins/pipeline/tests/test-issue17-integration.sh
+++ b/plugins/pipeline/tests/test-issue17-integration.sh
@@ -119,9 +119,32 @@ assert_eq "CONTROL: the same count reports 2 when two files match, so the 1 abov
 assert_contains "the run step is the exact command" "$(cat "$WF_WITH_SUITE")" "bash plugins/pipeline/tests/run.sh"
 assert_contains "it triggers on pull_request" "$(cat "$WF_WITH_SUITE")" "pull_request"
 assert_contains "and on push to main" "$(cat "$WF_WITH_SUITE")" "branches: [main]"
-assert_not_contains "with no install step (matching the repo's dependency-free CI constraint)" \
-  "$(cat "$WF_WITH_SUITE")" "npm install"
-assert_not_contains "and no package.json dependency" "$(cat "$WF_WITH_SUITE")" "npm ci"
+# THE CLAIM IS ABOUT STEPS, AND SO IS THE READING. Both of these matched the WHOLE FILE, so they
+# could not tell an instruction from an explanation of why there is no such instruction: the
+# workflow now carries a paragraph about the repo's dependency-free constraint, and the phrase
+# `npm install` inside that paragraph turned the assertion red while the workflow ran no npm at
+# all. A check that a comment can flip is a check about prose (#47).
+WF_RUN_LINES="$(grep -E '^[[:space:]]*run:' "$WF_WITH_SUITE")"
+assert_eq "CONTROL: the run: steps were actually extracted (an empty read refuses nothing)" \
+  "$([[ -n "$WF_RUN_LINES" ]] && echo ok || echo "no run: step found")" "ok"
+assert_not_contains "no step runs npm install (the repo's dependency-free CI constraint)" \
+  "$WF_RUN_LINES" "npm install"
+assert_not_contains "and no step runs npm ci" "$WF_RUN_LINES" "npm ci"
+# NON-ZERO CONTROL, or the two above are equally satisfied by a reader pointed at nothing.
+WF_NPM_PROBE="$TEMP_PROJECT/npm-step-probe.yml"
+printf 'jobs:\n  a:\n    steps:\n      - run: npm install\n' > "$WF_NPM_PROBE"
+assert_contains "CONTROL: the same extraction DOES find an npm step when one is present" \
+  "$(grep -E '^[[:space:]]*(- )?run:' "$WF_NPM_PROBE")" "npm install"
+
+# THE ONE INSTALL STEP THE WORKFLOW DOES CARRY, pinned here so it cannot be dropped in silence.
+# The `[zsh]` columns in test-mis-tier-tripwire.sh and test-panel-composition-fail-direction.sh
+# are the regression test for the #17 VETO, and ubuntu-latest has no zsh: without this step those
+# 32 assertions did not exist where the gate is enforced, on a green build (#47). Removing the
+# step reddens HERE rather than shrinking a suite nobody is counting.
+assert_contains "the workflow installs zsh, so the [zsh] columns run where the gate is enforced" \
+  "$WF_RUN_LINES" "install -y zsh"
+assert_contains "and it runs the suite in strict-capability mode, so a future absent tool is a FAILURE" \
+  "$(cat "$WF_WITH_SUITE")" "PIPELINE_TESTS_REQUIRE_CAPABILITIES"
 
 # The file must PARSE as YAML, not merely exist. No YAML parser ships with node, so the
 # structural properties are asserted directly: a top-level `on:` with both triggers, a `jobs:`

--- a/plugins/pipeline/tests/test-mis-tier-tripwire.sh
+++ b/plugins/pipeline/tests/test-mis-tier-tripwire.sh
@@ -455,9 +455,14 @@ assert_eq "surface module PRESENT + resolver PRESENT: and the tripwire is silent
 # `{db/migrate/001_add_users.rb, src/app.ts}`: bash halted, zsh was silent. This is the
 # control the whole issue exists to protect, so it gets the matrix nobody had.
 
+# The zsh column is DECLARED, not discovered. A bare `command -v zsh` opened this column on a
+# developer's machine and closed it with a self-equal assertion on ubuntu-latest, so eight
+# assertions here simply did not exist where CI enforces the gate (#47). optional_tool records
+# the answer either way and, under PIPELINE_TESTS_REQUIRE_CAPABILITIES=1 (which the workflow
+# sets), fails by NAME rather than shrinking the population in silence.
 RUNNERS=(bash bash-nosplit)
 ZSH_PRESENT=no
-if command -v zsh >/dev/null 2>&1; then RUNNERS+=(zsh); ZSH_PRESENT=yes; fi
+if optional_tool zsh; then RUNNERS+=(zsh); ZSH_PRESENT=yes; fi
 
 # `bash-nosplit` is bash with IFS emptied, i.e. field splitting off: the defect condition
 # itself, in a shell every checkout has, so this dimension is never skipped for want of zsh.
@@ -528,9 +533,6 @@ if [[ "$ZSH_PRESENT" == yes ]]; then
   assert_eq "and the stand-in reproduces it byte-for-byte on this form" \
     "$(run_tripwire_in zsh "$ROOT_OK" "$REPO_MULTI" "$OLD_TRIPWIRE")" \
     "$(run_tripwire_in bash-nosplit "$ROOT_OK" "$REPO_MULTI" "$OLD_TRIPWIRE")"
-else
-  assert_eq "zsh is ABSENT on this machine: the real-zsh cells were NOT RUN (the stand-in covers the condition)" \
-    "not-run" "not-run"
 fi
 
 suite "THE FIX: the shipped tripwire gives the same verdict in every cell of shell x path count"

--- a/plugins/pipeline/tests/test-moving-ref-population.sh
+++ b/plugins/pipeline/tests/test-moving-ref-population.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# THE RATCHET (#37): no test population may be derived from a range against a MOVING REF.
+#
+# THREE OCCURRENCES OF ONE SHAPE, TWICE BREAKING `main` AT MERGE.
+#
+#   1. #17's merge. test-issue17-integration.sh computed its window as
+#      `merge-base origin/main HEAD`..HEAD. On `main` that merge-base IS HEAD, so the range was
+#      empty, every subject lookup returned "", and `set -u` killed the suite before it could
+#      print a count. Fixed in #26 by delimiting the series on commit SUBJECT and resolving
+#      against full history.
+#   2. #32's merge. test-claims-consumers.sh built AC30's population from
+#      `git log --format=%s <moving-ref>..HEAD`. Empty on `main`, so the control asserting there
+#      were subjects failed and the fresh-checkout meta-test cascaded -- five failures. Fixed in
+#      #36, and the derivation itself survived that fix until this file was written.
+#   3. This ratchet, which exists because occurrence 2 was written three review rounds AFTER
+#      occurrence 1 was fixed, in the same repo, by authors who had the first fix in front of
+#      them. A rule that lives only in a commit message is a rule the next author does not have.
+#
+# WHY IT IS A DEFECT AND NOT A STYLE. `origin/main..HEAD` names the BRANCH'S development range,
+# so it describes nothing the moment the branch lands: the range goes empty, and an assertion
+# over an empty population does not fail loudly -- it passes vacuously, or it dies on an unbound
+# variable somewhere downstream. `gh pr merge --rebase` rewrites every sha on the way in, so
+# pinning shas is no escape either. What survives a merge is a commit's SUBJECT and full history.
+#
+# WHAT THIS SUITE IS NOT. It does not refuse the ranges themselves. Two shipped suites build a
+# throwaway repo with its own `origin/main` ref precisely so the block under test -- which really
+# does run `git diff origin/main...HEAD` in a real worktree -- resolves at all. Those are correct
+# and must not be refused: a ratchet that refuses both the defect and the legitimate use is a
+# ratchet that gets deleted the first week. The discriminator is which REPOSITORY the command is
+# pointed at, and it is asserted in both directions below.
+#
+# This suite needs no node: it exercises bash plumbing only.
+
+. "$(dirname "${BASH_SOURCE[0]}")/harness.sh"
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+new_tmpdir || exit 90
+SCRATCH="$NEW_TMPDIR"
+
+# ---------------------------------------------------------------------------
+# the detector
+# ---------------------------------------------------------------------------
+
+# ASSEMBLED, NEVER WRITTEN AS ONE TOKEN. This file is inside the population the ratchet walks,
+# and it names the construct it hunts on nearly every line. A detector that matched its own
+# pattern would be un-passable for a reason that has nothing to do with the corpus -- the
+# self-counting trap #30 hit twice, once with a detector matching its own fixture and once with a
+# docstring assertion counting its own prose. Every case pattern below therefore needs BOTH the
+# remote-ref half (which lives only in this variable) and the range half on the same line, and no
+# line in this file has both.
+OREF="or""igin"
+
+# The variables that name THE CHECKOUT. A git command pointed at one of these -- or at nothing at
+# all, which leaves it in the suite's own cwd, i.e. inside the checkout -- is deriving over the
+# real repository. Anything else is a path the fixture built, and is allowed.
+ROOT_VARS="REPO_ROOT PLUGIN_ROOT PLUGIN_DIR TESTS_DIR SCRIPTS_DIR HOOKS_DIR"
+
+# repo_target <line> -> the variable name the git command is pointed at, or "" for none.
+# `-C` is preferred over `cd` because that is the precedence git itself applies. Pure parameter
+# expansion, no sed: the strings being taken apart are shell source containing backslashes,
+# nested quotes and `$` -- every one of which is a metacharacter to something in a sed pipeline,
+# and the first spelling of this function silently matched nothing on the escaped-quote form
+# that two shipped suites use inside their heredoc fixtures.
+#
+# ONLY a `$VAR` target is recognised. A literal path (`git -C /tmp/x`) reads as NO target and is
+# therefore refused, which is the fail-closed direction and costs nothing here: every fixture
+# repo in this directory is already named by a variable.
+repo_target() {
+  local l="$1" seg lead
+  case "$l" in
+    *"-C "*)  seg="${l#*-C }" ;;
+    *"cd "*)  seg="${l#*cd }" ;;
+    *) printf ''; return 0 ;;
+  esac
+  # Strip the leading run of quoting characters: `"$D`, `\"\$D` and `'$D` all reach the same $.
+  lead="${seg%%[!\\\"\']*}"
+  seg="${seg#"$lead"}"
+  case "$seg" in
+    '$'*) seg="${seg#\$}"; seg="${seg#\{}" ;;
+    *) printf ''; return 0 ;;
+  esac
+  printf '%s' "${seg%%[!A-Za-z0-9_]*}"
+}
+
+# moving_ref_offenders <file>... -> one "<basename>:<lineno>" per offending line, space-joined.
+# NAMES the offender rather than counting it: a count tells you something moved, a name tells you
+# what to open. Full-line comments are skipped -- this file, and the two suites that legitimately
+# use the ranges, all describe the construct in prose directly above the code that uses it.
+moving_ref_offenders() {
+  local f line trimmed target v n allowed hits=""
+  for f in "$@"; do
+    [[ -f "$f" ]] || continue
+    n=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      n=$((n + 1))
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      case "$trimmed" in '#'*) continue ;; esac
+      case "$line" in
+        *"$OREF"/*..HEAD*) ;;
+        *merge-base*"$OREF"/*HEAD*) ;;
+        *) continue ;;
+      esac
+      target="$(repo_target "$line")"
+      allowed=no
+      if [[ -n "$target" ]]; then
+        allowed=yes
+        for v in $ROOT_VARS; do
+          [[ "$target" == "$v" ]] && allowed=no
+        done
+      fi
+      [[ "$allowed" == yes ]] && continue
+      hits="$hits $(basename "$f"):$n"
+    done < "$f"
+  done
+  printf '%s' "${hits# }"
+}
+
+# ---------------------------------------------------------------------------
+suite "the ratchet: no shipped suite derives a population from a moving ref"
+# ---------------------------------------------------------------------------
+
+# Discovery is by the SAME test-*.sh glob run.sh uses, plus the two files run.sh is made of.
+# Never an enumeration of suite filenames: an enumeration leaves suite number 34 unguarded the
+# day it lands and a renamed suite unguarded forever, which is a control that quietly stops
+# firing -- the failure this whole file exists to catch, wearing a different hat.
+POPULATION=()
+for f in "$TESTS_DIR"/test-*.sh "$TESTS_DIR/harness.sh" "$TESTS_DIR/run.sh"; do
+  [[ -f "$f" ]] && POPULATION+=("$f")
+done
+assert_eq "the population is the whole tests/ directory, discovered by run.sh's own glob" \
+  "$([[ "${#POPULATION[@]}" -ge 30 ]] && echo ok || echo "only ${#POPULATION[@]} files found")" "ok"
+assert_eq "no test file derives a population from a range against a moving ref" \
+  "$(moving_ref_offenders "${POPULATION[@]}")" ""
+
+# The population is asserted to CONTAIN the two suites whose legitimate fixture-repo uses are the
+# hard half of this rule. Without this, the empty result above is equally satisfied by a walk that
+# never reached them, and the over-refusal control below would be measuring a file nothing scans.
+LEGIT_ONE="$TESTS_DIR/test-mis-tier-tripwire.sh"
+LEGIT_TWO="$TESTS_DIR/test-panel-composition-fail-direction.sh"
+assert_eq "and the walk really reached the two suites that DO use these ranges, legitimately" \
+  "$([[ -f "$LEGIT_ONE" && -f "$LEGIT_TWO" ]] && echo both || echo "MISSING")" "both"
+assert_eq "CONTROL: those two suites really do carry the construct (else they prove nothing here)" \
+  "$(grep -c -e "$OREF/.*\.\.HEAD" "$LEGIT_ONE" "$LEGIT_TWO" | awk -F: '{n+=$2} END {print (n>0 ? "carried" : "ABSENT")}')" \
+  "carried"
+
+# ---------------------------------------------------------------------------
+suite "GATE BITES: the exact line from occurrence 2, and the legitimate use beside it"
+# ---------------------------------------------------------------------------
+
+# #37's own requirement, in its own words: plant the exact line from occurrence 2 and record the
+# ratchet catching it, then plant a legitimate fixture-repo use and record it passing. Both
+# probes are written here rather than committed under fixtures/, so the corpus assertion above
+# never has to except them and can stay a statement about every file run.sh can reach.
+PLANT_BAD="$SCRATCH/planted-offender.sh"
+printf 'BRANCH_SUBJECTS=$(cd "$REPO_ROOT" && git log --format=%%s %s/main..HEAD 2>/dev/null)\n' "$OREF" > "$PLANT_BAD"
+assert_contains "the planted probe really carries occurrence 2's line" "$(cat "$PLANT_BAD")" "REPO_ROOT"
+assert_eq "CONTROL: the ratchet CATCHES occurrence 2, named by file and line" \
+  "$(moving_ref_offenders "$PLANT_BAD")" "planted-offender.sh:1"
+
+# The same derivation pointed at a fixture repo, which is what the two shipped suites do.
+PLANT_GOOD="$SCRATCH/planted-fixture-use.sh"
+printf 'CHANGED="$(git -C "$WORKTREE_PATH" diff --name-only %s/main...HEAD)"\n' "$OREF" > "$PLANT_GOOD"
+assert_eq "CONTROL: and PASSES the identical range pointed at a fixture repo" \
+  "$(moving_ref_offenders "$PLANT_GOOD")" ""
+
+# The three spellings #37 enumerates, so the ratchet is not pinned to the one that broke last.
+PLANT_TWODOT="$SCRATCH/planted-twodot.sh"
+printf 'git log --format=%%s %s/main..HEAD\n' "$OREF" > "$PLANT_TWODOT"
+assert_eq "the two-dot range with NO repo argument at all is caught (it inherits the checkout)" \
+  "$(moving_ref_offenders "$PLANT_TWODOT")" "planted-twodot.sh:1"
+PLANT_THREEDOT="$SCRATCH/planted-threedot.sh"
+printf 'git -C "$REPO_ROOT" diff --name-only %s/main...HEAD\n' "$OREF" > "$PLANT_THREEDOT"
+assert_eq "the three-dot range against the checkout is caught" \
+  "$(moving_ref_offenders "$PLANT_THREEDOT")" "planted-threedot.sh:1"
+PLANT_MERGEBASE="$SCRATCH/planted-mergebase.sh"
+printf 'W=$(git -C "$REPO_ROOT" merge-base %s/main HEAD)\n' "$OREF" > "$PLANT_MERGEBASE"
+assert_eq "and occurrence 1's merge-base spelling is caught too" \
+  "$(moving_ref_offenders "$PLANT_MERGEBASE")" "planted-mergebase.sh:1"
+
+# A branch other than main. The defect is the ref MOVING, not the word `main`.
+PLANT_OTHER="$SCRATCH/planted-other-branch.sh"
+printf 'git -C "$REPO_ROOT" log --format=%%s %s/develop..HEAD\n' "$OREF" > "$PLANT_OTHER"
+assert_eq "any remote-tracking branch is a moving ref, not just main" \
+  "$(moving_ref_offenders "$PLANT_OTHER")" "planted-other-branch.sh:1"
+
+# ---------------------------------------------------------------------------
+suite "the ratchet does not count prose, and does not count itself"
+# ---------------------------------------------------------------------------
+
+# #37 names this explicitly as one of the two things that make the ratchet non-trivial: the
+# construct is DESCRIBED in comments all over this repo, directly above the code that uses it.
+PLANT_COMMENT="$SCRATCH/planted-comment.sh"
+printf '# it used to read `git log --format=%%s %s/main..HEAD` against $REPO_ROOT, and that broke\n' "$OREF" > "$PLANT_COMMENT"
+assert_eq "a full-line comment describing the defect is prose, not the defect" \
+  "$(moving_ref_offenders "$PLANT_COMMENT")" ""
+# ...and the same text UNCOMMENTED is caught, so the exemption above is a discrimination and not
+# a hole the next author can widen by shifting a line.
+PLANT_UNCOMMENT="$SCRATCH/planted-uncommented.sh"
+sed 's/^# it used to read `//; s/` against .*$//' "$PLANT_COMMENT" > "$PLANT_UNCOMMENT"
+assert_contains "the uncommented twin really lost its comment marker" "$(cat "$PLANT_UNCOMMENT")" "git log"
+assert_eq "CONTROL: uncommented, the identical text IS caught" \
+  "$(moving_ref_offenders "$PLANT_UNCOMMENT")" "planted-uncommented.sh:1"
+
+# THE SELF-COUNTING TRAP, closed by construction rather than by an exemption list. This file is in
+# the population above and names the construct constantly; it passes because the remote-ref half
+# is only ever produced by expanding $OREF at run time.
+assert_eq "this suite is inside the population it walks" \
+  "$(moving_ref_offenders "$TESTS_DIR/$(basename "${BASH_SOURCE[0]}")")" ""
+# ...and it passes BY CONSTRUCTION rather than by an exemption list: every occurrence of the
+# remote ref in this file is prose. An exemption would leave this file the one place the rule
+# does not apply, which is where the next author would put the next occurrence.
+assert_eq "CONTROL: and every occurrence of the ref in THIS file is a comment, never a pattern" \
+  "$(grep -n "$OREF/" "${BASH_SOURCE[0]}" | grep -cv ':[[:space:]]*#' | tr -d ' ')" "0"
+
+finish

--- a/plugins/pipeline/tests/test-panel-composition-fail-direction.sh
+++ b/plugins/pipeline/tests/test-panel-composition-fail-direction.sh
@@ -233,9 +233,12 @@ make_diff_repo() {  # $1 = dest dir, remaining args = paths to add in the HEAD c
 # CONDITION of the second escape (see the matrix section below), reproduced in a shell every
 # checkout has, so that dimension is never skipped for want of zsh. Real zsh is added when
 # present, and the two are asserted equivalent rather than assumed to be.
+# The zsh column is DECLARED, not discovered -- see optional_tool in harness.sh. Discovered by
+# `command -v`, this column simply did not exist on ubuntu-latest and said nothing about it:
+# 24 assertions fewer than a local run, both green (#47).
 RUNNERS=(bash bash-nosplit)
 ZSH_PRESENT=no
-if command -v zsh >/dev/null 2>&1; then RUNNERS+=(zsh); ZSH_PRESENT=yes; fi
+if optional_tool zsh; then RUNNERS+=(zsh); ZSH_PRESENT=yes; fi
 
 in_shell() {  # $1 = runner name, $2 = script text; runs it, stdout only
   case "$1" in
@@ -524,8 +527,6 @@ suite "the bash-nosplit stand-in, and the EXACT boundary of what it stands in fo
 # splits strictly less than zsh, so it reddens on every shape zsh reddens on and on some it
 # does not. Over-detection is the correct direction for a guard; the reverse would be a
 # stand-in that quietly passes a shape the real shell breaks on.
-assert_eq "zsh availability is REPORTED, so an absent shell is never read as a passing cell" \
-  "$([[ "$ZSH_PRESENT" == yes || "$ZSH_PRESENT" == no ]] && echo reported || echo unreported)" "reported"
 split_argc() {  # $1 = runner, $2 = shell snippet ending in `set -- ...`
   in_shell "$1" "printf 'a\nb\n' > \"$TEMP_PROJECT/two-lines.txt\"; $2; echo \$#"
 }
@@ -542,9 +543,6 @@ if [[ "$ZSH_PRESENT" == yes ]]; then
     "$(run_old_in zsh "$DL_MULTI")" "$(run_old_in bash-nosplit "$DL_MULTI")"
   assert_not_contains "and real zsh is the shell the orchestrator runs: it drops dba on the pre-fix shape" \
     "$(run_old_in zsh "$DL_MULTI")" "dba"
-else
-  assert_eq "zsh is ABSENT on this machine: the real-zsh cells were NOT RUN (the stand-in over-detects, so it still covers the condition)" \
-    "not-run" "not-run"
 fi
 
 suite "THE FIX: the shipped block gives the same answer in every cell of shell x path count"


### PR DESCRIPTION
Lane 3. Three fixes, one theme: **CI was reporting green on guarantees it did not check, and the guards meant to notice were counting instead of naming.**

Closes #47, closes #37, closes #33.
(#46 was already fixed on `main` and has been closed separately with its CI evidence. #44 turned out to live in Lane 1's file and has been handed over. #25 stays open by design.)

---

### #47 — 32 assertions did not exist where the gate is enforced

The `[zsh]` columns in `test-mis-tier-tripwire.sh` and `test-panel-composition-fail-direction.sh` are the regression test for the #17 **VETO**: zsh does not word-split an unquoted parameter expansion, so a multi-file diff reached the surface probes as one glued argument and the mis-tier tripwire silently failed to halt. `ubuntu-latest` has no zsh. Those columns ran on a laptop and nowhere else — 70 and 141 assertions in CI against 78 and 165 locally, both printing `failed=0`, both green.

Both options in the issue:

1. The runner installs zsh.
2. The columns are **declared**, not discovered. Each suite opened its column with a bare `command -v zsh` and closed the else branch with `assert_eq "..." "not-run" "not-run"` — an assertion that cannot fail, printed in the same `ok` column as one that can. `harness.sh` grows `optional_tool`, which records the tool and its state either way and, under `PIPELINE_TESTS_REQUIRE_CAPABILITIES=1` (set by the workflow and nowhere else), converts an absent tool into a counted failure **naming it**.

The issue's second option was an asserted per-platform assertion count. A count is the instrument #33 is open against — it decays every time the suite it guards legitimately grows. A capability name does not decay. With zsh installed the population no longer depends on the platform at all, which is what lets #33's pin be stated once rather than once per platform.

**Gate bites**, on a PATH stripped of zsh:

| | result |
|---|---|
| strict + absent | rc 1, `` FAIL CAPABILITY `zsh` is present ``, `passed=69 failed=1` |
| ordinary + absent | rc 0, the absence named, `passed=70` — exactly CI's number |
| strict + present | rc 0, `passed=79` |

### #37 — the ratchet

Third occurrence of one shape, twice breaking `main` at merge. `tests/test-moving-ref-population.sh` walks every file `run.sh` can reach and refuses a range against a remote-tracking ref pointed at **the checkout** — named by `$REPO_ROOT` and friends, or pointed at nothing, which leaves the command in the suite's own cwd. It names the offender by file and line.

Both hard halves are handled and asserted:

- **Fixture repos legitimately use these ranges.** The gate-bites pair the issue asks for is recorded: occurrence 2's exact line is caught, and the identical range pointed at a fixture repo passes.
- **Comments and heredocs quote these strings.** Full-line comments are prose; the uncommented twin of the same text is caught. The detector's own remote-ref half is assembled at run time, so this file sits inside the population it walks and passes by construction rather than by exemption.

### #33 — pin the set, not the count

AC19's `>=` floor decayed twice (95 against a true 96, then 96 against a true 99, at which point three assertions could have been deleted silently *through* the guard). #30's `<=` DRIFT ALARM was the interim patch, kept until the real fix existed. It exists: AC19 now pins the **set of assertion labels** each guarded suite emits, as tracked files under `tests/fixtures/labels/`. A deletion is reported by the name of the assertion that vanished. Four literals are gone.

**Gate bites:** deleting `assert_eq "an AC-label match covers the criterion" ...` reddens AC19 with that label quoted back — where the floor would have gone 95 → 94 and said nothing.

Both label sets were verified byte-identical between macOS and `ubuntu-latest` before the pin was taken, and every sort and `comm` is `LC_ALL=C`.

### Folded in (rule 0.1 — same file, no tier change, recorded rather than filed)

- `test-claims-consumers.sh` AC30's #36 patch left a control that **could not fail**: its `elif` re-ran the identical command whose emptiness had already put it there, so both branches answered `ok`. AC30 now asks its question of full history only, which is strictly stronger, with two computed non-zero controls.
- `test-issue17-integration.sh`'s `npm install` / `npm ci` checks matched the **whole workflow file**, so a comment explaining that CI installs no npm dependency turned them red while no npm ran. They now read the `run:` steps, with a control that the extraction found any and a planted npm step proving the reader still bites. The zsh step and the strict-capability env are pinned there too, so dropping either reddens a named assertion.

---

**Verification.** Full suite locally: 34 suites, `failed=0`, including AC41(c)'s fresh-checkout case. CI is the remaining unknown this PR exists to settle — specifically that `apt-get install -y zsh` succeeds and that the two suites then report 79 and 165 rather than 70 and 141.

**Net issue count for this lane: −4 closed, 0 opened.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)