### PR TITLE
Unpin two test populations from things that move (#67, #68)

### DIFF
--- a/plugins/pipeline/tests/test-moving-ref-population.sh
+++ b/plugins/pipeline/tests/test-moving-ref-population.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# THE RATCHET (#37): no test population may be derived from a range against a MOVING REF.
+# THE RATCHET: no test population may be pinned to something that moves independently of the
+# property under test. Two shapes so far, one per section: a git range against a MOVING REF
+# (#37), and an ABSOLUTE LINE RANGE into a shipped document (#68).
 #
 # THREE OCCURRENCES OF ONE SHAPE, TWICE BREAKING `main` AT MERGE.
 #
@@ -212,5 +214,92 @@ assert_eq "this suite is inside the population it walks" \
 # does not apply, which is where the next author would put the next occurrence.
 assert_eq "CONTROL: and every occurrence of the ref in THIS file is a comment, never a pattern" \
   "$(grep -n "$OREF/" "${BASH_SOURCE[0]}" | grep -cv ':[[:space:]]*#' | tr -d ' ')" "0"
+
+# =============================================================================
+# SHAPE TWO: AN ABSOLUTE LINE RANGE INTO A SHIPPED DOCUMENT (#68).
+# =============================================================================
+#
+# Same family, different moving thing. `sed -n '55,80p' "$PIPELINE_MD"` reads a 1100-line file
+# that five lanes edit concurrently, so the population is decided by everyone else's edits
+# rather than by the property under test. Measured: thirteen lines added to a section well ABOVE
+# the region pushed the paragraph one line past the window and reddened two assertions while
+# nothing about the property changed. And the failure invites the wrong remedy, which is to nudge
+# the numbers. It is over-falsifiable upward and under-falsifiable downward at the same time:
+# moving the sentences anywhere else INSIDE the window kept them green while the claim went false.
+#
+# THE DISCRIMINATOR IS THE OPERAND, and it is exact rather than heuristic. `sed -n 'N,Mp'` applied
+# to a FILE is an offset into a document somebody else owns. The same script reading STDIN is an
+# offset into a population this suite already derived for itself, which is a different statement
+# and a correct one: test-claims-consumers.sh takes the lead paragraph of a section it extracted
+# by heading, and that must not be refused.
+#
+# Written as case globs rather than as literals, for the same reason as $OREF above: this file is
+# inside the population it walks. The globs require a DIGIT after `sed -n '`, and every occurrence
+# in this file has a `[` or a `%` there instead.
+RANGE_TO_FILE_QUOTED="*sed -n '[0-9]*,[0-9]*p' \"*"
+RANGE_TO_FILE_BARE="*sed -n '[0-9]*,[0-9]*p' \$*"
+
+# line_range_offenders <file>... -> one "<basename>:<lineno>" per offending line.
+line_range_offenders() {
+  local f line trimmed n hits=""
+  for f in "$@"; do
+    [[ -f "$f" ]] || continue
+    n=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      n=$((n + 1))
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      case "$trimmed" in '#'*) continue ;; esac
+      case "$line" in
+        $RANGE_TO_FILE_QUOTED|$RANGE_TO_FILE_BARE) hits="$hits $(basename "$f"):$n" ;;
+      esac
+    done < "$f"
+  done
+  printf '%s' "${hits# }"
+}
+
+# ---------------------------------------------------------------------------
+suite "the ratchet: no test reads a shipped document through an absolute line range"
+# ---------------------------------------------------------------------------
+
+assert_eq "no test file pins a line range into a file it does not own" \
+  "$(line_range_offenders "${POPULATION[@]}")" ""
+
+# ---------------------------------------------------------------------------
+suite "GATE BITES: #68's exact line, and the derived-population read beside it"
+# ---------------------------------------------------------------------------
+
+LR_BAD="$SCRATCH/planted-line-range.sh"
+printf 'EVENTS_REGION=$(sed -n %s55,80p%s "$PIPELINE_MD")\n' "'" "'" > "$LR_BAD"
+assert_contains "the planted probe really carries #68's line" "$(cat "$LR_BAD")" "PIPELINE_MD"
+assert_eq "CONTROL: the ratchet CATCHES it, named by file and line" \
+  "$(line_range_offenders "$LR_BAD")" "planted-line-range.sh:1"
+
+# The legitimate shape, which is live in this repo today and must not be refused: an offset into
+# a population the suite derived for itself, arriving on STDIN rather than as a file operand.
+LR_GOOD="$SCRATCH/planted-derived-offset.sh"
+printf 'WORDS=$(printf %s%%s\\n%s "$UPGRADE" | sed -n %s1,4p%s | grep -oE x)\n' "'" "'" "'" "'" > "$LR_GOOD"
+assert_contains "the legitimate probe really carries the same sed script" "$(cat "$LR_GOOD")" "sed -n"
+assert_eq "CONTROL: and PASSES the identical range applied to a derived population on stdin" \
+  "$(line_range_offenders "$LR_GOOD")" ""
+
+# The unquoted operand, so the rule is about the OPERAND and not about a quoting habit.
+LR_BARE="$SCRATCH/planted-bare-operand.sh"
+printf 'R=$(sed -n %s10,20p%s $PIPELINE_MD)\n' "'" "'" > "$LR_BARE"
+assert_eq "an unquoted file operand is caught too" \
+  "$(line_range_offenders "$LR_BARE")" "planted-bare-operand.sh:1"
+
+# Prose, and its uncommented twin, exactly as for the moving-ref half.
+LR_COMMENT="$SCRATCH/planted-line-range-comment.sh"
+printf '# it used to read sed -n %s55,80p%s "$PIPELINE_MD", which broke whenever anyone edited above it\n' "'" "'" > "$LR_COMMENT"
+assert_eq "a full-line comment describing the defect is prose, not the defect" \
+  "$(line_range_offenders "$LR_COMMENT")" ""
+LR_UNCOMMENT="$SCRATCH/planted-line-range-uncommented.sh"
+sed 's/^# it used to read //; s/, which broke.*$//' "$LR_COMMENT" > "$LR_UNCOMMENT"
+assert_contains "the uncommented twin really lost its comment marker" "$(cat "$LR_UNCOMMENT")" "sed -n"
+assert_eq "CONTROL: uncommented, the identical text IS caught" \
+  "$(line_range_offenders "$LR_UNCOMMENT")" "planted-line-range-uncommented.sh:1"
+
+assert_eq "this suite is inside the population this half walks too" \
+  "$(line_range_offenders "$TESTS_DIR/$(basename "${BASH_SOURCE[0]}")")" ""
 
 finish

--- a/plugins/pipeline/tests/test-scripts-lib.sh
+++ b/plugins/pipeline/tests/test-scripts-lib.sh
@@ -43,13 +43,72 @@ suite "isMain: path form does not matter"
 # argv[1] keeps the path as invoked while import.meta.url is realpathed, so the two disagree
 # through a symlink. On macOS /tmp is itself a symlink, making that routine, not exotic.
 # Deliberately NOT canonicalized here: pwd -P would resolve the link away and measure nothing.
+#
+# --root IS AS MUCH THE SUBJECT OF THIS BLOCK AS THE PATH FORM IS (#67). Both cells ran with no
+# --root at all, so the CLI defaulted its root to THE INVOKER'S cwd, and the string they matched
+# -- "Knowledge store is empty." -- was produced by there being no knowledge/ directory beside
+# whoever ran the suite, not by main() having fired. run.sh cds into tests/, which holds no
+# store, so CI was green; run this same file from the repo root, which holds a real one, and
+# both cells failed with the live store's contents in the diff (measured: 21 passed, 2 failed).
+# A cell whose verdict is decided by the caller's working directory is not measuring the guard.
+#
+# The root is now a store THIS FILE builds and fills, and the cells match a title that only a
+# run of main() over that root can print. An absent store cannot produce it, a guard that never
+# fires prints nothing at all, and no cwd anywhere on the machine can supply it. The three
+# controls underneath are what make that a measurement rather than a claim.
+#
+# The `--root`-less shape also matters beyond this assertion, which is why it is worth removing
+# rather than working around: knowledge/ is NOT gitignored and this repo is public, run.sh is
+# the Stop-hook checkCommand at every dirty-tree turn end, and a `--list` that inherits the
+# caller's cwd is one copy-paste away from a `--write` that lands test documents in the tracked
+# store during a live pipeline run. test-knowledge-store.sh's header states that rule as prose,
+# and every invocation in this directory now carries --root.
+#
+# WHAT IS STILL ONLY PROSE, stated rather than quietly left: nothing ENFORCES that rule. A scan
+# over the suites was considered and rejected as half a guard -- most invocations here name the
+# CLI through a `$STORE` variable, which no pattern match over a single line can resolve, so the
+# scan would have been green while blind to the commonest spelling. The enforcing version belongs
+# in knowledge-store.mjs, which would refuse a WRITE whose root resolved to the checkout with no
+# --root given, and that file is not this lane's to edit.
+PROBE_ROOT="$d/probe-root"
+mkdir -p "$PROBE_ROOT/knowledge/living-context"
+cat > "$PROBE_ROOT/knowledge/living-context/probe--entrypoint.json" <<'EOF'
+{"title":"ENTRYPOINT-PROBE-MARKER","status":"current","domain":"testing",
+ "tags":["probe"],"content":"Only a run of main() over this root can print the title above.",
+ "last_updated":"2026-01-01T00:00:00Z"}
+EOF
+
 mkdir -p "$d/real" && cp "$d/lib.mjs" "$d/knowledge-store.mjs" "$d/real/" && ln -s real "$d/link"
-out=$( node "$d/link/knowledge-store.mjs" --list --collection living-context 2>&1 )
-assert_contains "invoked through a symlinked directory" "$out" "Knowledge store is empty."
+out=$( node "$d/link/knowledge-store.mjs" --list --collection living-context --root "$PROBE_ROOT" 2>&1 )
+assert_contains "invoked through a symlinked directory" "$out" "ENTRYPOINT-PROBE-MARKER"
 
 mkdir -p "$d/has space" && cp "$d/lib.mjs" "$d/knowledge-store.mjs" "$d/has space/"
-out=$( node "$d/has space/knowledge-store.mjs" --list --collection living-context 2>&1 )
-assert_contains "invoked through a path containing a space" "$out" "Knowledge store is empty."
+out=$( node "$d/has space/knowledge-store.mjs" --list --collection living-context --root "$PROBE_ROOT" 2>&1 )
+assert_contains "invoked through a path containing a space" "$out" "ENTRYPOINT-PROBE-MARKER"
+
+# CONTROL 1: THE CWD NO LONGER DECIDES. This is #67 itself, run rather than described. The same
+# invocation is made from two directories that differ in exactly the property that used to flip
+# the verdict -- one holds a real knowledge store, one holds none -- and the two must agree.
+REPO_ROOT="$(git -C "$PLUGIN_ROOT" rev-parse --show-toplevel 2>/dev/null || printf '')"
+assert_eq "CONTROL: the repo root really does hold a knowledge store (else the next cell proves nothing)" \
+  "$([[ -n "$REPO_ROOT" && -d "$REPO_ROOT/knowledge" ]] && echo holds || echo "NO STORE at ${REPO_ROOT:-<unresolved>}")" \
+  "holds"
+FROM_REPO=$( cd "$REPO_ROOT" && node "$d/link/knowledge-store.mjs" --list --collection living-context --root "$PROBE_ROOT" 2>&1 )
+FROM_TMP=$(  cd "$d"         && node "$d/link/knowledge-store.mjs" --list --collection living-context --root "$PROBE_ROOT" 2>&1 )
+assert_eq "CONTROL: run from a cwd WITH a store and from one WITHOUT, the output is identical" \
+  "$FROM_REPO" "$FROM_TMP"
+assert_contains "  and it is the probe root's content in both, not the caller's" \
+  "$FROM_REPO" "ENTRYPOINT-PROBE-MARKER"
+
+# CONTROL 2: THE MARKER IS NOT FREE. A guard that never fires prints nothing, so the cells above
+# would be equally satisfied by a harness that always printed. Through the SAME symlinked
+# directory, an IMPORT of the same module must produce no store output at all.
+printf 'import { archiveIssue } from "%s/link/knowledge-store.mjs";\nconsole.log("link-importer-ok", typeof archiveIssue);\n' "$d" > "$d/link-importer.mjs"
+LINK_IMPORT=$( cd "$d" && node "$d/link-importer.mjs" 2>&1 )
+assert_contains "CONTROL: importing through the symlink still exposes the exports" \
+  "$LINK_IMPORT" "link-importer-ok function"
+assert_not_contains "CONTROL: and prints no store, so the marker above came from main() running" \
+  "$LINK_IMPORT" "ENTRYPOINT-PROBE-MARKER"
 
 suite "assertPathSegment: refuses anything that could escape a join"
 

--- a/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
+++ b/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
@@ -256,12 +256,80 @@ assert_eq "AC12: and names KNOWN_PHASES as the key source" \
   "$([[ "$(grep -c 'KNOWN_PHASES' "$SCHEMA" | tr -d ' ')" -ge 1 ]] && echo ok || echo no)" "ok"
 
 # AC13. Two fields with OPPOSITE conventions five lines apart is the trap that produced this
-# defect. The sentence must sit inside that region, where a reader of either field meets it.
-EVENTS_REGION=$(sed -n '55,80p' "$PIPELINE_MD")
+# defect. The sentence must sit where a reader of EITHER field meets it.
+#
+# THE POPULATION IS DERIVED, NEVER A LINE RANGE (#68). This read was `sed -n '55,80p'` into an
+# 1100-line file that five lanes edit concurrently, which is #37's family exactly: a population
+# fixed to something that moves independently of the property under test. It was not
+# hypothetical. Adding thirteen lines to the Phase 0 secret rule, well ABOVE the region, pushed
+# the paragraph from line 69 to line 81, one past the window, and reddened both cells while
+# nothing about the siting changed; the remedy that failure invited was to shrink the edit or
+# nudge the numbers. It was worse in the other direction: move the sentences anywhere else
+# inside 55-80, away from the fields entirely, and both cells stay green while the claim AC13
+# makes becomes false.
+#
+# The region is now THE SECTION THE TWO FIELDS LIVE IN. It opens at the status.json template
+# that declares them and closes at the next `###` heading. That is what AC13 actually claims,
+# that a reader who meets either field meets the convention before leaving the section, and no
+# absolute line range can express it. Both anchors are unique in the file.
+md_events_region() { sed -n '/^  "current_phase": "0-setup",$/,/^### /p' "$1"; }
+EVENTS_REGION=$(md_events_region "$PIPELINE_MD")
+
+# SCOPING CONTROLS, before the claims. A range that silently swallowed the whole file would
+# satisfy every assert_contains below, so the extraction's two edges are pinned first: it must
+# reach both field definitions, and it must stop at the heading rather than running on.
+# (Precedent: the same shape at test-status-schema-contract.sh's extraction control.)
+assert_contains "AC13 SCOPE: the region opens at the status.json template that declares the fields" \
+  "$EVENTS_REGION" '"current_phase": "0-setup"'
+assert_contains "AC13 SCOPE: and reaches the other field's definition, so a reader of either is inside it" \
+  "$EVENTS_REGION" '"events": []'
+assert_contains "AC13 SCOPE: and closes on the next heading" \
+  "$EVENTS_REGION" "### Durable checkpoint convention"
+assert_not_contains "AC13 SCOPE: it does not run on into that section's body" \
+  "$EVENTS_REGION" "post-hoc log"
+assert_not_contains "AC13 SCOPE: nor back above the template" \
+  "$EVENTS_REGION" "Resolve the absolute pipeline base"
+assert_not_contains "AC13 SCOPE: nor forward past the section after it" \
+  "$EVENTS_REGION" "Risk-tiered orchestration depth"
+
 assert_contains "AC13: the events[]/current_phase region names events[] as EXIT markers" \
   "$EVENTS_REGION" "EXIT marker"
 assert_contains "AC13: and current_phase as an ENTRY marker" \
   "$EVENTS_REGION" "ENTRY marker"
+
+# GATE BITES, both directions, on copies of the real document.
+#
+# (a) THE REGRESSION #68 MEASURED, which must now pass. Thirteen lines are inserted above the
+#     region, the same shape as the secret-rule edit that broke this. The paragraph's absolute
+#     line number is asserted to have MOVED, computed rather than pinned, so this control cannot
+#     pass by the padding having silently landed somewhere harmless.
+SHIFTED="$TEMP_PROJECT/pipeline-shifted.md"
+awk '{ print } /^3\. \*\*Fetch fresh integration branch/ { for (i = 0; i < 13; i++) print "<!-- padding -->" }' \
+  "$PIPELINE_MD" > "$SHIFTED"
+md_exit_line() { grep -n 'entries are EXIT markers' "$1" | head -1 | cut -d: -f1; }
+assert_eq "CONTROL: the padded copy really moved the paragraph 13 lines down" \
+  "$(( $(md_exit_line "$SHIFTED") - $(md_exit_line "$PIPELINE_MD") ))" "13"
+assert_contains "CONTROL: and the derived region still finds it" \
+  "$(md_events_region "$SHIFTED")" "EXIT marker"
+# ...where an ABSOLUTE offset does not, which is the comparison that makes the change worth
+# making. The offset is READ OUT of the unpadded file rather than written down, so this cell
+# cannot rot into a statement about two numbers somebody typed in 2026.
+assert_not_contains "CONTROL: while the paragraph's own former line number now holds something else entirely" \
+  "$(sed -n "$(md_exit_line "$PIPELINE_MD")p" "$SHIFTED")" "EXIT marker"
+
+# (b) THE ESCAPE THE LINE RANGE COULD NOT SEE, which must now fail. The paragraph is MOVED out
+#     of the section, below the heading, and left otherwise untouched: same words, same file,
+#     wrong place. That is the whole of AC13's claim, and the old pin was blind to it.
+MOVED="$TEMP_PROJECT/pipeline-moved.md"
+awk '
+  /^\*\*`events\[\]` entries are EXIT markers/ { held = $0; next }
+  /^### Durable checkpoint convention/ { print; print ""; print held; next }
+  { print }
+' "$PIPELINE_MD" > "$MOVED"
+assert_contains "CONTROL: the mutated copy still CONTAINS the paragraph (this is a move, not a deletion)" \
+  "$(cat "$MOVED")" "entries are EXIT markers"
+assert_not_contains "CONTROL: but it is outside the section, and the derived region no longer finds it" \
+  "$(md_events_region "$MOVED")" "EXIT marker"
 
 suite "AC25: the schema stops forbidding a value its own corpus produces"
 


### PR DESCRIPTION
Both handed over by Lane 2. Both are #37/#33's family: a test whose verdict is decided by something outside the property it claims to measure.

Closes #67, closes #68.

---

### #67 — the entrypoint cells asserted on the invoker's working directory

`test-scripts-lib.sh`'s symlink and spaced-path cells ran the CLI with no `--root`, so it defaulted its root to whatever directory the caller happened to be in. The string they matched, `Knowledge store is empty.`, was produced by there being no `knowledge/` beside that caller, not by `main()` having fired. `run.sh` cds into `tests/`, which holds no store, so CI was green. From the repo root, which holds a real one, the same file reported `21 passed, 2 failed` with the live store's contents in the diff.

The root is now a store this file builds and fills, and the cells match a title only a run of `main()` over that root can print. Three controls:

- the same invocation from a cwd **with** a store and from one **without** is byte-identical, which is #67 itself run rather than described;
- an import through the same symlink prints no store at all, so the marker is evidence that `main()` ran and not that something always prints;
- the repo root is asserted to actually hold a store, or the first control proves nothing.

Measured after: `28 passed, 0 failed` from the repo root, from `tests/`, and from `$HOME`.

**Not taken, and written into the file rather than left implicit:** nothing *enforces* that every invocation carries `--root`. A scan was considered and rejected as half a guard, because most invocations name the CLI through a `$STORE` variable that no single-line pattern match can resolve, so it would have been green while blind to the commonest spelling. The enforcing version belongs in `knowledge-store.mjs`, which refuses a **write** whose root resolved to the checkout with no `--root` given. That file is Lane 2's, and this is a hardening rather than a demonstrated defect, so it is stated, not filed.

### #68 — AC13 read `pipeline.md` through `sed -n '55,80p'`

AC13's claim is a **siting** claim, and a good one. The population was an absolute offset into an 1100-line file that five lanes edit. That is over-falsifiable upward and under-falsifiable downward at the same time: thirteen lines added *above* the region reddened both cells while nothing about the siting changed, and moving the sentences anywhere else *inside* the window would keep them green while the claim went false.

The region is now the **section the two fields live in**: it opens at the `status.json` template that declares them and closes at the next `###` heading. Six scoping assertions pin both edges, because a range that silently swallowed the file would satisfy every `assert_contains` under it.

Both directions gate-bitten, on copies of the real document:

| mutation | before | after |
|---|---|---|
| 13 lines added above the region | both cells red | passes, and the paragraph's own former line number is shown to hold something else |
| the paragraph moved below the heading, same words | passes (blind to it) | **red**, which is the escape the line range could not see |

The former-line-number check reads the offset out of the file rather than writing it down, so it cannot rot into a statement about two numbers somebody typed.

### Ratcheted

`test-moving-ref-population.sh` grows a second half refusing `sed -n 'N,Mp'` applied to a **file**. The discriminator is the operand and it is exact rather than heuristic: the same script reading **stdin** is an offset into a population the suite already derived for itself, which is correct, live in this repo today at `test-claims-consumers.sh:190`, and asserted to pass. Prose and its uncommented twin are handled as in the first half, and the file stays outside its own patterns by construction.

---

**Net for this lane: 2 closed, 0 opened.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)