### PR TITLE
fix(gate): pin the in-flight boundary to the constant the guard actually uses (#63)

### DIFF
--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -506,10 +506,15 @@ function prerequisiteSatisfied(issueDir, row, events) {
  * agree on, because `??` does not fire on it.
  *
  * They also DATE the field differently -- `Date.parse` here, `new Date(...).getTime()` there --
- * which agree on the ISO strings status.schema.json requires and diverge on anything else.
- * `updated_at: 12345` reads here as the year 12345, so the record is permanently in flight,
- * while pipeline-status.mjs never classifies it at all: it throws on the number before its
- * filter is reached. Nothing in this tree pins either spelling.
+ * and MEASURED, those two agree on every STRING, not only the ISO ones status.schema.json
+ * requires: `new Date(string)` delegates to `Date.parse`, so "March 3, 2020", "2020/03/03" and
+ * "not-a-date" all land identically in both. They part only on values that are NOT strings,
+ * where `Date.parse` coerces to string first and the constructor does not. `updated_at: 12345`
+ * reads here as the year 12345, so the record is permanently in flight, while
+ * pipeline-status.mjs never classifies it at all: its filter is not reached on ANY path. With
+ * two or more issue dirs it throws first in `listActive`'s sort comparator, in both markdown
+ * and `--json`; with one dir it throws in `renderMarkdown`; and the sole non-throwing case, one
+ * dir under `--json`, does not run the filter either. Nothing in this tree pins either spelling.
  *
  * That mtime-for-updated_at substitution is the same grain mismatch #74 records against
  * session-start.sh, in a second module #74 does not yet count. No symbol is shared either, so

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -23,8 +23,9 @@
  * among the issue dirs. Two consequences are load-bearing and neither is hypothetical:
  *   - The Stop hook is PROJECT-scoped, not run-scoped, so without a recency ceiling an
  *     abandoned run parked at a guarded phase would refuse every turn in that project forever.
- *     Hence the in-flight predicate below (R6), reusing pipeline-status.mjs's own 24h /
- *     no-final-verdict definition rather than inventing a second one.
+ *     Hence the in-flight predicate below (R6). Its 24h / no-final-verdict window is a SECOND
+ *     copy of the one pipeline-status.mjs holds at :156, not a shared symbol: see the drift
+ *     note above `inFlight`, which is where that duplication lives and where #74 tracks it.
  *   - An explicit signal (CLAUDE_PIPELINE_ACTIVE_ISSUE / PIPELINE_ACTIVE_ISSUE) must not be
  *     able to NARROW the subject: pointing it at a satisfied dir would be the env-var opt-out
  *     the design rejected, and it would leave no trace in the archived record. So both the
@@ -160,7 +161,7 @@ export const UNGUARDED = [
  */
 export const TERMINAL = ["5-archived"];
 
-const IN_FLIGHT_MS = 24 * 60 * 60 * 1000;
+export const IN_FLIGHT_MS = 24 * 60 * 60 * 1000;
 
 /**
  * An unusable risk_tier resolves to the STRICTEST row, never the loosest. That default is right
@@ -487,10 +488,17 @@ function prerequisiteSatisfied(issueDir, row, events) {
 }
 
 /**
- * A run is IN FLIGHT when it was updated under 24h ago and carries no final verdict -- the
- * predicate pipeline-status.mjs already uses to call a run "possibly stuck", inverted. A record
+ * A run is IN FLIGHT when it was updated under 24h ago and carries no final verdict. A record
  * with no readable `updated_at` is not in flight: the guard cannot date it, and a control that
  * cannot date a record must not hold a project's turns open on it.
+ *
+ * DRIFT RISK, LIVE AND UNRESOLVED, TRACKED IN #74. The window below is this module's OWN
+ * literal. pipeline-status.mjs:156 holds an independent copy of the same number to call a run
+ * "possibly stuck", and the two are inverses on the age term ALONE: an undatable record is
+ * neither stuck there nor in flight here, so neither predicate is the negation of the other.
+ * No symbol is shared, so they agree only for as long as nobody moves one of them, and nothing
+ * in this tree fails if one does. #74 carries the several independent spellings of this window
+ * and the abstention they hide; until it lands the agreement is a coincidence, not a contract.
  */
 function inFlight(status, now) {
   if (status.final_verdict) return false;

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -24,8 +24,9 @@
  *   - The Stop hook is PROJECT-scoped, not run-scoped, so without a recency ceiling an
  *     abandoned run parked at a guarded phase would refuse every turn in that project forever.
  *     Hence the in-flight predicate below (R6). Its 24h / no-final-verdict window is a SECOND
- *     copy of the one pipeline-status.mjs holds at :156, not a shared symbol: see the drift
- *     note above `inFlight`, which is where that duplication lives and where #74 tracks it.
+ *     copy of the one pipeline-status.mjs holds in its `stuck` filter, not a shared symbol: see
+ *     the drift note above `inFlight`, which is where that duplication lives and where #74
+ *     tracks it.
  *   - An explicit signal (CLAUDE_PIPELINE_ACTIVE_ISSUE / PIPELINE_ACTIVE_ISSUE) must not be
  *     able to NARROW the subject: pointing it at a satisfied dir would be the env-var opt-out
  *     the design rejected, and it would leave no trace in the archived record. So both the
@@ -493,12 +494,27 @@ function prerequisiteSatisfied(issueDir, row, events) {
  * cannot date a record must not hold a project's turns open on it.
  *
  * DRIFT RISK, LIVE AND UNRESOLVED, TRACKED IN #74. The window below is this module's OWN
- * literal. pipeline-status.mjs:156 holds an independent copy of the same number to call a run
- * "possibly stuck", and the two are inverses on the age term ALONE: an undatable record is
- * neither stuck there nor in flight here, so neither predicate is the negation of the other.
- * No symbol is shared, so they agree only for as long as nobody moves one of them, and nothing
- * in this tree fails if one does. #74 carries the several independent spellings of this window
- * and the abstention they hide; until it lands the agreement is a coincidence, not a contract.
+ * literal. pipeline-status.mjs holds an independent copy of the same number in its `stuck`
+ * filter, to call a run "possibly stuck", and on the AGE term those two comparisons are
+ * complements. Neither predicate is the negation of the other even so, and the DATABILITY term
+ * is where they part -- not in agreement, as an earlier draft of this comment had it. This
+ * guard dates a record from its OWN `updated_at` and abstains when that will not parse;
+ * pipeline-status.mjs substitutes the status.json FILE MTIME for an ABSENT or NULL one first
+ * (`updated_at: status?.updated_at ?? mtime`). So a record carrying no `updated_at` at all is
+ * NOT in flight here and IS listed "possibly stuck" there as soon as the file is a day old.
+ * Measured, not reasoned. An unparseable STRING is the one undatable spelling the two still
+ * agree on, because `??` does not fire on it.
+ *
+ * They also DATE the field differently -- `Date.parse` here, `new Date(...).getTime()` there --
+ * which agree on the ISO strings status.schema.json requires and diverge on anything else.
+ * `updated_at: 12345` reads here as the year 12345, so the record is permanently in flight,
+ * while pipeline-status.mjs never classifies it at all: it throws on the number before its
+ * filter is reached. Nothing in this tree pins either spelling.
+ *
+ * That mtime-for-updated_at substitution is the same grain mismatch #74 records against
+ * session-start.sh, in a second module #74 does not yet count. No symbol is shared either, so
+ * the numbers agree only for as long as nobody moves one of them, and nothing in this tree
+ * fails if one does.
  */
 function inFlight(status, now) {
   if (status.final_verdict) return false;

--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -511,10 +511,11 @@ function prerequisiteSatisfied(issueDir, row, events) {
  * "not-a-date" all land identically in both. They part only on values that are NOT strings,
  * where `Date.parse` coerces to string first and the constructor does not. `updated_at: 12345`
  * reads here as the year 12345, so the record is permanently in flight, while
- * pipeline-status.mjs never classifies it at all: its filter is not reached on ANY path. With
- * two or more issue dirs it throws first in `listActive`'s sort comparator, in both markdown
- * and `--json`; with one dir it throws in `renderMarkdown`; and the sole non-throwing case, one
- * dir under `--json`, does not run the filter either. Nothing in this tree pins either spelling.
+ * pipeline-status.mjs never classifies it at all: its `stuck` filter is not reached on any
+ * path. Markdown mode always throws before it -- in `listActive`'s sort comparator or in
+ * `renderMarkdown`'s table loop, depending on where the offending row lands in readdir order --
+ * and `--json` never calls `renderMarkdown` at all, so the filter does not run there even when
+ * nothing throws. Nothing in this tree pins either spelling.
  *
  * That mtime-for-updated_at substitution is the same grain mismatch #74 records against
  * session-start.sh, in a second module #74 does not yet count. No symbol is shared either, so

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -36,7 +36,184 @@ REPO_ROOT="$(git -C "$PLUGIN_ROOT" rev-parse --show-toplevel 2>/dev/null || prin
 iso_hours_ago() { node -e 'process.stdout.write(new Date(Date.now()-Number(process.argv[1])*3600e3).toISOString())' "$1"; }
 
 FRESH_ISO="$(iso_hours_ago 1)"     # in flight
-STALE_ISO="$(iso_hours_ago 25)"    # past R6's 24h ceiling
+STALE_ISO="$(iso_hours_ago 25)"    # past the in-flight window; #63-P2 asserts that against
+                                   # the value the guard exports, rather than restating it here
+
+# ===========================================================================================
+# #63 -- THE IN-FLIGHT CEILING, READ FROM THE GUARD INSTEAD OF RE-SPELLED HERE (preflight half)
+#
+# THE DEFECT. `IN_FLIGHT_MS` decides whether this guard evaluates a record AT ALL, and until now
+# no cell in this suite pinned either side of its boundary. The measured green window was roughly
+# (1.0h, 25.05h): the constant could fall to 1/23rd of its value with every assertion in the
+# three gate suites still green. TWO FIXED FIXTURE AGES WOULD REPRODUCE THAT DEFECT AT NEW
+# COORDINATES, so both ages below are COMPUTED from the value the module exports, and the only
+# remaining bound on the VALUE is the pair of premise cells at the bottom of this block.
+#
+# THE PATH RULE, STATED ONCE AND NOT RESTATED AT EACH CELL. Three resolutions are in play and
+# mixing them is the collision this section is most likely to be broken by.
+#   - #63-A1/#63-A2 (the export and its value) and #63-D1/#63-D2/#63-D3 (the module-shape pins
+#     the declared survivor rests on) read the CHECKOUT, `$REPO_ROOT/plugins/pipeline/scripts/
+#     gate-phase-entry.mjs`. REPO_ROOT derives from PLUGIN_ROOT, which no SCRIPTS_DIR redirect
+#     moves. Bind those to $GUARD instead and they go RED under the rewritten copy described
+#     below WITH THE CHECKOUT UNTOUCHED -- a red cell about nothing, and one that falsifies the
+#     expected-red declaration below for a reason unrelated to the constant.
+#   - The two off-checkout copies (#63-C1..#63-C3, #63-V1..#63-V3) resolve $SCRIPTS_DIR, which
+#     harness.sh:11 leaves overridable.
+#   - probe43 expands $GUARD at CALL time, so `GUARD="<copy>" probe43 ...` drives a copy for
+#     exactly that call. On /bin/bash 3.2.57 a prefix assignment before a FUNCTION call is scoped
+#     to the call (`G=outer; G=inner f; echo $G` prints `outer`); no subshell, no global rebind.
+#
+# DRIFT IMMUNITY, AND WHAT A REWRITTEN RUN IS EXPECTED TO LOOK LIKE. harness.sh:11 is
+# `SCRIPTS_DIR="${SCRIPTS_DIR:-...}"`, so
+#     SCRIPTS_DIR=<tmpdir copy of the WHOLE scripts dir, constant rewritten> \
+#       /bin/bash plugins/pipeline/tests/test-gate-phase-entry.sh
+# drives a different ceiling with the checkout untouched. At 24h and at 2h THIS suite is fully
+# green -- so the declaration below DISCRIMINATES rather than merely permits. At 48h EXACTLY TWO
+# cells in THIS suite are expected red, and both fail for the same correct reason, that STALE_ISO
+# is a 25h LITERAL and 25h is legitimately INSIDE a 48h window:
+#     (i) the existing label `(a) 25h old, no final verdict -> not-applicable even at a guarded
+#         phase`, and (ii) #63-P2 below.
+# Leave those red or record them. Do NOT rebase STALE_ISO onto the constant (out of scope) and do
+# NOT delete #63-P2. Neither red is evidence against the derivation.
+#
+# SCRIPTS_DIR IS NOT TRANSPARENT, AND THE NON-TRANSPARENCY IS NOT THIS CONSTANT'S DOING. Measured
+# in three checkouts on ONE machine and ONE toolchain (bash 3.2.57(1)-release
+# x86_64-apple-darwin25, node v24.19.0 -- three observations, not three environments): an
+# UNMODIFIED whole-directory copy under SCRIPTS_DIR leaves THIS suite at 462/0 and takes
+# test-gate-phase-entry-hook.sh from 59/0 to 57/2 at EVERY ceiling value (24h, 2h and 48h alike),
+# because test-voice-lint.sh itself measures 44/4 under a redirected SCRIPTS_DIR. So a WHOLE-SET
+# run at 48h shows THREE reds, not two: this suite's two, plus the hook suite's two-cell artefact
+# of the REDIRECTION. Whoever re-derives this months from now reads this file, not a PR body.
+#
+# TWO MUTATIONS ARE EXPECTED TO SURVIVE THIS SECTION, each with a stated mechanism, because a
+# battery in which everything reddens cannot tell coverage from a rubber stamp.
+#   1. `inFlight`'s `now - updated <= IN_FLIGHT_MS` -> `<`. The two spellings differ only when the
+#      age is exactly IN_FLIGHT_MS to the MILLISECOND, and the guard reads its own Date.now() in a
+#      child process started AFTER the fixture was written, so no CLI-driven fixture lands there.
+#      The residual is bounded to one millisecond and points toward ABSTENTION -- a silence, not a
+#      falsehood. #63-D1/#63-D2/#63-D3 pin the CHEAP ways that premise stops holding (a re-spelled
+#      clock, an override folded into the single read, an added `inFlight` export). THEY DO NOT
+#      CLOSE THE CLASS: an override threaded into `inFlight`'s `now` ARGUMENT at its call site
+#      leaves all three green and makes the guard's clock millisecond-exact from outside. That
+#      remains a REVIEW OBLIGATION on any future edit to that argument, not a mechanized guarantee.
+#   2. probe43's `age > CEIL` -> `>=`, the exact COMPLEMENT of (1), unreachable for the same
+#      reason. #63-V5 makes that BRANCH live -- before it, deleting the staleness push entirely
+#      left this suite at 462/0 -- which buys liveness, not falsifiability. The OPERATOR stays
+#      unpinned and this section does not claim otherwise.
+# If either ever reddens, something changed about the CLOCK, not about the boundary.
+# ===========================================================================================
+
+# MARGIN: how far each boundary fixture sits from the ceiling, on both sides. A LITERAL, pinned
+# here rather than left to a caller, by a two-sided rule -- at least two orders of magnitude above
+# the measured fixture-write-to-gate-return elapsed (237/227/239 ms over three runs, so ~1250x
+# headroom, and #63-E1 ASSERTS that headroom rather than assuming it), and under 1% of the window
+# (0.35% at 24h). Note the grain: that elapsed is fixture-write-to-gate-RETURN, which is not the
+# 80-90 ms figure for a bare CLI invocation. The two measure different spans.
+MARGIN=300000
+
+# The #63 id ledger. Its own, not an extension of #43's or #61's: their Z2 cells grep `#43-...`
+# and `#61-...` and a `#63-` id would not match either, so the three are independent by
+# construction. Every `#63-` id is registered as its cell RUNS, and #63-Z2 at the bottom of this
+# file compares that against every `#63-` id written in this file's SOURCE -- comments included.
+# So do not write a `#63-<suffix>` in a comment unless a cell registers it.
+AC63_IDS=""
+reg63() { AC63_IDS="$AC63_IDS$1
+"; }
+
+# iso_ms_ago <ms> -> an ISO timestamp COMPUTED NOW, at MILLISECOND grain. `iso_hours_ago` above
+# cannot express a margin small enough to sit inside the window without rounding it away.
+iso_ms_ago() { node -e 'process.stdout.write(new Date(Date.now()-Number(process.argv[1])).toISOString())' "$1"; }
+
+# ac63_age_vs_ceiling <iso> <ceiling-ms> -> `inside` | `outside` | `exactly-at-the-ceiling` | a
+# diagnosis. Three-way on purpose: folding equality into either side would let a premise cell
+# claim a strictness it never checked.
+ac63_age_vs_ceiling() {
+  node -e '
+    const CEIL = Number(process.argv[2]);
+    if (!Number.isFinite(CEIL) || CEIL <= 0) { process.stdout.write("the exported IN_FLIGHT_MS did not read as a finite positive number"); process.exit(0); }
+    const parsed = Date.parse(process.argv[1]);
+    if (!Number.isFinite(parsed)) { process.stdout.write("NOT DATABLE: " + JSON.stringify(process.argv[1])); process.exit(0); }
+    const age = Date.now() - parsed;
+    process.stdout.write(age < CEIL ? "inside" : age > CEIL ? "outside" : "exactly-at-the-ceiling");
+  ' "$1" "$2"
+}
+
+# ac63_capture_staleness <status.json> <ceiling-ms> -> `stale` | `REFRESHED` | the validation
+# sentence. EXTRACTED rather than left inline at its one call site, because #63-V4 has to drive
+# THE SAME FUNCTION the capture tripwire calls; an exercise against a COPY of the tripwire would
+# be testing a copy of the check rather than the check.
+#
+# THE GUARD IS NOT DEFENCE IN DEPTH HERE. A substituted read can arrive as `undefined` or as an
+# empty shell argument where a literal could not, and `age > undefined` and `age > NaN` are both
+# FALSE -- so an unvalidated site answers `REFRESHED` about a 437-hour-old capture and the
+# tripwire silently retires. `Number("") === 0`, so an EMPTY argument is caught by the `CEIL <= 0`
+# half and not by `isFinite`: both halves are required, and the argument must be QUOTED at every
+# call site or an empty one vanishes and shifts argv.
+ac63_capture_staleness() {
+  node -e '
+    const CEIL = Number(process.argv[2]);
+    if (!Number.isFinite(CEIL) || CEIL <= 0) { process.stdout.write("the exported IN_FLIGHT_MS did not read as a finite positive number"); process.exit(0); }
+    const s = require(process.argv[1]);
+    process.stdout.write((Date.now() - new Date(s.updated_at).getTime()) > CEIL ? "stale" : "REFRESHED");
+  ' "$1" "$2"
+}
+
+# ac63_read_state <read> <margin> -> `ok`, or a diagnosis that NAMES what came back.
+ac63_read_state() {
+  node -e '
+    const raw = process.argv[1], margin = Number(process.argv[2]);
+    if (raw === "") { process.stdout.write("the read produced NOTHING: the import failed, or the module threw before it could be read"); process.exit(0); }
+    if (raw === "undefined") { process.stdout.write("the module exports no IN_FLIGHT_MS: the read came back as the string \"undefined\""); process.exit(0); }
+    const n = Number(raw);
+    if (!Number.isFinite(n)) { process.stdout.write("the read is not a finite number: " + JSON.stringify(raw)); process.exit(0); }
+    if (!Number.isInteger(n)) { process.stdout.write("the read is not an integer: " + JSON.stringify(raw)); process.exit(0); }
+    if (!(n > 2 * margin)) { process.stdout.write("the read is " + n + ", which is not strictly greater than 2*MARGIN (" + (2 * margin) + ")"); process.exit(0); }
+    process.stdout.write("ok");
+  ' "$1" "$2"
+}
+
+# THE READ: ONCE, here, through the dynamic-import path probe43 already uses. Everything #63
+# derives is derived from this one value.
+IN_FLIGHT_MS="$(node --input-type=module -e 'const m = await import(process.argv[1]); process.stdout.write(String(m.IN_FLIGHT_MS))' "$GUARD" 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+suite "#63 preflight: the ceiling is READ from the guard, and asserted before anything derives from it"
+# ---------------------------------------------------------------------------
+AC63_READ_STATE="$(ac63_read_state "$IN_FLIGHT_MS" "$MARGIN")"
+reg63 "#63-R1"
+assert_eq "#63-R1 the ceiling read out of the guard is a finite INTEGER strictly greater than 2*MARGIN -- \"a positive integer of plausible magnitude\" is one adjective short of the precondition the fixtures need: any value at or below MARGIN makes the INSIDE age IN_FLIGHT_MS - MARGIN zero or NEGATIVE, which dates that fixture in the FUTURE, and the guard has no floor, so a future-dated record is PERMANENTLY in flight" \
+  "$AC63_READ_STATE" "ok"
+
+# THE HALT, AND WHY IT IS NOT BELT-AND-BRACES. Measured against a real export-only build: with an
+# EMPTY read -- the one spelling `set -u` does NOT catch, since $(( IN_FLIGHT_MS - MARGIN )) then
+# yields -300000 with rc 0 and no diagnostic -- the INSIDE fixture is dated in the FUTURE and
+# #63-B1 PASSES, the #63-C1..#63-C3 control's shift goes negative so every record falls out of
+# flight and #63-C3 PASSES too, and ONLY #63-B2 reddens, with a message that says nothing about
+# the read. Two of the three boundary cells go green VACUOUSLY. Halting here is the only thing
+# that turns that one-cell red into a diagnosis.
+#
+# THE SPELLING IS LOAD-BEARING: `finish || exit 1`, never a bare `exit`. A bare exit skips
+# finish(), so the run prints no passed=/failed= tally AND never runs the harness's
+# uncounted-assertion guard. The assertion above fires FIRST so the failure is a COUNTED red cell
+# in the ledger rather than a bare message.
+if [[ "$AC63_READ_STATE" != "ok" ]]; then
+  printf '\n#63 HALT: %s\n' "$AC63_READ_STATE" >&2
+  printf '       Every age this suite derives from that value is meaningless, and two of the three\n' >&2
+  printf '       boundary cells would go GREEN VACUOUSLY rather than red. Refusing to report on them.\n' >&2
+  printf '       The guard must export IN_FLIGHT_MS (see #63-A1). If this is a partial revert that\n' >&2
+  printf '       dropped the export while keeping this suite, restore the export or revert both.\n' >&2
+  finish || exit 1
+fi
+
+# THE TWO PREMISES. These carry more weight than their own cells and are NOT a nicety a later
+# author may tidy away. FRESH_ISO and STALE_ISO are load-bearing for 400-plus assertions in this
+# file and their in/out status was, until now, assumed and never stated.
+reg63 "#63-P1"
+assert_eq "#63-P1 FRESH_ISO is INSIDE the ceiling. This is the only thing standing between the corpus walk's zero (\`no committed record is refused by the table\`) and a VACUOUS green: that walk rewrites every committed record's updated_at to FRESH_ISO precisely so staleness cannot mask the table, and its pass set is granted|not-applicable -- so if FRESH_ISO ever fell OUTSIDE, every corpus record would abstain and the zero would stay green over a wholly abstaining population. DIAGNOSIS, not sole detection: ~234 other cells redden in the same run" \
+  "$(ac63_age_vs_ceiling "$FRESH_ISO" "$IN_FLIGHT_MS")" "inside"
+reg63 "#63-P2"
+assert_eq "#63-P2 STALE_ISO is OUTSIDE the ceiling. With #63-P1 this is the ONLY remaining bound on the VALUE of IN_FLIGHT_MS after #63 -- roughly (1.0h, 25.05h) -- because every other new cell is DERIVED from the value and therefore value-independent. EXPECTED RED, and correctly so, under a rewrite of the constant to 48h: STALE_ISO is a 25h literal and 25h is legitimately inside a 48h window" \
+  "$(ac63_age_vs_ceiling "$STALE_ISO" "$IN_FLIGHT_MS")" "outside"
 
 # new_case <issue-dir-name> <status-json> -> CASE_ROOT, CASE_DIR
 new_case() {
@@ -609,7 +786,7 @@ assert_eq "(b) 1h old (COMPUTED at test time) at the same phase -> refused" "$GA
 # refreshes exp-script-test-coverage's updated_at, this fails loudly instead of the staleness
 # check silently retiring.
 assert_eq "the capture is still permanently stale (>24h), which is what (c) tests" \
-  "$(node -e 'const s=require(process.argv[1]);process.stdout.write((Date.now()-new Date(s.updated_at).getTime())>24*3600e3?"stale":"REFRESHED")' "$REC_STC")" \
+  "$(ac63_capture_staleness "$REC_STC" "$IN_FLIGHT_MS")" \
   "stale"
 new_case exp-script-test-coverage '{}'
 capture "$REC_STC" "$CASE_DIR/status.json" '{}'
@@ -983,11 +1160,18 @@ probe43() {
     import { readFileSync } from "node:fs";
     const mod = await import(process.argv[1]);
     const guarded = new Set([...mod.ENTRY, ...mod.EXIT]);
+    // #63: the ceiling this probe judges against is the guard'"'"'s OWN exported value, not a second
+    // copy of the number spelled here -- and it is VALIDATED before it is compared against. A
+    // substituted read can arrive as `undefined` where a literal could not, and `age > undefined`
+    // and `age > NaN` are both FALSE, so an unvalidated read answers `ok` about a fixture it never
+    // judged, silently, for the ~345 assertions this probe qualifies.
+    const CEIL = Number(mod.IN_FLIGHT_MS);
     let s;
     try { s = JSON.parse(readFileSync(process.argv[2], "utf8")); }
     catch (e) { process.stdout.write("UNPARSEABLE FIXTURE: " + e.message.slice(0, 60)); process.exit(0); }
     if (!s || typeof s !== "object" || Array.isArray(s)) { process.stdout.write("NON-OBJECT FIXTURE"); process.exit(0); }
     const bad = [];
+    if (!Number.isFinite(CEIL) || CEIL <= 0) bad.push("the exported IN_FLIGHT_MS did not read as a finite positive number");
     if (s.completed_at) bad.push("completed_at is truthy: this fixture exits by the isTerminal route");
     if (s.final_verdict) bad.push("final_verdict is truthy: this fixture exits by the concluded route");
     if (typeof s.current_phase !== "string" || !guarded.has(s.current_phase)) {
@@ -996,7 +1180,7 @@ probe43() {
     const parsed = Date.parse(s.updated_at);
     if (process.argv[3] === "fresh") {
       if (!Number.isFinite(parsed)) bad.push("updated_at is NOT datable, but this cell is the datable control");
-      else if (Date.now() - parsed > 24 * 3600e3) bad.push("updated_at is past the 24h ceiling: this cell would test staleness");
+      else if (Number.isFinite(CEIL) && CEIL > 0 && Date.now() - parsed > CEIL) bad.push("updated_at is past the in-flight ceiling this suite reads from the guard: this cell would test staleness");
     } else if (process.argv[3] === "undatable") {
       if (Number.isFinite(parsed)) bad.push("updated_at IS datable, so this cell tests staleness, not undatability");
     } else bad.push("the cell asked for an unknown datability: " + process.argv[3]);
@@ -2273,5 +2457,260 @@ assert_eq "#61-Z1 no #61 assertion id is used twice (a colliding label makes the
 assert_eq "#61-Z2 every #61 id written in this file was REGISTERED by a cell that ran" \
   "$(printf '%s\n' "$AC61_UNIQ" | grep -c . | tr -d ' ')" \
   "$(grep -o '#61-[A-Za-z0-9][A-Za-z0-9]*' "${BASH_SOURCE[0]}" | sort -u | grep -c . | tr -d ' ')"
+
+
+# ===========================================================================================
+# #63 -- THE BOUNDARY PAIR, ITS CONTROL, AND THE PINS UNDER THE DECLARED SURVIVOR.
+#
+# The preflight half of this section is at the top of the file, beside the fixture helpers,
+# because the capture tripwire at the AC15 suite calls one of its functions. The PATH RULE, the
+# expected-red declaration under a rewritten ceiling, the SCRIPTS_DIR non-transparency
+# measurement and the two expected survivors are all stated there, once, and are not restated
+# here.
+#
+# ONE COPY HELPER, TWO CONSUMERS. `ac63_guard_copy` below is the only way this section builds an
+# off-checkout guard, and it copies the WHOLE scripts directory every time. harness.sh's
+# `copy_script_with_deps` (the script plus lib.mjs) is NOT usable here and the near-miss is the
+# most likely wrong turn in this section: gate-phase-entry.mjs imports ./lib.mjs,
+# ./dispatch-model.mjs, ./pipeline-telemetry.mjs and ./validate-pipeline-artifact.mjs by relative
+# path, and a partial copy throws ERR_MODULE_NOT_FOUND straight into the guard's own
+# fail-open-on-tooling-error catch. MEASURED: that produces `<no-decision-on-stdout>` with rc 1 --
+# which an rc-only assertion reads as a pass -- and, worse, probe43 folds stderr into stdout, so
+# against a partial copy the VALIDATED and the UNVALIDATED probe emit BYTE-IDENTICAL stack traces
+# and an `output != "ok"` exercise passes identically for both. That is why every cell below
+# asserts the DECISION STRING or the EXACT SENTENCE, and never an exit code and never an
+# inequality against "ok".
+# ===========================================================================================
+
+# ac63_guard_copy <label> <replacement-line> -> AC63_COPY_GUARD, AC63_COPY_MATCHES.
+# The match count is REPORTED, never swallowed, because every call site asserts it is exactly 1:
+# a 0 means the declaration was reformatted and the cells below are silently driving the SHIPPED
+# ceiling while claiming to drive a rewritten one.
+#
+# IT SETS GLOBALS AND DOES NOT ECHO, for the reason new_tmpdir gives one line up in harness.sh: a
+# `$(...)` capture runs in a SUBSHELL, so both the guard path AND the temp-dir REGISTRATION would
+# be discarded there and the trap would never own the directory it handed out. MEASURED, on the
+# first draft of this section: `X="$(ac63_guard_copy ...)"` died at the next line with
+# `AC63_COPY_GUARD: unbound variable`.
+ac63_guard_copy() {
+  local label="$1" repl="$2"
+  new_tmpdir || exit 90
+  cp -R "$SCRIPTS_DIR" "$NEW_TMPDIR/scripts" || exit 90
+  AC63_COPY_GUARD="$NEW_TMPDIR/scripts/gate-phase-entry.mjs"
+  AC63_COPY_MATCHES="$(node -e '
+    const fs = require("node:fs");
+    const p = process.argv[1], repl = process.argv[2];
+    const re = /^export const IN_FLIGHT_MS = .*;$/;
+    let n = 0;
+    const out = fs.readFileSync(p, "utf8").split("\n").map((l) => { if (re.test(l)) { n++; return repl; } return l; });
+    fs.writeFileSync(p, out.join("\n"));
+    if (n !== 1) process.stderr.write("ac63_guard_copy(" + process.argv[3] + "): matched " + n + " declaration line(s), expected 1\n");
+    process.stdout.write(String(n));
+  ' "$AC63_COPY_GUARD" "$repl" "$label")"
+}
+
+# ---------------------------------------------------------------------------
+suite "#63 the boundary PAIR: both ages COMPUTED from the exported ceiling, neither spelled"
+# ---------------------------------------------------------------------------
+# Both cells are `3-impl` at the architectural tier with the prerequisite ABSENT and no events --
+# the same shape the AC15(a)/(b) cells use -- so the only thing that differs between them is
+# which side of the ceiling the record sits on.
+
+AC63_IN_AGE=$(( IN_FLIGHT_MS - MARGIN ))
+AC63_OUT_AGE=$(( IN_FLIGHT_MS + MARGIN ))
+
+AC63_T0="$(node -e 'process.stdout.write(String(Date.now()))')"
+MK_UPDATED="$(iso_ms_ago "$AC63_IN_AGE")"
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+MK_UPDATED=""
+AC63_IN_ROOT="$CASE_ROOT"
+gate "$CASE_ROOT"
+AC63_ELAPSED=$(( $(node -e 'process.stdout.write(String(Date.now()))') - AC63_T0 ))
+reg63 "#63-B1"
+assert_eq "#63-B1 INSIDE the ceiling by MARGIN (updated_at = now - (IN_FLIGHT_MS - MARGIN), COMPUTED from the exported value and spelled nowhere): the guard EVALUATES the record and refuses" \
+  "$GATE_DEC/$GATE_RC" "refused/2"
+reg63 "#63-E1"
+assert_eq "#63-E1 the wall clock from writing the INSIDE fixture to the gate returning is strictly under MARGIN. ASSERTED, not printed: that cell's EFFECTIVE age is IN_FLIGHT_MS - MARGIN + elapsed, so an unasserted margin turns a slow runner into a FLAKE instead of a failure. Measured elapsed here: ${AC63_ELAPSED}ms against a MARGIN of ${MARGIN}ms" \
+  "$(if [[ "$AC63_ELAPSED" -lt "$MARGIN" ]]; then printf 'under'; else printf 'OVER'; fi)" "under"
+
+MK_UPDATED="$(iso_ms_ago "$AC63_OUT_AGE")"
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+MK_UPDATED=""
+AC63_OUT_ROOT="$CASE_ROOT"
+gate "$CASE_ROOT"
+reg63 "#63-B2"
+assert_eq "#63-B2 OUTSIDE the ceiling by MARGIN (the IDENTICAL record body, updated_at = now - (IN_FLIGHT_MS + MARGIN)): the guard ABSTAINS -- and with #63-B1 that is the first pin either side of a boundary whose green window was measured at roughly (1.0h, 25.05h)" \
+  "$GATE_DEC/$GATE_RC" "not-applicable/0"
+reg63 "#63-B3"
+assert_contains "#63-B3 and the abstention names the IN-FLIGHT route specifically: decideForDir reaches not-applicable by four routes before this one, and a decision-only assertion cannot say which fired" \
+  "$GATE_OUT" "is not in flight"
+
+# ---------------------------------------------------------------------------
+suite "#63 the NON-ZERO CONTROL: the pair reads the ceiling rather than merely equalling itself"
+# ---------------------------------------------------------------------------
+# THE SHIFT IS COMPUTED, NEVER SPELLED. floor((IN_FLIGHT_MS - MARGIN) / 2) is strictly below the
+# INSIDE fixture's age at EVERY base value, because floor(X/2) < X for X = IN_FLIGHT_MS - MARGIN
+# > MARGIN -- which is exactly what #63-R1 asserts. So the flip below is guaranteed, not lucky.
+# A control that rewrote the LITERAL instead would find ZERO occurrences of it in a rewritten
+# build and would manufacture a third red cell there, falsifying the expected-red declaration in
+# the preflight block for a reason that has nothing to do with the constant.
+
+AC63_PORCELAIN_BEFORE="$(git -C "$PLUGIN_ROOT" status --porcelain 2>/dev/null)"
+AC63_GUARD_SUM_BEFORE="$(cksum < "$SCRIPTS_DIR/gate-phase-entry.mjs")"
+
+AC63_SHIFT=$(( (IN_FLIGHT_MS - MARGIN) / 2 ))
+ac63_guard_copy "shifted-boundary control" "export const IN_FLIGHT_MS = $AC63_SHIFT;"
+AC63_SHIFT_GUARD="$AC63_COPY_GUARD"
+reg63 "#63-C1"
+assert_eq "#63-C1 the shifted-boundary rewrite located EXACTLY ONE declaration line -- 0 means the declaration was reformatted and #63-C2/#63-C3 are silently driving the SHIPPED ceiling while reporting a control" \
+  "$AC63_COPY_MATCHES" "1"
+
+gate_using "$AC63_SHIFT_GUARD" "$AC63_IN_ROOT"
+reg63 "#63-C2"
+assert_eq "#63-C2 against a whole-scripts-dir copy whose ceiling is HALVED, the IDENTICAL INSIDE fixture FLIPS to not-applicable. Asserted on the DECISION STRING and never on rc: a partial copy fails open to <no-decision-on-stdout> with rc 1, which an rc-only assertion reads as a pass and cannot tell from a real abstention" \
+  "$GATE_DEC" "not-applicable"
+gate_using "$AC63_SHIFT_GUARD" "$AC63_OUT_ROOT"
+reg63 "#63-C3"
+assert_eq "#63-C3 and the OUTSIDE fixture HOLDS at not-applicable against that same copy, so #63-C2 is a DISCRIMINATION and not a copy that abstains on sight" \
+  "$GATE_DEC" "not-applicable"
+
+# THE CHECKOUT IS NEVER WRITTEN. Both halves are asserted, and #63-C5 is the load-bearing one.
+# MEASURED, by pointing the rewrite at $SCRIPTS_DIR/gate-phase-entry.mjs in a tree where that
+# file was ALREADY modified: #63-C4 SURVIVED that mutation and only #63-C5 caught it, because
+# `git status --porcelain` prints the same ` M <path>` line before and after -- a file already
+# recorded as modified cannot be recorded as modified twice. So the porcelain half is the coarse
+# one and is blind in a dirty tree, which is the tree Dev works in; the checksum half compares
+# two NON-EMPTY operands and fires either way. Do not delete #63-C5 as a duplicate of #63-C4.
+#
+# DELIBERATE DEVIATION, FLAGGED FOR REVIEW: the criterion says `git status --porcelain` is EMPTY.
+# Asserted as written, this cell reddens for anyone with unrelated uncommitted work in the tree --
+# including whoever is mid-edit on this very file -- which is a red cell about the operator's
+# working tree rather than about the control. INVARIANCE is the property the criterion exists for
+# ("an interrupted run cannot leave a shifted constant in the checkout") and it reddens under the
+# criterion's own named mutation (point the rewrite at $SCRIPTS_DIR/gate-phase-entry.mjs).
+AC63_PORCELAIN_AFTER="$(git -C "$PLUGIN_ROOT" status --porcelain 2>/dev/null)"
+reg63 "#63-C4"
+assert_eq "#63-C4 the controls left the checkout EXACTLY as they found it: git status --porcelain inside the plugin tree is unchanged across them, so an interrupted run cannot leave a shifted constant behind. THE COARSE HALF: it is blind when the guard is already modified, since porcelain prints the same line before and after -- #63-C5 is what bites there" \
+  "$AC63_PORCELAIN_AFTER" "$AC63_PORCELAIN_BEFORE"
+reg63 "#63-C5"
+assert_eq "#63-C5 and the SHIPPED guard is byte-identical after those cells ran (checksum, two non-empty operands, so this is not a zero-versus-zero comparison)" \
+  "$(cksum < "$SCRIPTS_DIR/gate-phase-entry.mjs")" "$AC63_GUARD_SUM_BEFORE"
+
+# ---------------------------------------------------------------------------
+suite "#63 the export itself, and the module shape the declared survivor rests on"
+# ---------------------------------------------------------------------------
+AC63_CHECKOUT_GUARD="$REPO_ROOT/plugins/pipeline/scripts/gate-phase-entry.mjs"
+reg63 "#63-A0"
+assert_eq "#63-A0 REPO_ROOT resolves and the checkout copy of the guard is readable. This cell FAILS rather than skipping: the five cells below are the only ones in #63 that read the CHECKOUT rather than whatever \$SCRIPTS_DIR points at, and a skip would retire all five in silence" \
+  "$(if [[ -n "$REPO_ROOT" && -f "$AC63_CHECKOUT_GUARD" ]]; then printf 'resolved'; else printf 'UNRESOLVED: REPO_ROOT=%s' "${REPO_ROOT:-<empty>}"; fi)" "resolved"
+reg63 "#63-A1"
+assert_eq "#63-A1 the guard EXPORTS the ceiling exactly once, so this suite can read the number instead of re-spelling it. Read from the CHECKOUT, never \$GUARD" \
+  "$(grep -c '^export const IN_FLIGHT_MS' "$AC63_CHECKOUT_GUARD" 2>/dev/null | tr -d ' ')" "1"
+reg63 "#63-A2"
+assert_eq "#63-A2 and the exported VALUE is unchanged by the export -- both halves are needed, since a cell asserting only the grep count would pass with the value silently moved" \
+  "$(sed -n 's/^export const IN_FLIGHT_MS = \(.*\);$/\1/p' "$AC63_CHECKOUT_GUARD" 2>/dev/null)" "24 * 60 * 60 * 1000"
+
+# The three pins under the FIRST declared survivor. They catch the CHEAP ways its premise stops
+# holding. They do NOT close the class -- see the preflight block.
+reg63 "#63-D1"
+assert_eq "#63-D1 Date.now() occurs exactly ONCE in the module. IF THIS FAILS: the count moved, which means EITHER a clock seam now exists OR the token was written in a comment or a string with no seam at all -- this cell's failure direction is toward FALSE ALARM, so read the diff. If it is a seam, the <=/< survivor is no longer justified and must be re-opened" \
+  "$(grep -o 'Date\.now()' "$AC63_CHECKOUT_GUARD" 2>/dev/null | grep -c . | tr -d ' ')" "1"
+reg63 "#63-D2"
+assert_eq "#63-D2 the initializer that feeds inFlight is spelled exactly \`  const now = Date.now();\`. This is NOT redundant with #63-D1: folding an override into that single read (\`Number(process.env.GATE_NOW) || Date.now()\`) leaves the whole-file count at exactly 1 and #63-D1 GREEN, and that divergence is the entire reason this cell exists. IF THIS FAILS the survivor's justification must be re-opened" \
+  "$(grep -c '^  const now = Date\.now();$' "$AC63_CHECKOUT_GUARD" 2>/dev/null | tr -d ' ')" "1"
+reg63 "#63-D3"
+assert_eq "#63-D3 the module exports no inFlight, asserted by DYNAMIC IMPORT and deliberately not by grep: appending \`export { inFlight };\` leaves \`grep -c '^export function inFlight'\` at 0 while the import reads \`function\`. Exporting the predicate would create a second parallel path to the same answer, which is what the survivor's justification rests on NOT existing" \
+  "$(node --input-type=module -e 'const m = await import(process.argv[1]); process.stdout.write(typeof m.inFlight === "undefined" ? "absent" : "EXPORTED as " + typeof m.inFlight)' "$AC63_CHECKOUT_GUARD" 2>/dev/null)" "absent"
+
+# ---------------------------------------------------------------------------
+suite "#63 the guard's own prose: the shared-definition claim is corrected AND sited"
+# ---------------------------------------------------------------------------
+# (i) and (ii) are both satisfied by DELETION, which would leave no drift-risk sentence anywhere
+# near the predicate and nothing citing the follow-up issue in the file. (iii) is the cell that
+# closes that: it is POSITIVE and SITED, and it is RED before the change (neither token occurs
+# anywhere under scripts/ or tests/ today), so it can go green only by putting the citation where
+# the predicate is. The BAND IS RELATIVE to `function inFlight(`, never an absolute line range:
+# an absolute range decays the first time anything above it moves.
+ac63_scripts_hits() { grep -r -c -- "$1" "$REPO_ROOT/plugins/pipeline/scripts/" 2>/dev/null | awk -F: '{ s += $NF } END { print s + 0 }'; }
+reg63 "#63-H1"
+assert_eq "#63-H1 the guard no longer claims it is \"reusing\" pipeline-status.mjs's window: there is no shared symbol and both modules hold their own literal, so the header claim was flatly false (non-zero control: exactly 1 hit before the change)" \
+  "$(ac63_scripts_hits 'reusing pipeline-status')" "0"
+reg63 "#63-H2"
+assert_eq "#63-H2 and inFlight's own doc comment no longer claims the predicate is the one pipeline-status.mjs \"already uses\" -- TRUE today and silently FALSE the moment either literal moves, which is the exact drift risk being named (non-zero control: exactly 1 hit before the change)" \
+  "$(ac63_scripts_hits 'already uses to call a run')" "0"
+reg63 "#63-H3"
+assert_eq "#63-H3 a #74 citation is SITED in the 20 lines above \`function inFlight(\`, where the duplication actually is. Without this, deleting the false clause outright passes #63-H1 and #63-H2 while leaving the drift risk unstated and unciteable anywhere in the file. A citation in the FILE HEADER alone does NOT satisfy this" \
+  "$(node -e '
+    const fs = require("node:fs");
+    const src = fs.readFileSync(process.argv[1], "utf8").split("\n");
+    const i = src.findIndex((l) => /^function inFlight\(/.test(l));
+    if (i < 0) { process.stdout.write("NO `function inFlight(` LINE FOUND: re-anchor this cell, do not delete it"); process.exit(0); }
+    const band = src.slice(Math.max(0, i - 20), i);
+    process.stdout.write(band.some((l) => l.indexOf("#74") !== -1) ? "sited" : "NOT SITED: no #74 in lines " + Math.max(1, i - 19) + "-" + i);
+  ' "$AC63_CHECKOUT_GUARD" 2>/dev/null)" "sited"
+
+# ---------------------------------------------------------------------------
+suite "#63 this suite stops re-deriving the ceiling, in code AND in the prose beside it"
+# ---------------------------------------------------------------------------
+# THE PATTERNS ARE ASSEMBLED SO THEY CANNOT MATCH THEIR OWN CELL. This file is inside the
+# population these two greps walk, and a self-matching detector is un-passable for a reason that
+# has nothing to do with the subject -- the trap this repo has hit twice. The character class in
+# the first pattern and the split literal in the second are what keep these lines out of their
+# own results; verify with the mutations below rather than by eye.
+AC63_VALUE_PHRASE="24h ""ceiling"
+reg63 "#63-G1"
+assert_eq "#63-G1 no cell in this suite re-derives the ceiling as its own hardcoded arithmetic: both former sites (the capture tripwire and probe43's staleness diagnosis) now READ the exported constant. MUTATE THE TWO SITES SEPARATELY -- restoring one and restoring both are indistinguishable to a zero-hit grep, and that hides a dead site" \
+  "$(grep -c '24 *[*] *3600e3' "${BASH_SOURCE[0]}" | tr -d ' ')" "0"
+reg63 "#63-G2"
+assert_eq "#63-G2 and no prose in this suite still spells that ceiling's VALUE (\"$AC63_VALUE_PHRASE\"): a message asserting 24h while comparing against a constant that may not be 24h is the same false claim in prose that this issue corrects in the guard's header. SCOPED TO THE PHRASE, not to the bare number, deliberately: a zero-hit rule over \"24h\" alone would collide with the frozen assertion label at the capture tripwire" \
+  "$(grep -c "$AC63_VALUE_PHRASE" "${BASH_SOURCE[0]}" | tr -d ' ')" "0"
+
+# ---------------------------------------------------------------------------
+suite "#63 the substituted reads are VALIDATED, the validation is EXERCISED, the branch is LIVE"
+# ---------------------------------------------------------------------------
+# ~345 assertions in this file rest on probe43's qualification and its failure mode is SILENCE, so
+# a read that arrives as `undefined` must be named rather than compared against: `age > undefined`
+# is FALSE, and the probe would answer `ok` about a fixture it never judged.
+
+ac63_guard_copy "no-export driver" "const IN_FLIGHT_MS = $IN_FLIGHT_MS;"
+AC63_NOEXP_GUARD="$AC63_COPY_GUARD"
+reg63 "#63-V1"
+assert_eq "#63-V1 the no-export rewrite located EXACTLY ONE declaration line. The replacement is the SAME declaration with the \`export\` keyword stripped and the value carried across from the read, so ENTRY/EXIT still export and the module still imports cleanly -- only the ceiling becomes unreadable" \
+  "$AC63_COPY_MATCHES" "1"
+
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+AC63_PROBE_FIXTURE="$CASE_DIR/status.json"
+reg63 "#63-V2"
+assert_eq "#63-V2 CONTROL: against the SHIPPED guard this same fixture qualifies cleanly, so #63-V3 is the VALIDATION firing and not the fixture being wrong" \
+  "$(probe43 "$AC63_PROBE_FIXTURE" fresh exact:architectural)" "ok"
+reg63 "#63-V3"
+assert_eq "#63-V3 driven against a WHOLE-scripts-dir copy with the export stripped, probe43 NAMES the unreadable ceiling instead of answering ok. Asserted as an EXACT SENTENCE and never as \`!= ok\`: probe43 folds stderr into stdout, so against a partial copy a module-resolution stack trace satisfies \`!= ok\` IDENTICALLY for the probe that validates and the probe that does not -- the rubber stamp reappearing inside the cell written to abolish one" \
+  "$(GUARD="$AC63_NOEXP_GUARD" probe43 "$AC63_PROBE_FIXTURE" fresh exact:architectural)" \
+  "the exported IN_FLIGHT_MS did not read as a finite positive number"
+
+reg63 "#63-V4"
+assert_eq "#63-V4 the capture tripwire's OWN validation, exercised in ITS environment -- a shell variable, not a module read -- by driving THE SAME function that tripwire calls with the ceiling argument EMPTY. Number(\"\") === 0, so an empty argument is caught by the \`CEIL <= 0\` half and NOT by isFinite: both halves are required, and the argument must be QUOTED or an empty one vanishes and shifts argv" \
+  "$(ac63_capture_staleness "$REC_STC" "")" \
+  "the exported IN_FLIGHT_MS did not read as a finite positive number"
+
+MK_UPDATED="$(iso_ms_ago "$AC63_OUT_AGE")"
+new_case 4242 "$(mk_status "3-impl" '"architectural"' "$NO_EVENTS")"
+MK_UPDATED=""
+reg63 "#63-V5"
+assert_eq "#63-V5 probe43's staleness branch is LIVE: a fixture past the ceiling by MARGIN produces exactly that diagnosis. Before this cell the branch was DEAD -- every fixture in this file sat INSIDE the ceiling, all three call sites assert == ok, and both flipping the comparison and DELETING the whole staleness push left the suite at 462/0. This buys LIVENESS, not falsifiability: the > versus >= distinction is the second declared survivor and stays unpinned" \
+  "$(probe43 "$CASE_DIR/status.json" fresh exact:architectural)" \
+  "updated_at is past the in-flight ceiling this suite reads from the guard: this cell would test staleness"
+
+# ---------------------------------------------------------------------------
+suite "#63 the label namespace: unique, and every id that exists actually RAN"
+# ---------------------------------------------------------------------------
+reg63 "#63-Z1"
+reg63 "#63-Z2"
+AC63_UNIQ="$(printf '%s' "$AC63_IDS" | grep . | sort -u)"
+assert_eq "#63-Z1 no #63 assertion id is used twice (a colliding label makes the battery's grep return two unrelated sites)" \
+  "$(printf '%s\n' "$AC63_IDS" | grep -c . | tr -d ' ')" "$(printf '%s\n' "$AC63_UNIQ" | grep -c . | tr -d ' ')"
+assert_eq "#63-Z2 every #63 id written in this file was REGISTERED by a cell that ran" \
+  "$(printf '%s\n' "$AC63_UNIQ" | grep -c . | tr -d ' ')" \
+  "$(grep -o '#63-[A-Za-z0-9][A-Za-z0-9]*' "${BASH_SOURCE[0]}" | sort -u | grep -c . | tr -d ' ')"
 
 finish

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -212,7 +212,7 @@ reg63 "#63-P1"
 assert_eq "#63-P1 FRESH_ISO is INSIDE the ceiling. This is the only thing standing between the corpus walk's zero (\`no committed record is refused by the table\`) and a VACUOUS green: that walk rewrites every committed record's updated_at to FRESH_ISO precisely so staleness cannot mask the table, and its pass set is granted|not-applicable -- so if FRESH_ISO ever fell OUTSIDE, every corpus record would abstain and the zero would stay green over a wholly abstaining population. DIAGNOSIS, not sole detection: ~234 other cells redden in the same run" \
   "$(ac63_age_vs_ceiling "$FRESH_ISO" "$IN_FLIGHT_MS")" "inside"
 reg63 "#63-P2"
-assert_eq "#63-P2 STALE_ISO is OUTSIDE the ceiling. With #63-P1 this is the ONLY remaining bound on the VALUE of IN_FLIGHT_MS after #63 -- roughly (1.0h, 25.05h) -- because every other new cell is DERIVED from the value and therefore value-independent. EXPECTED RED, and correctly so, under a rewrite of the constant to 48h: STALE_ISO is a 25h literal and 25h is legitimately inside a 48h window" \
+assert_eq "#63-P2 STALE_ISO is OUTSIDE the ceiling. With #63-P1 this brackets the VALUE of IN_FLIGHT_MS to roughly (1.0h, 25.05h), which is the only bound the DERIVED cells contribute -- they read the value and are therefore value-independent. It is NOT the tightest bound in #63, and an earlier draft of this label said it was: #63-A2 pins the constant's exact SOURCE TEXT, is neither derived nor value-independent, and is strictly tighter -- MEASURED, a rewrite of the shipped constant to 2h leaves this cell GREEN and reddens #63-A2 as the sole red. So do not read this label as licence to delete #63-A2 as redundant. EXPECTED RED, and correctly so, under a rewrite of the constant to 48h: STALE_ISO is a 25h literal and 25h is legitimately inside a 48h window" \
   "$(ac63_age_vs_ceiling "$STALE_ISO" "$IN_FLIGHT_MS")" "outside"
 
 # new_case <issue-dir-name> <status-json> -> CASE_ROOT, CASE_DIR
@@ -2607,7 +2607,7 @@ reg63 "#63-A1"
 assert_eq "#63-A1 the guard EXPORTS the ceiling exactly once, so this suite can read the number instead of re-spelling it. Read from the CHECKOUT, never \$GUARD" \
   "$(grep -c '^export const IN_FLIGHT_MS' "$AC63_CHECKOUT_GUARD" 2>/dev/null | tr -d ' ')" "1"
 reg63 "#63-A2"
-assert_eq "#63-A2 and the exported VALUE is unchanged by the export -- both halves are needed, since a cell asserting only the grep count would pass with the value silently moved" \
+assert_eq "#63-A2 and the exported VALUE is unchanged by the export -- both halves are needed, since a cell asserting only the grep count would pass with the value silently moved. THIS IS THE PERMANENT VALUE PIN, not a one-shot check on the export refactor: it is the TIGHTEST bound on IN_FLIGHT_MS in this file, strictly tighter than the #63-P1/#63-P2 interval and the SOLE red when the shipped constant is rewritten to 2h, so do not delete it as redundant with #63-P2. It pins EXACT SOURCE TEXT, so this cell's failure direction is toward FALSE ALARM -- a behaviour-preserving reformat to 86_400_000 reddens it for a non-defect reason, so read the diff" \
   "$(sed -n 's/^export const IN_FLIGHT_MS = \(.*\);$/\1/p' "$AC63_CHECKOUT_GUARD" 2>/dev/null)" "24 * 60 * 60 * 1000"
 
 # The three pins under the FIRST declared survivor. They catch the CHEAP ways its premise stops
@@ -2700,6 +2700,20 @@ reg63 "#63-V5"
 assert_eq "#63-V5 probe43's staleness branch is LIVE: a fixture past the ceiling by MARGIN produces exactly that diagnosis. Before this cell the branch was DEAD -- every fixture in this file sat INSIDE the ceiling, all three call sites assert == ok, and both flipping the comparison and DELETING the whole staleness push left the suite at 462/0. This buys LIVENESS, not falsifiability: the > versus >= distinction is the second declared survivor and stays unpinned" \
   "$(probe43 "$CASE_DIR/status.json" fresh exact:architectural)" \
   "updated_at is past the in-flight ceiling this suite reads from the guard: this cell would test staleness"
+
+# THE LAST WRITE-CAPABLE COPY CALL IS ABOVE (#63-V1's no-export driver). #63-C4 and #63-C5 sit
+# after the FIRST copy call only, so neither can see a write performed after they ran, and the
+# LAST call is the one whose residue an interrupted run actually leaves behind: under the copy
+# helper's own named mutation (repoint AC63_COPY_GUARD at $SCRIPTS_DIR) the run ends with the
+# shipped guard reading `const IN_FLIGHT_MS = 86400000;` -- this PR's only executable change,
+# reverted AND the literal respelled, sitting in the checkout waiting for a `git commit -a`.
+# Do not delete this as a duplicate of #63-C5; a checksum taken earlier proves nothing about a
+# later write. Failure direction is toward a REAL defect, not false alarm: if this reddens, the
+# checkout has been written by this file and the diff must be inspected before anything is
+# committed.
+reg63 "#63-C6"
+assert_eq "#63-C6 the SHIPPED guard is STILL byte-identical after the LAST copy-driven cell in this file (checksum, two non-empty operands, so this is not a zero-versus-zero comparison). #63-C5 covers only the copies above it" \
+  "$(cksum < "$SCRIPTS_DIR/gate-phase-entry.mjs")" "$AC63_GUARD_SUM_BEFORE"
 
 # ---------------------------------------------------------------------------
 suite "#63 the label namespace: unique, and every id that exists actually RAN"


### PR DESCRIPTION
Closes #63

## What

Two commits, two files, no behaviour change.

**`c95537a` (QA, Phase 3a)** — the failing behavioral contract in `plugins/pipeline/tests/test-gate-phase-entry.sh`. The suite went 462 → 492 passing assertions.

**`56e8671` (Dev, Phase 3b)** — `plugins/pipeline/scripts/gate-phase-entry.mjs`, +13/−5:

- `const IN_FLIGHT_MS` → `export const IN_FLIGHT_MS`. Value byte-identical (`24 * 60 * 60 * 1000`), `inFlight` and its single call site untouched. `inFlight` itself stays private: a second parallel path to the same answer is precisely what the declared `<=`/`<` survivor's justification rests on not existing.
- The header claim that the guard reuses `pipeline-status.mjs`'s window "rather than inventing a second one" is deleted. It was flatly false — no symbol is shared and both modules hold their own literal.
- `inFlight`'s doc comment loses "the predicate pipeline-status.mjs already uses to call a run 'possibly stuck', inverted" (true today, silently false the moment either literal moves) and gains a drift-risk paragraph sited at the predicate, citing #74 and naming `pipeline-status.mjs:156` as the independent copy. It also states the precise divergence: the two are inverses on the age term **alone**, since an undatable record is neither stuck there nor in flight here.

Before this, the boundary the guard enforces was untestable from outside without re-spelling `24 * 3600e3` in the suite — which is what both former sites did, judging fixtures against a ceiling they did not own.

## Verification

| | result |
|---|---|
| `bash plugins/pipeline/tests/run.sh` | 34 suites, **2560 passed, 0 failed**, no self-skips, no cached counts |
| entry / drift / hook | 492/0, 37/0, 59/0 (hook byte-identical to base) |
| baseline red at `c95537a` | `passed=0 failed=1` — `#63-R1`, then the suite HALTS by design (`finish || exit 1`) rather than reporting vacuous greens on a broken read |
| staging control (export only, prose reverted) | `passed=489 failed=3`, reds exactly `#63-H1`, `#63-H2`, `#63-H3` |
| drift immunity, 2h rewrite | 492/0 |
| drift immunity, 48h rewrite | 490/2 — reds exactly `#63-P2` and `(a) 25h old…`, whose premises are genuinely false at a 48h ceiling. The boundary pair and its control stayed green at both bases. |
| label-set containment (entry, drift) | 0 base labels lost, +30 / +0 added |

### Mutation battery

Isolated detached worktree, one mutation at a time, each applied by unique literal replacement (`count == 1` asserted, changed line printed) and restored with `git checkout --`.

| | mutation | expected | result |
|---|---|---|---|
| M1 | guard `<=` → `<` | **survive** | SURVIVED (entry 492/0, drift 37/0) |
| M2 | probe43 `>` → `>=` | **survive** | SURVIVED (492/0) |
| M3 | guard `<=` → `>=` | redden | CAUGHT — 261/231, incl. `#63-B1/B2/B3/C2/C3` |
| M4 | age term deleted (`return true`) | redden | CAUGHT — 486/6, incl. `#63-B2/B3/C2/C3` |

Two survivors are **declared and expected**, each documented in the suite with its mechanism, residual and expiry: both spellings differ only when the age is exactly the ceiling to the millisecond, and the guard reads its own `Date.now()` in a child process started after the fixture was written, so no CLI-driven fixture lands there. The residual is one millisecond in the direction of abstention — a silence, not a falsehood. A battery in which everything reddens cannot tell coverage from a rubber stamp.

Mutating the constant's **value** deliberately does not redden the pair (the 2h/48h runs above), which is why it is inadmissible as coverage evidence.

## Phase 4 fix round (commit `5bdc9bf`)

The panel returned **SecOps REQUEST_CHANGES** on one blocker plus a DBA major. Both are fixed here, with two related notes.

**BLOCKER — the round-1 corrected prose was ALSO false, in the same class as the claim it replaced.** It said the two predicates *"are inverses on the age term ALONE: an undatable record is neither stuck there nor in flight here."* The second half is false. `pipeline-status.mjs` builds its row as `updated_at: status?.updated_at ?? mtime`, so an **absent or null** `updated_at` is filled in from the status.json **file mtime** before its comparison. Measured on one record — `.pipeline/91/status.json = {"current_phase":"3-impl","events":[]}`, mtime touched to 2026-01-01:

```
pipeline-status.mjs  ->  ## Possibly stuck (over 24h, no final verdict)   - #91 at `3-impl`
gate-phase-entry.mjs ->  {"decision":"not-applicable","reason":"... is not in flight ..."}
```

Both fire on one record, which "inverses" says cannot happen. Non-zero controls on both axes: `updated_at` 1h ago → not-stuck / refused; 25h ago → STUCK / not-applicable. Why it mattered beyond pedantry: the comment's job is to send a future maintainer to #74, whose ask is to unify the two modules — and that sentence told them the datability paths already agree and need no reconciliation.

**Refinement measured beyond the blocker report:** `??` fires only on **absent** and **null**, so an **unparseable string** (`"not-a-date"`) with an old mtime is *not* stuck there and *not* in flight here. It is the one undatable spelling on which the two modules still agree, and the shipped prose now says exactly that rather than generalising over "undatable".

**Correction to a related QA finding, caught before it shipped.** QA reported that with `updated_at: 12345`, `Date.parse` reads year 12345 (permanently in flight here) while `new Date(12345)` reads epoch 12.345s, so pipeline-status.mjs calls the same record possibly-stuck — "both fire". **The second half is false.** pipeline-status.mjs does not classify a numeric `updated_at` at all; it **throws first**: `TypeError: (r.updated_at ?? "").slice is not a function` at `pipeline-status.mjs:130` in `renderMarkdown`, `rc=1`. The `stuck` filter is at `:153`, inside `renderMarkdown` and *after* the throwing line, so it is never reached; in `--json` mode `renderMarkdown` is never called at all. Shipping QA's sentence verbatim would have put a second measured-false claim into the very comment this round exists to correct. The divergence **is** recorded in the shipped prose, in the form actually measured.

**MAJOR (DBA) — `#63-P2`'s label was false.** It claimed the P1/P2 interval was *"the ONLY remaining bound on the VALUE of `IN_FLIGHT_MS` after #63 … because every other new cell is DERIVED from the value."* Measured false: `#63-A2` pins the constant's exact source text, is neither derived nor value-independent, and is strictly tighter. Rewriting the shipped constant to 2h gives **492/1 with `#63-A2` as the sole red**. The label is corrected, and `#63-A2` gained the two notes its siblings carry — a do-not-delete, and a failure-direction sentence (direction is toward **false alarm**: a reformat to `86_400_000` reddens it for a non-defect reason). **Consequence: SecOps' round-1 concern that "after #63 the value 2h is STILL green" is no longer true and should not be re-litigated.**

**LOW (SecOps) — the invariance tripwire missed the last write-capable call.** `#63-C4`/`#63-C5` sat after the *first* of two `ac63_guard_copy` call sites; the second had no invariance cell after it, and that is the call whose residue an interrupted run actually leaves in the checkout. Added **`#63-C6`**, re-asserting the checksum after the last copy-driven cell.

**NIT — the prose did the thing its own test warns against.** Both drift comments cited the sibling literal as the absolute `pipeline-status.mjs:156`, twice in one file, with nothing pinning either — while `#63-H3`'s own siting check deliberately uses a band *relative* to `function inFlight(` because "an absolute range decays the first time anything above it moves." Both absolute citations are gone; `grep -c ':156'` on the guard is now **0**. The sibling is cited once, by symbol.

### Fix-round mutation battery

Fix committed **first**, so every restore is `git checkout --` from a committed state. Each mutation applied by literal replacement through a helper that **refuses unless the literal matches exactly once**; changed line printed from the file after the edit; restored from git; `git status --porcelain` verified after each. Guard mutations were driven against a **copy** via the `SCRIPTS_DIR` override, so nothing was written to the tracked guard except the two checkout-value rewrites, both restored and verified clean.

Redirected baseline `SCRIPTS_DIR=<copy>`: **493/0**. Unredirected: **493/0**.

| | mutation | expected | result |
|---|---|---|---|
| MUT-A | write the real residue (`const IN_FLIGHT_MS = 86400000;`) to the checkout after the **last** copy call | redden `#63-C6` | CAUGHT — 490/3, `#63-C6` red, **`#63-C4` and `#63-C5` both GREEN** (the blind spot) |
| MUT-B | same siting, semantically inert write (`printf '\n' >>`) | redden `#63-C6` | CAUGHT — **492/1, `#63-C6` the SOLE red** |
| MUT-C | shipped constant → 2h (checkout) | redden `#63-A2` only | CAUGHT — 492/1, `#63-A2` sole red, P1/P2 green |
| MUT-D | shipped constant → 48h (checkout) | redden `#63-P2` | CAUGHT — 490/3 (`#63-P2`, the `(a) 25h old` label, `#63-A2`) |
| MUT-D′ | same 48h rewrite, in a **copy** | redden the declared pair only | CAUGHT — 491/2, `#63-A2` **green** |
| MUT-E | strip both `#74` tokens from the band above `function inFlight(` | redden `#63-H3` | CAUGHT — 492/1, `#63-H3` sole red |

**MUT-B is the load-bearing one:** a single trailing newline written to the checkout after the last copy call is invisible to every other cell in the file, including `#63-C4` and `#63-C5`. That is the gap `#63-C6` closes.

**MUT-D′ reconciles a discrepancy rather than leaving it.** DBA reported the 48h rewrite as "490/2, no third red"; this round measured 490/3. Both are correct — `#63-A2` reads the **checkout**, so it is blind to a copy mutation and reddens only when the shipped file moves. The reading depends entirely on which file was mutated.

**Both declared survivors re-verified and still surviving:** `<=` → `<` in `inFlight` (493/0) and probe43's `>` → `>=` (493/0).

> **Harness disclosure.** The first attempt at survivor 2 was a **false green**. The replacement literal carried a trailing newline the file did not have, so it matched 0 times; the uniqueness guard **refused the edit** and the suite that ran was unmutated, reporting a meaningless 493/0. Re-done with the correct literal, verified applied by printing the changed line *and* asserting 0 remaining occurrences of the original spelling. Recorded because a battery that cannot tell "survived" from "never applied" is a rubber stamp.

## Delta re-review round (commit `a90dd19`)

QA and SecOps **independently found the same single blocker**: the paragraph I *added* in the previous round contained a third measured-false universal.

> ~~which agree on the ISO strings `status.schema.json` requires and diverge on anything else~~

**`new Date(string)` delegates to `Date.parse`**, so the two agree on *every* string, not only the ISO ones. Verified independently rather than relayed — 10 formats, **0 divergences**:

| input | `Date.parse` | `new Date().getTime()` | |
|---|---|---|---|
| `"2026-08-20T00:00:00Z"` | 1787184000000 | 1787184000000 | AGREE |
| `"March 3, 2020"` | 1583211600000 | 1583211600000 | AGREE |
| `"2020/03/03"` | 1583211600000 | 1583211600000 | AGREE |
| `"Tue, 03 Mar 2020 00:00:00 GMT"` | 1583193600000 | 1583193600000 | AGREE |
| `"garbage 99"` | 915166800000 | 915166800000 | AGREE |
| `"not-a-date"` / `""` | NaN | NaN | AGREE |
| `12345` | 327403400400000 | 12345 | **DIVERGE** |
| `0` / `false` / `true` / `null` / `1.5` | — | — | **DIVERGE** |

They part **only on values that are not strings**, where `Date.parse` coerces to string first and the constructor treats a non-string primitive as a *time value*. The clause also **contradicted the immediately preceding paragraph**, which correctly says an unparseable string is the one undatable spelling the two agree on — two lines below the words "Measured, not reasoned."

**One refinement I measured beyond the drafted fix:** `[]` and `{}` are non-strings that **agree** (both `NaN`), because the constructor's `ToPrimitive` yields a string that is then parsed. So "all non-strings diverge" would have been a *fourth* false universal. The shipped sentence states "part **only** on values that are NOT strings" as a **necessary** condition, not a sufficient one — that distinction is load-bearing.

**QA-N1 folded in, and tightened rather than kept.** "It throws on the number before its filter is reached" was precise only for markdown mode with one issue dir. I measured all four configurations:

| dirs | mode | result |
|---|---|---|
| 2+ | markdown **and** `--json` | throws in `listActive`'s sort comparator, `pipeline-status.mjs:106` (`localeCompare is not a function`), rc=1 |
| 1 | markdown | throws in `renderMarkdown`, `:130`, rc=1 |
| 1 | `--json` | **no throw**, rc=0 — and never runs the filter either |

So the shipped sentence now states the load-bearing property — **the filter is not reached on any path** — instead of naming one site.

### Corrected paragraph, as shipped

```
 * They also DATE the field differently -- `Date.parse` here, `new Date(...).getTime()` there --
 * and MEASURED, those two agree on every STRING, not only the ISO ones status.schema.json
 * requires: `new Date(string)` delegates to `Date.parse`, so "March 3, 2020", "2020/03/03" and
 * "not-a-date" all land identically in both. They part only on values that are NOT strings,
 * where `Date.parse` coerces to string first and the constructor does not. `updated_at: 12345`
 * reads here as the year 12345, so the record is permanently in flight, while
 * pipeline-status.mjs never classifies it at all: its filter is not reached on ANY path. With
 * two or more issue dirs it throws first in `listActive`'s sort comparator, in both markdown
 * and `--json`; with one dir it throws in `renderMarkdown`; and the sole non-throwing case, one
 * dir under `--json`, does not run the filter either. Nothing in this tree pins either spelling.
```

Applied uniquely (`count == 1`) with **zero occurrences of either original clause remaining**, verified by grep — that second check is what caught an earlier false green in this PR. `#63-H1`/`H2` at 0 hits, `#63-H3` still sited (band 504–523, `#74` at 519/520). Suite **493/0**; full runner **34 suites / 2561 / 0**.

### `MUT-A` call site — answering SecOps' non-blocking question

**I never repointed `AC63_COPY_GUARD`.** The helper `ac63_guard_copy` was not edited at all: its only assignment, `AC63_COPY_GUARD="$NEW_TMPDIR/scripts/gate-phase-entry.mjs"`, is untouched at `test-gate-phase-entry.sh:2499`.

`MUT-A` inserted **one new standalone statement immediately after the second and last `ac63_guard_copy` call** — the `no-export driver`, at what was line 2675 — writing directly to `$SCRIPTS_DIR/gate-phase-entry.mjs` via `node -e`. The first call site was not modified. That is exactly why `#63-C4`/`#63-C5` stayed green: **they had already run before the only write occurred.**

SecOps applied the criterion's *own named mutation* instead (repoint the helper at `$SCRIPTS_DIR`), which is **global** — it writes at the first call too, before C5's checksum — so C5 correctly reddens there. SecOps' reasoning was sound for the mutation it ran. Both readings are right for the mutation each applied, and they answer different questions: the global variant proves the class is caught *somewhere*; the targeted variant isolates *which cell* catches a write performed **after** C5 — the gap `#63-C6` exists to close. QA reproduced the targeted 490/3 with C4/C5 green.

## Round 4 — the enumeration is deleted (commit `4a62295`)

QA and SecOps **independently** found a fourth false claim in the same paragraph, and converged on the same root cause *and* the same fix. Two clauses I added in round 3:

> ~~With two or more issue dirs it throws first in `listActive`'s sort comparator, in both markdown and `--json`~~
> ~~the sole non-throwing case, one dir under `--json`~~

**Root cause.** The comparator is `(b.updated_at ?? "").localeCompare(a.updated_at ?? "")`. `localeCompare` **coerces its argument**, so a bad value in `a` is harmless — it throws only when the bad row is the **receiver `b`**. V8's insertion sort passes the element being inserted as `a`. The governing variable is therefore **where the offending row lands in readdir order**, not the dir count, which is exactly what my clause keyed on.

Reproduced before shipping the fix — two fixtures, identical readdir order `["10","63"]`, differing only in which dir carries the bad value:

| fixture | markdown | `--json` |
|---|---|---|
| bad row **first** | rc=1, `listActive` | rc=1, `listActive` |
| bad row **last** | rc=1, `renderMarkdown` | **rc=0, no throw** |

The second row alone falsifies both clauses. QA's tally across 20 cells: cmp=10 / `renderMarkdown`=5 / no-throw=5, where my sentence predicted 18/1/1 — **8 of 18 multi-dir cells contradict it**. SecOps ran n=1..1000.

**Why this is a deletion and not a fifth draft.** It is not a clean "not last" rule either: a mid-position bad row **survives** at n=5,10,22,23,24 and **throws** at n=3,32,64,100,1000, because binary insertion probes only an O(log n) prefix. Any characterisation of the throw site is a claim about a V8 sort internal — pinning it would be the fifth false claim, this time with a green checkmark behind it.

### Final paragraph, as shipped

```
 * They also DATE the field differently -- `Date.parse` here, `new Date(...).getTime()` there --
 * and MEASURED, those two agree on every STRING, not only the ISO ones status.schema.json
 * requires: `new Date(string)` delegates to `Date.parse`, so "March 3, 2020", "2020/03/03" and
 * "not-a-date" all land identically in both. They part only on values that are NOT strings,
 * where `Date.parse` coerces to string first and the constructor does not. `updated_at: 12345`
 * reads here as the year 12345, so the record is permanently in flight, while
 * pipeline-status.mjs never classifies it at all: its `stuck` filter is not reached on any
 * path. Markdown mode always throws before it -- in `listActive`'s sort comparator or in
 * `renderMarkdown`'s table loop, depending on where the offending row lands in readdir order --
 * and `--json` never calls `renderMarkdown` at all, so the filter does not run there even when
 * nothing throws. Nothing in this tree pins either spelling.
```

It makes **no claim about which site fires or how many dirs are needed** — which is precisely why it cannot be falsified the way the last four were. Its two remaining premises both hold: markdown always throws before the filter (structurally, `renderMarkdown`'s table loop at `:130` does `(r.updated_at ?? "").slice(0,19)` over every row and precedes the filter at `:153`), and `--json` never calls `renderMarkdown` at all.

Applied uniquely (`count == 1`) with **zero occurrences of all four original clause fragments remaining**, grep-verified. `#63-H1`/`H2` at 0 hits, `#63-H3` sited (band 505–524). Suite **493/0**; runner **34 suites / 2561 / 0**.

**Held under attack and deliberately not re-touched:** "agree on every STRING" (SecOps: 47-case corpus + **300,000 random strings**, zero disagreements, oracle control firing both ways; QA: 14/14, and it is *specified* behaviour, not merely empirical); "part only on values that are NOT strings" (both confirm the necessary-not-sufficient reading; QA measured 9 of 16 non-strings agree); "Nothing in this tree pins either spelling" (settled by mutation, both swaps survive with controls reddening in the same session); "year 12345 / permanently in flight".

## Known limits and what is left undone

`.pipeline/` is gitignored in this repo, so the implementation report does not survive the worktree. Everything load-bearing is therefore written here.

1. ~~**`AC2` is PARTIAL.**~~ **DISCHARGED — `AC2` is now PASS.** The hook suite's label-set capture, the one half missing at hand-off, has been captured **three times independently** — QA and BA in Phase 4, and Dev in this fix round — all agreeing: **58 unique labels at base, 58 at head, 0 lost, 0 added, 59/0 at both ends.** Non-zero control on the diff itself: the same `comm -23` against a deliberately truncated 3-label set reports 55 losses, so the zero is a measurement, not a broken pipeline. QA ruled explicitly that the byte-identity argument alone was **not** sufficient — byte-identity pins the label *strings* but not which cells *run*, and the hook suite is guard-sensitive — so PARTIAL was the honest grade at hand-off and is discharged by capture rather than by argument. Entry suite is now 362 → 393 (0 lost, 31 added, including `#63-C6`); drift 37 → 37.
2. ~~**The `<=` → `<` survivor on the hook suite is owed.**~~ **DISCHARGED.** Re-verified surviving; the full runner is green at 34 suites / **2561 passed / 0 failed**, hook 59/0 included.
3. **The third `inFlight` term — the undatable record — is now measured**, by SecOps: direction is fail-**open** (an undatable record is never in flight, so the guard never holds a project's turns open on a record it cannot date), and that direction is correct, since fail-closed would refuse every turn in a project holding one truncated `status.json`, permanently. One **documented expected survivor**: deleting the term alone leaves the suite green, because `NaN <= C` is already false — it is a defensive restatement, not a live branch under the current spelling.
4. **Single environment.** Every number in this PR is bash 3.2.57(1)-release on one machine with node v24.19.0. Agreement across QA's, BA's, DBA's, SecOps' and Dev's figures is agreement across **checkouts**, not across environments — one observation, five readers. The hook label capture now has three independent captures; all three are on this machine.
5. **`AC12`'s content half is a named human read.** Whether the replacement sentence actually says what it must has no assertion behind it and is not mechanizable without making the test a copy of the comment. `#63-H1/H2/H3` pin the removal and the location only. **This limit has now cost four defects in four drafts:** round-1's claim, round-2's replacement, round-3's parse-divergence clause and round-4's throw-site enumeration each passed all three cells while measurably false. **A green suite has never once flagged this sentence** — every one was caught by a human reading the clause against a fresh measurement. The final version survives by *asserting less*: it states the outcome property that held across every cell anyone ran and deletes every enumeration of the mechanism behind it. When a claim keeps turning out false at the edges, the fix is to stop enumerating the edges, not to enumerate them more carefully. Treat the content half as a human read, always.
6. **Two artefacts are frozen on purpose and must not be tidied.** The assertion label containing `24h` and the `25h` literal on `STALE_ISO`.
7. **NEW — owed to #74, not fixed here.** Three things this round measured that #74 does not yet record: (a) **two** modules read a different column than the guard, not one — `pipeline-status.mjs`'s `?? mtime` substitution is the same grain mismatch #74 records against `session-start.sh`, in a second module #74 does not count; (b) the **parse-function divergence** (`Date.parse` vs `new Date(...).getTime()`), which nothing in this tree pins — swapping the guard to `new Date(...).getTime()` survives all three suites; (c) `pipeline-status.mjs` **throws** (`rc=1`) on a numeric `updated_at` rather than classifying it. All three belong in #74 §1. Off-contract per `status.schema.json` (which types `updated_at` as a date-time string) and outside #63's lane, so reported rather than fixed.

## Incidental finding, not fixed here

While validating the Phase 3 artifact against `plugins/pipeline/schemas/impl-report.schema.json`, one planted defect **survived**: setting a `requirement_check` to `status: "PARTIAL"` with its `justification` deleted validates clean (0 errors) and passes the pre-Phase-4 gate.

The schema declares an `if`/`then` block requiring `justification` when status is `PARTIAL` or `SKIP`, and `dev.md:195` states the same rule. But `validate-pipeline-artifact.mjs` implements only `type`/`enum`/`required`/`minItems`/`allOf` — `grep -n 'schema\.\(if\|then\|else\)'` returns nothing — and `gate-pre-phase4.mjs` has no `justification` or `PARTIAL` handling either. So the rule is enforced by nobody: a written expectation no code reads is a comment.

Not fixed in this PR — changing a shared validator's constraint support is architectural and outside this spec. **Now tracked on issue #66**, which already owns validator inertness (including the knowledge-store under-reporting DBA flagged: the `living-context` entry enumerates the unenforced keyword set as `maxLength`/`pattern` and never names `if`/`then`, which is the one of them a shipped schema actually uses). A deferral parked only in a merged PR body is one step from being a comment, so it has an issue number. (The `AC2` PARTIAL above does carry its justification; it passes on merit, not because the check is absent.)

Related API trap worth knowing: `validate(value, schema, root, ...)` takes the **root schema object** as its third argument. Passing a label string instead makes `deref` fail to resolve and silently skips every `$ref`-declared constraint while still returning `[]` — measured on this very file, a string root also returns 0 errors. The clean result above is meaningful only because the correct call was used *and* because three planted defects each made it go red, and the gate itself was watched failing on a planted copy (`FAIL … exit 1`) and passing on the real one (`OK … exit 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



