### PR TITLE
fix: declare 0-setup in both Lane-1 consumer tables (#53)

### DIFF
--- a/plugins/pipeline/scripts/gate-phase-entry.mjs
+++ b/plugins/pipeline/scripts/gate-phase-entry.mjs
@@ -162,6 +162,29 @@ export const UNGUARDED = [
  */
 export const TERMINAL = ["5-archived"];
 
+/**
+ * The run's setup step, and the one phase that precedes every guarded one.
+ *
+ * A FIFTH CELL rather than a PREREQUISITES row or a widening of UNGUARDED, and both refusals are
+ * load-bearing. ENTRY is DERIVED from PREREQUISITES keys and must equal the set of phases
+ * pipeline.md names at its `Checkpoint first` sites; `0-setup` is written at no such site, so a
+ * row there would break a correct invariant. And UNGUARDED's own reason reads "a halt or rework
+ * state, which is never guarded", which is not true of the step that starts the run: shipping a
+ * reason that is false of its subject is the defect this cell exists to correct.
+ *
+ * MECHANISM. pipeline.md writes `current_phase: "0-setup"` at Phase 0 step 5, before any phase
+ * artifact exists and before the first dispatch, so there is no prerequisite a record here could
+ * satisfy or fail. Phase 0's only full-voice owner-facing decision block is the dirty-worktree
+ * halt at step 1, which runs BEFORE that write, so a turn cannot end parked at this phase in
+ * that halt either -- the same mechanism voice-lint.mjs's NON_VOICE_PHASES declaration rests on,
+ * stated here so the two declarations cannot drift apart in their justification.
+ *
+ * EXPIRY, general rather than the single reversal that suggests it: this cell is wrong the moment
+ * ANY owner-facing decision block comes to sit between the step that writes `0-setup` and the
+ * next `Checkpoint first` write, because a run can then END here rather than only pass through.
+ */
+export const PRELUDE = ["0-setup"];
+
 export const IN_FLIGHT_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -555,6 +578,12 @@ function decideForDir(issueDir, now) {
   const at = `.pipeline/${name} at \`${phase}\``;
 
   if (isTerminal(phase, status)) return decided("not-applicable", `${at} is finished.`);
+  // AFTER the terminal check, and the order is the assertion's subject rather than a style
+  // choice: measured, this branch placed BEFORE it renders a `0-setup` record carrying
+  // `completed_at` as a setup step, un-finishing every concluded run that ended here.
+  if (PRELUDE.includes(phase)) {
+    return decided("not-applicable", `${at} is the run's setup step, which precedes every guarded phase.`);
+  }
   if (UNGUARDED.includes(phase)) {
     return decided("not-applicable", `${at} is a halt or rework state, which is never guarded.`);
   }

--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -98,6 +98,13 @@ export const NON_VOICE_PHASES = new Set([
   // between the step that writes `0-setup` and the next `Checkpoint first` write. Re-derive
   // with `grep -n 'full voice\|decision block\|Checkpoint first\|current_phase' on
   // commands/pipeline.md and read what falls between the two.
+  //
+  // #80 IS WHAT MAKES THAT EXPIRY CHECKABLE RATHER THAN ASPIRATIONAL. The mechanism above says
+  // the halt at Phase 0 step 1 is structurally unreachable by this lint, because it runs before
+  // a phase is ever recorded -- so the one owner-facing moment in Phase 0 is not covered by
+  // anything here, and no failing assertion marks that. #80 tracks it. If #80 changes where
+  // that decision block sits, or gives it a phase of its own, this declaration is the line that
+  // has to move.
   "0-setup",
   "0.5-map", "0.5-map-complete",
   "1-ba", "1-ba-complete",

--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -67,7 +67,17 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 // defect this plugin keeps re-learning. tests/test-voice-lint.sh now parses every
 // `current_phase: "..."` out of pipeline.md and fails when one is neither listed here nor
 // explicitly declared non-voice, so the table cannot drift from the orchestrator again.
-const VOICE_MOMENTS = {
+// EXPORTED so tests/test-voice-lint.sh can assert SET MEMBERSHIP over the table itself. The
+// check it replaces was `grep -q "\"$phase\"" voice-lint.mjs`, a substring grep over this
+// source that a phase named in a COMMENT satisfies and that cannot tell a table key from a
+// mention.
+//
+// NEITHER TABLE IS FROZEN, and that is a ruling rather than an omission. Measured:
+// `Object.freeze(new Set(["a"]))` reports `Object.isFrozen === true` and then accepts
+// `.add("b")` with size going 1 -> 2, because a Set's members are not own properties. Freezing
+// the Set would report a protection it does not provide, and freezing only the object half
+// would leave a reader assuming both were covered.
+export const VOICE_MOMENTS = {
   "1-ba-open-questions": { decision: true, label: "a blocking open question" },
   "1-ba-rework-required": { scales: true, label: "a veto rework halt" },
   "2.5-design-owner-decision": { decision: true, label: "the design-lock" },
@@ -79,7 +89,16 @@ const VOICE_MOMENTS = {
 
 // Phases that are deliberately NOT voice moments: internal checkpoints the owner never sees.
 // Listed explicitly so the drift test can tell "decided this is silent" from "forgot about it".
-const NON_VOICE_PHASES = new Set([
+export const NON_VOICE_PHASES = new Set([
+  // The run's setup step. MECHANISM: pipeline.md's Phase 0 holds exactly one full-voice
+  // owner-facing decision block, the dirty-worktree halt at step 1, and it runs BEFORE step 5
+  // writes `current_phase: "0-setup"`, so a turn cannot end at this phase in that halt.
+  // EXPIRY, stated generally rather than as the single reversal that suggests it: this
+  // declaration is wrong the moment ANY full-voice owner-facing decision block comes to sit
+  // between the step that writes `0-setup` and the next `Checkpoint first` write. Re-derive
+  // with `grep -n 'full voice\|decision block\|Checkpoint first\|current_phase' on
+  // commands/pipeline.md and read what falls between the two.
+  "0-setup",
   "0.5-map", "0.5-map-complete",
   "1-ba", "1-ba-complete",
   "2-constraints", "2-constraints-complete",
@@ -372,7 +391,16 @@ function selfTest() {
   return fail === 0;
 }
 
-if (isMainScript("voice-lint.mjs")) {
+// Self-run ONLY as a real CLI entry, copied from gate-phase-entry.mjs, which ships this guard
+// and the comment describing the hazard. isMainScript compares the BASENAME of argv[1], and a
+// test that imports this module passes the module's own path there -- without the execArgv
+// test, `await import()` SELF-RUNS main(), the importing eval body never executes, and every
+// assertion built on the exports above reads a green nothing. Measured before it was added:
+// a marker printed BEFORE the import appears and the one after it never does, rc 0.
+const evalEntry = process.execArgv.some(
+  (a) => a === "-e" || a === "--eval" || a === "--input-type=module" || /^--eval=/.test(a),
+);
+if (isMainScript("voice-lint.mjs") && !evalEntry) {
   if (process.argv.includes("--self-test")) process.exit(selfTest() ? 0 : 1);
   main();
 }

--- a/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
@@ -34,24 +34,44 @@ derive() {
   node --input-type=module -e '
     import { readFileSync } from "node:fs";
     const [mdPath, guardPath, setsArg] = process.argv.slice(1);
+    const names = ["ENTRY", "EXIT", "UNGUARDED", "TERMINAL", "PRELUDE"];
     let sets;
     if (setsArg === "MODULE") {
       const m = await import(guardPath);
-      sets = { ENTRY: m.ENTRY, EXIT: m.EXIT, UNGUARDED: m.UNGUARDED, TERMINAL: m.TERMINAL };
+      sets = {};
+      for (const n of names) sets[n] = m[n];
     } else {
       sets = JSON.parse(setsArg);
     }
     const md = readFileSync(mdPath, "utf8");
-    // The STRICT form, matching tests/test-voice-lint.sh:225-239. A looser pattern picks up
-    // `0-setup` from the Phase 0 JSON block, so the two checks would disagree about their own
-    // population.
-    const literals = [...new Set([...md.matchAll(/current_phase: *"([^"]*)"/g)].map((m) => m[1]))]
+    // THE WIDE FORM, and it is the ONE extraction this suite performs (#53 R1/AC1). It claims
+    // BOTH quoting styles the writer uses -- the bare `current_phase: "..."` and the JSON
+    // `"current_phase": "..."` -- because the population of a coverage check must equal its
+    // SUBJECT. The strict form this replaced claimed only the first, so this suite derived 25
+    // concrete literals from a file that writes 26, and `0-setup` was invisible to the
+    // assertion AND to the control, which ranged over the same narrowed set: a phase the
+    // pattern cannot see is not an unaccounted phase, it is not a phase at all.
+    // THE RULE NOW IN FORCE: the derivation matches the WRITER, and the bare-word TRI-PARTITION
+    // below is what holds it to that -- every occurrence of the bare word `current_phase` is
+    // forced into a named bucket, so no future assignment spelling can leave the population in
+    // silence. The sibling copy in the voice-lint suite pins the SAME label set; re-derive both
+    // with `git grep -n "THE WIDE FORM" -- plugins/pipeline/tests`. No line range is cited into
+    // another shipped file: a coordinate pin rots the moment its subject is edited (#68).
+    const literals = [...new Set([...md.matchAll(/"?current_phase"?: *"([^"]*)"/g)].map((m) => m[1]))]
       .filter((p) => p !== "<phase>-error");
-    const names = ["ENTRY", "EXIT", "UNGUARDED", "TERMINAL"];
     const counts = {}; const seen = new Map(); const dupes = [];
+    const shapes = []; const emptyCells = [];
     for (const n of names) {
+      const v = sets[n];
+      shapes.push(n + "=" + (v === undefined ? "ABSENT"
+        : Array.isArray(v) ? "Array" : v instanceof Set ? "Set" : typeof v));
+      // The pre-existing idiom, left as it is by scope. It is CORRECT for an Array cell and
+      // silently yields an EMPTY population for a Set one, which is why `emptyCells` below
+      // exists: notInMd is computed FROM these cells, so an empty cell makes it green having
+      // compared nothing.
       const arr = Array.isArray(sets[n]) ? sets[n] : [];
       counts[n] = arr.length;
+      if (!Array.isArray(v) || v.length === 0) emptyCells.push(n);
       for (const p of arr) {
         if (seen.has(p)) dupes.push(p + " in " + seen.get(p) + " and " + n);
         else seen.set(p, n);
@@ -59,8 +79,18 @@ derive() {
     }
     const unassigned = literals.filter((p) => !seen.has(p));
     const notInMd = [...seen.keys()].filter((p) => !literals.includes(p));
+    // AC9: the `-complete` sub-derivation is taken from the SAME single extraction above,
+    // never a second narrow grep of its own.
+    const complete = literals.filter((p) => p.endsWith("-complete")).sort();
+    const exitArr = Array.isArray(sets.EXIT) ? sets.EXIT : [];
     process.stdout.write(JSON.stringify({
-      literalCount: literals.length, counts, dupes, unassigned, notInMd,
+      literalCount: literals.length,
+      literals: [...literals].sort().join(","),
+      shapes: shapes.join(" "),
+      preludeMembers: (Array.isArray(sets.PRELUDE) ? [...sets.PRELUDE].sort() : []).join(","),
+      completeLiterals: complete.join(","),
+      counts, dupes, unassigned, notInMd, emptyCells,
+      completeNotInExit: complete.filter((p) => !exitArr.includes(p)),
     }));
   ' "$PIPELINE_MD" "$GUARD" "${1:-MODULE}" 2>/dev/null
 }
@@ -76,6 +106,23 @@ field() {
   printf '%s' "$1" | sed -n "s/.*\"$2\":\\[\\([^]]*\\)\\].*/\\1/p"
 }
 num()   { printf '%s' "$1" | sed -n "s/.*\"$2\":\\([0-9]*\\).*/\\1/p"; }
+# strfield: the STRING-valued siblings of field(). Same <no-report>/<no-field> discipline, for
+# the same reason -- a label-set assertion whose report never arrived must say so rather than
+# compare "" against "".
+strfield() {
+  [[ -n "$1" ]] || { printf '<no-report>'; return; }
+  case "$1" in *"\"$2\":"*) ;; *) printf '<no-field:%s>' "$2"; return ;; esac
+  printf '%s' "$1" | sed -n "s/.*\"$2\":\"\\([^\"]*\\)\".*/\\1/p"
+}
+
+# THE PINNED LABEL SET (#33, and #53 AC1). Never a bare count: a count is discharged by editing
+# one digit, and the edit that absorbs a legitimate new phase is the same edit that absorbs a
+# phase nobody declared -- which is exactly how `literalCount == 25` shipped green over a writer
+# that writes 26. Derived ONCE by RUNNING the extraction above and pasted, so a new literal
+# forces the editor to paste the LABEL. The voice-lint suite pins this identical list, so a
+# narrowing in either copy reddens in that copy.
+PHASE_LITERALS_26='0-setup,0.5-map,0.5-map-complete,1-ba,1-ba-complete,1-ba-open-questions,1-ba-rework-required,2-constraints,2-constraints-complete,2-review,2-review-complete,2.5-design,2.5-design-complete,2.5-design-owner-decision,3-impl,3-impl-complete,3-impl-frontend-gate-failed,3-impl-gate-failed,3-impl-live-verify-unverified,3-impl-tripwire,3-impl-tripwire-indeterminate,4-review,4-review-complete,4-veto-rework-required,5-archive,5-archived'
+COMPLETE_LITERALS_7='0.5-map-complete,1-ba-complete,2-constraints-complete,2-review-complete,2.5-design-complete,3-impl-complete,4-review-complete'
 
 REPORT="$(derive MODULE)"
 
@@ -85,17 +132,48 @@ suite "AC18(vi): VACUITY CONTROL -- the derivation found a population at all"
 LIT_N="$(num "$REPORT" literalCount)"
 assert_eq "the pipeline.md derivation found at least 20 current_phase literals" \
   "$([[ "${LIT_N:-0}" -ge 20 ]] && echo enough || echo "ONLY ${LIT_N:-<no-report>}")" "enough"
-assert_eq "and exactly the 25 concrete ones (26 distinct minus the <phase>-error template)" \
-  "${LIT_N:-<no-report>}" "25"
+# THE SET, not the count (#53 AC1). `literalCount == 25` sat here and was green over a
+# 25-literal population derived from a 26-literal file, because assertion and control ranged
+# over the same narrowed set. The count survives only as the vacuity floor above.
+assert_eq "and the derived label SET is exactly the 26 concrete literals pipeline.md writes, \`0-setup\` among them" \
+  "$(strfield "$REPORT" literals)" "$PHASE_LITERALS_26"
 
 # ---------------------------------------------------------------------------
-suite "AC18(i): the four sets PARTITION the 25 literals"
+suite "AC18(i)/#53 AC6: the partition cells cover the 26 literals, in both directions"
 # ---------------------------------------------------------------------------
 # A partition is strictly stronger than a union check, and it is what makes 'decided' tellable
 # from 'forgot' in BOTH directions: a literal in two sets fails, and a literal in none fails.
 assert_eq "the sets are pairwise DISJOINT" "$(field "$REPORT" dupes)" ""
 assert_eq "every pipeline.md literal is assigned to exactly one set" "$(field "$REPORT" unassigned)" ""
 assert_eq "and no set names a phase pipeline.md does not write" "$(field "$REPORT" notInMd)" ""
+
+# --- the SHAPE of what the partition read, asserted BEFORE anything is concluded from it -----
+#
+# #53 AC4(iii)/R4(b). `notInMd` and the disjointness walk are computed FROM these cells, so an
+# ABSENT cell (a mistyped export name), an EMPTY cell, or a Set where an Array is expected makes
+# them green having compared nothing. MEASURED, and the reason this sits here rather than at the
+# diagonals: with every cell emptied, `notInMd` is [] and GREEN, while `unassigned` names all 26
+# literals and is loudly RED -- so the vacuity lives in the table-as-population direction ONLY,
+# and this is where the assertion belongs. The two cells below are the ones that NAME it.
+assert_eq "every partition cell reads back as a NON-EMPTY Array (an ABSENT, empty or Set-shaped cell makes notInMd green having compared nothing)" \
+  "$(field "$REPORT" emptyCells)" ""
+assert_eq "and the guard exports a fifth cell PRELUDE that this partition READS BY NAME -- a mistyped export resolves to ABSENT here, with the typo named, instead of to an unrelated red elsewhere" \
+  "$(strfield "$REPORT" shapes)" "ENTRY=Array EXIT=Array UNGUARDED=Array TERMINAL=Array PRELUDE=Array"
+assert_eq "PRELUDE declares exactly \`0-setup\`: the run's setup step, which is a real occupied phase and belongs in no other cell (a PREREQUISITES row is refused by AC18(ii) below, and UNGUARDED's own reason -- \"a halt or rework state\" -- is not true of it)" \
+  "$(strfield "$REPORT" preludeMembers)" "0-setup"
+
+# --- and the CONTROL that proves those two cells are the ones doing that work ----------------
+CTRL_EMPTY='{"ENTRY":[],"EXIT":[],"UNGUARDED":[],"TERMINAL":[],"PRELUDE":[]}'
+CTRL_EMPTY_REPORT="$(derive "$CTRL_EMPTY")"
+assert_eq "TABLE-AS-POPULATION VACUITY, measured: with every cell EMPTIED, \`notInMd\` is still empty and still GREEN -- the diagonal cannot see an empty table" \
+  "$(field "$CTRL_EMPTY_REPORT" notInMd)" ""
+assert_contains "  and the shape-and-non-emptiness cell above is what DOES see it, naming every empty cell" \
+  "$(field "$CTRL_EMPTY_REPORT" emptyCells)" "PRELUDE"
+assert_contains "  PAIRED, so this is not a one-sided reading: the OTHER direction is not blind either -- an emptied table makes \`unassigned\` name all 26 literals, loudly" \
+  "$(field "$CTRL_EMPTY_REPORT" unassigned)" "0-setup"
+CTRL_MISTYPED='{"ENTRY":["3-impl"],"EXIT":["3-impl-complete"],"UNGUARDED":["3-impl-tripwire"],"TERMINAL":["5-archived"],"PRELUDEE":["0-setup"]}'
+assert_contains "  and a MISTYPED fifth-cell name is diagnosed as an ABSENT cell rather than left for a reader to infer from an unrelated \`unassigned\` red" \
+  "$(strfield "$(derive "$CTRL_MISTYPED")" shapes)" "PRELUDE=ABSENT"
 
 # ---------------------------------------------------------------------------
 suite "AC18(vii): DETECTABILITY CONTROL -- the same derivation reports a planted miss"
@@ -111,38 +189,72 @@ assert_contains "a literal placed in TWO sets fails disjointness" \
   "$(field "$(derive "$CTRL_DUPE")" dupes)" "3-impl"
 
 # ---------------------------------------------------------------------------
-suite "AC18(ii): |ENTRY| is pinned to pipeline.md's 'Checkpoint first' sites"
+suite "AC18(ii)/#53 AC8: ENTRY equals the SET of phases pipeline.md checkpoints into"
 # ---------------------------------------------------------------------------
-CP_N="$(grep -o 'Checkpoint first' "$PIPELINE_MD" | wc -l | tr -d ' ')"
-assert_eq "pipeline.md has 8 'Checkpoint first' occurrences (grep -o | wc -l, never grep -c)" "$CP_N" "8"
-assert_eq "and |ENTRY| equals that count" "$(num "$REPORT" ENTRY)" "$CP_N"
+# BOTH DIRECTIONS, EACH REPORTED BY NAME, and asserted as a SET rather than as a count. The
+# count assertion that stood here (`8 'Checkpoint first' occurrences` == `|ENTRY|`) is now a
+# `record`: pipeline.md already describes loop-backs re-entering Phases 2 and 3, so a SECOND
+# Checkpoint-first site for an EXISTING phase takes the occurrence count to 9 while ENTRY
+# correctly stays 8 -- measured on a copy, the count assertion goes RED on a correct table
+# while the set assertion stays GREEN in both directions.
+#
+# THIS IS THE ASSERTION THAT REFUSES A `PREREQUISITES` ROW FOR `0-setup` (#53 R4). ENTRY is
+# DERIVED from PREREQUISITES keys, and `0-setup` is written at no Checkpoint-first site, so a
+# planted row surfaces here as `entryNotCp: ["0-setup"]` rather than being absorbed.
+#
+# The Checkpoint-first literals come out of the SAME wide pattern the derivation uses (#53 R1's
+# third strict copy, folded in), and a Checkpoint-first line yielding NO literal is identified
+# by its LINE NUMBER AND ITS TEXT -- not by a constant `<no-literal-on-line>` placeholder, which
+# collapses N such lines into N indistinguishable tokens a reader cannot locate.
+CP_REPORT="$(node --input-type=module -e '
+  import { readFileSync } from "node:fs";
+  const [mdPath, guardPath] = process.argv.slice(1);
+  const md = readFileSync(mdPath, "utf8");
+  const WIDE = /"?current_phase"?: *"([^"]*)"/g;
+  const sites = []; const noLit = []; const lits = new Set();
+  md.split("\n").forEach((l, i) => {
+    if (!l.includes("Checkpoint first")) return;
+    sites.push(i + 1);
+    const found = [...l.matchAll(WIDE)].map((m) => m[1]);
+    if (found.length === 0) noLit.push((i + 1) + ": " + l.trim().replace(/\s+/g, " ").slice(0, 90));
+    for (const f of found) lits.add(f);
+  });
+  const m = await import(guardPath);
+  const entry = Array.isArray(m.ENTRY) ? [...m.ENTRY] : [];
+  const cp = [...lits].sort();
+  process.stdout.write(JSON.stringify({
+    siteCount: sites.length,
+    cpSet: cp.join(","),
+    entrySet: entry.slice().sort().join(","),
+    cpNotEntry: cp.filter((x) => !entry.includes(x)),
+    entryNotCp: entry.filter((x) => !lits.has(x)),
+    noLiteralSites: noLit,
+  }));
+' "$PIPELINE_MD" "$GUARD" 2>/dev/null)"
 
-# Each literal at a Checkpoint-first site must BE an entry key. The count agreeing while the
-# membership does not is the exact drift a count-only check misses.
-CP_MISSING=""
-while IFS= read -r line; do
-  lit="$(printf '%s' "$line" | sed -n 's/.*current_phase: *"\([^"]*\)".*/\1/p')"
-  [[ -n "$lit" ]] || { CP_MISSING="$CP_MISSING <no-literal-on-line>"; continue; }
-  node --input-type=module -e '
-    const m = await import(process.argv[1]);
-    process.exit(m.ENTRY.includes(process.argv[2]) ? 0 : 1);
-  ' "$GUARD" "$lit" 2>/dev/null || CP_MISSING="$CP_MISSING $lit"
-done < <(grep 'Checkpoint first' "$PIPELINE_MD")
-assert_eq "every phase literal at a 'Checkpoint first' site IS an ENTRY key" "${CP_MISSING# }" ""
+CP_ENTRY_SET_8='0.5-map,1-ba,2-constraints,2-review,2.5-design,3-impl,4-review,5-archive'
+record "REPORTED, not asserted: pipeline.md holds $(num "$CP_REPORT" siteCount) 'Checkpoint first' occurrences (grep -o | wc -l semantics, never grep -c). A second site for an EXISTING phase is legitimate and moves this number without moving the set"
+assert_eq "the SET of phases pipeline.md checkpoints into is the eight it names" \
+  "$(strfield "$CP_REPORT" cpSet)" "$CP_ENTRY_SET_8"
+assert_eq "and the guard's exported ENTRY set is the same eight" \
+  "$(strfield "$CP_REPORT" entrySet)" "$CP_ENTRY_SET_8"
+assert_eq "  direction 1, by name: every Checkpoint-first phase IS an ENTRY key" \
+  "$(field "$CP_REPORT" cpNotEntry)" ""
+assert_eq "  direction 2, by name: and ENTRY names no phase pipeline.md never checkpoints into -- this is what refuses a PREREQUISITES row for \`0-setup\`, which is written at no Checkpoint-first site" \
+  "$(field "$CP_REPORT" entryNotCp)" ""
+assert_eq "  a Checkpoint-first line yielding NO literal is reported by LINE and TEXT, never as an anonymous placeholder" \
+  "$(field "$CP_REPORT" noLiteralSites)" ""
 
 # ---------------------------------------------------------------------------
-suite "AC18(iii): every <phase>-complete literal pipeline.md writes is an EXIT key"
+suite "AC18(iii)/#53 AC9: every <phase>-complete literal pipeline.md writes is an EXIT key"
 # ---------------------------------------------------------------------------
+# The `-complete` sub-derivation is taken from the SAME single wide extraction (#53 R1's fourth
+# strict copy, folded in). A form fix with an empty residual: strict and wide both yield the
+# same seven, which is why the criterion pins the SET rather than the number 7.
 assert_eq "|EXIT| is 7" "$(num "$REPORT" EXIT)" "7"
-COMPLETE_MISSING=""
-while IFS= read -r lit; do
-  [[ -n "$lit" ]] || continue
-  node --input-type=module -e '
-    const m = await import(process.argv[1]);
-    process.exit(m.EXIT.includes(process.argv[2]) ? 0 : 1);
-  ' "$GUARD" "$lit" 2>/dev/null || COMPLETE_MISSING="$COMPLETE_MISSING $lit"
-done < <(grep -o 'current_phase: *"[^"]*-complete"' "$PIPELINE_MD" | sed -n 's/.*"\([^"]*\)"/\1/p' | sort -u)
-assert_eq "no -complete literal is missing from EXIT" "${COMPLETE_MISSING# }" ""
+assert_eq "and the -complete label SET the wide derivation yields is unchanged by the widening" \
+  "$(strfield "$REPORT" completeLiterals)" "$COMPLETE_LITERALS_7"
+assert_eq "no -complete literal is missing from EXIT" "$(field "$REPORT" completeNotInExit)" ""
 
 # ---------------------------------------------------------------------------
 suite "AC18(iv): the satisfying token sets REFERENCE the registry, they do not restate it"
@@ -274,5 +386,202 @@ assert_contains "stop.sh's opt-out comment names the variable it is about" "$STO
 assert_contains "  and says the phase-entry guard is NOT bypassed" "$STOP_SRC" "NOT the phase-entry guard"
 assert_not_contains "  and the bare 'Opt-out for one-off iterations.' comment is corrected, not kept" \
   "$STOP_SRC" "# Opt-out for one-off iterations."
+
+# ===========================================================================================
+# #53 -- THE FORM-COVERAGE CONTROL: a population no assignment spelling can leave
+#
+# WHY A THIRD RULE IS NOT THE ANSWER. Replacing one pattern with a wider pattern does not close
+# the class, it moves the boundary. The class closes only when the coverage control's POPULATION
+# is something no assignment spelling can escape -- the BARE WORD `current_phase` -- with every
+# occurrence forced into a NAMED bucket:
+#   CLAIMED      = matched by the derivation this suite SHIPS (derive() above).
+#   EXCLUDED     = not matched even by a pattern STRICTLY WIDER than the claim pattern.
+#   UNCLASSIFIED = matched by the wider pattern but not by the shipped one, i.e. a REAL
+#                  assignment the derivation misses. Must be EMPTY, and is reported BY NAME.
+#
+# THE EXCLUSION RULE IS THE NEGATION OF THE WIDER PATTERN, NOT AN INDEPENDENTLY SPELLED THIRD
+# RULE. That is what makes the claim rule and the exclusion rule structurally unable to disagree
+# about what an assignment operator is -- the disagreement that lets `current_phase = "0-setup"`
+# be claimed by neither and excluded by a hand-written rule, silently.
+#
+# THE EXCLUDED BUCKET IS A SORTED MULTISET, ASSERTED; ITS SIZE IS ONLY REPORTED.
+#   - MULTISET, never `sort -u`: three of the five excluded LINES carry TWO occurrences each
+#     with IDENTICAL text (measured, per line: 2/2/2/1/1), so `sort -u` turns 8 entries into 5
+#     and a mutation removing one of a duplicated pair leaves the asserted list unchanged.
+#   - SIZE REPORTED, NOT ASSERTED (#33): a pinned 8 is discharged by editing one digit, and the
+#     edit that absorbs a legitimate new prose mention is the same edit that absorbs a SWALLOWED
+#     ASSIGNMENT. The failure direction is CLAIM-MORE: after the digit is bumped the report
+#     reads `0 UNCLASSIFIED, all accounted for` while a live assignment sits in EXCLUDED.
+#   - KEYED ON TEXT, WITH THE LINE NUMBER REPORTED AND NOT ASSERTED: pipeline.md is edited by a
+#     lane that does not own this suite, and a coordinate pin reddens on any insertion above the
+#     last excluded site -- churn that trains an editor to re-paste without reading (#68).
+#   - THE KEY IS A TEXT FINGERPRINT, `<trimmed length>|<first 72 trimmed characters>`, and the
+#     grain is deliberate: the three duplicated LINES yield IDENTICAL entries, so `sort -u`
+#     still collapses 8 to 5 and the multiset property still bites, while the assertion stays
+#     readable. Any edit to an excluded occurrence's line changes its length or its prefix and
+#     forces the editor to paste the occurrence rather than increment a digit.
+# ===========================================================================================
+
+# tripart <md-path> [wider|sameline] -> a line-oriented report.
+# The `sameline` rule is NOT shippable and is here only as the NON-ZERO CONTROL that separates
+# the two candidate exclusion rules; see the ghost cells below.
+tripart() {
+  node --input-type=module -e '
+    import { readFileSync } from "node:fs";
+    const [mdPath, rule] = process.argv.slice(1);
+    const md = readFileSync(mdPath, "utf8");
+    const CLAIM = /"?current_phase"?: *"([^"]*)"/g;
+    // STRICTLY WIDER than CLAIM: key optionally quoted with ", \x27 or a backtick; separator
+    // [:=]; whitespace around it that MAY SPAN NEWLINES; value quoted three ways or a bare
+    // token. Written with \x27 rather than a literal quote so the whole program survives the
+    // single-quoted shell string it lives in.
+    const WIDER = /["\x27`]?current_phase["\x27`]?\s*[:=]\s*(?:"[^"]*"|\x27[^\x27]*\x27|`[^`]*`|[A-Za-z0-9._<>-]+)/g;
+    const spans = (re) => [...md.matchAll(re)].map((m) => [m.index, m.index + m[0].length, m[0]]);
+    const claimSpans = spans(CLAIM), widerSpans = spans(WIDER);
+    const within = (i, ss) => ss.find(([a, b]) => i >= a && i < b);
+    const lines = md.split("\n");
+    const starts = []; { let o = 0; for (const l of lines) { starts.push(o); o += l.length + 1; } }
+    const lineOf = (i) => { let lo = 0, hi = starts.length - 1;
+      while (lo < hi) { const m = (lo + hi + 1) >> 1; if (starts[m] <= i) lo = m; else hi = m - 1; } return lo; };
+    const claimed = [], excluded = [], unclassified = [];
+    for (const m of md.matchAll(/current_phase/g)) {
+      const i = m.index, li = lineOf(i), text = lines[li];
+      if (within(i, claimSpans)) { claimed.push({ li, text }); continue; }
+      const isExcluded = rule === "sameline"
+        ? !/^current_phase["\x27`]?[ \t]*[:=]/.test(md.slice(i, starts[li] + text.length))
+        : !within(i, widerSpans);
+      if (isExcluded) excluded.push({ li, text });
+      else { const w = within(i, widerSpans); unclassified.push({ li, span: w ? w[2] : text }); }
+    }
+    const fp = (e) => e.text.trim().length + "|" + e.text.trim().slice(0, 72);
+    const out = [];
+    out.push("TOTAL=" + [...md.matchAll(/current_phase/g)].length);
+    out.push("CLAIMED=" + claimed.length);
+    out.push("EXCLUDED=" + excluded.length);
+    out.push("UNCLASSIFIED=" + unclassified.length);
+    out.push("EXLINES=" + excluded.map((e) => e.li + 1).join(","));
+    out.push("UNNAMED=" + unclassified.map((e) => (e.li + 1) + ":" + e.span.replace(/\s+/g, " ")).join(" ;; "));
+    out.push("--EXFP--");
+    for (const line of excluded.map(fp).sort()) out.push(line);
+    process.stdout.write(out.join("\n"));
+  ' "$1" "${2:-wider}" 2>&1
+}
+
+# tp <report> <KEY> -> the value; tp_exfp <report> -> the sorted excluded fingerprint multiset.
+tp()      { printf '%s' "$1" | sed -n "s/^$2=//p"; }
+tp_exfp() { printf '%s' "$1" | sed -n '/^--EXFP--$/,$p' | sed '1d'; }
+
+TP_REAL="$(tripart "$PIPELINE_MD" wider)"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC2: every bare-word occurrence lands in exactly one named bucket"
+# ---------------------------------------------------------------------------
+record "REPORTED, never asserted: pipeline.md holds $(tp "$TP_REAL" TOTAL) bare-word \`current_phase\` occurrences, $(tp "$TP_REAL" CLAIMED) CLAIMED and $(tp "$TP_REAL" EXCLUDED) EXCLUDED, the excluded ones at lines $(tp "$TP_REAL" EXLINES). Grain is OCCURRENCES, not distinct literals: do not subtract these from the 26"
+assert_eq "the three buckets ACCOUNT FOR every bare-word occurrence (a lost occurrence is the defect this control exists to make impossible)" \
+  "$(( $(tp "$TP_REAL" CLAIMED) + $(tp "$TP_REAL" EXCLUDED) + $(tp "$TP_REAL" UNCLASSIFIED) ))" \
+  "$(tp "$TP_REAL" TOTAL)"
+assert_eq "UNCLASSIFIED is EMPTY: no assignment the WIDER pattern can see is missed by the derivation this suite ships" \
+  "$(tp "$TP_REAL" UNNAMED)" ""
+
+# THE EXCLUDED MULTISET. Captured by RUNNING the extraction above and pasted; eight entries, of
+# which three pairs are identical by construction (one line, two occurrences).
+# NOT a heredoc inside a $( ) capture: /bin/bash 3.2.57 scans a command substitution for its
+# closing paren WITHOUT honouring quoted-heredoc rules, so the UNPAIRED backtick left by a
+# 72-character truncation makes the whole file un-parseable. A multi-line single-quoted
+# assignment has no such hazard, and single quotes cannot appear in these eight lines.
+EXCLUDED_MULTISET_8='133|- **User interrupts mid-phase**: status.json preserves position. `/pipel
+285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
+285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
+461|**`events[]` entries are EXIT markers and `current_phase` is an ENTRY ma
+461|**`events[]` entries are EXIT markers and `current_phase` is an ENTRY ma
+479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
+479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
+89|# Run BEFORE entering each phase, after setting current_phase to the pha'
+assert_eq "and the EXCLUDED bucket's MEMBERSHIP is what is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot move between buckets at constant bucket sizes" \
+  "$(tp_exfp "$TP_REAL")" "$EXCLUDED_MULTISET_8"
+assert_eq "MULTISET, NOT A SET: three of the five excluded LINES carry two occurrences each with identical text, so \`sort -u\` would collapse 8 entries to 5 and re-open the bypass. This cell measures that collapse rather than asserting it is absent by inspection" \
+  "$(tp_exfp "$TP_REAL" | sort -u | grep -c . | tr -d ' ')/$(tp_exfp "$TP_REAL" | grep -c . | tr -d ' ')" "5/8"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC3(i): the SYNTHETIC fixture -- six unclaimed assignment forms, each NAMED"
+# ---------------------------------------------------------------------------
+new_tmpdir || exit 90
+FIX_DIR="$NEW_TMPDIR"
+cat > "$FIX_DIR/seven-forms.md" <<'SYN'
+  "current_phase": "json-form",
+current_phase: 'single-quoted'
+current_phase: `backticked`
+current_phase
+  : "newline-split"
+current_phase: bare-token
+status.current_phase = "equals-form"
+current_phase   : "wide-gap-before-colon"
+Prose: the orchestrator writes current_phase before each phase begins.
+SYN
+TP_SYN="$(tripart "$FIX_DIR/seven-forms.md" wider)"
+assert_eq "eight bare-word occurrences partition as 1 CLAIMED + 1 EXCLUDED + 6 UNCLASSIFIED" \
+  "$(tp "$TP_SYN" CLAIMED)/$(tp "$TP_SYN" EXCLUDED)/$(tp "$TP_SYN" UNCLASSIFIED)" "1/1/6"
+for form in single-quoted backticked newline-split bare-token equals-form wide-gap-before-colon; do
+  assert_contains "  and the unclaimed \`$form\` assignment is named in UNCLASSIFIED rather than deleted by a pre-filter" \
+    "$(tp "$TP_SYN" UNNAMED)" "$form"
+done
+assert_contains "  while the PROSE mention lands in EXCLUDED, so the two buckets do not swap" \
+  "$(tp_exfp "$TP_SYN")" "Prose: the orchestrator writes current_phase"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC3(ii): the GHOST fixture -- the cell that separates the two exclusion rules"
+# ---------------------------------------------------------------------------
+# A copy of the REAL pipeline.md with `current_phase` and `: "9-ghost"` on CONSECUTIVE LINES and
+# one prose mention DELETED in the same edit. Bucket SIZES cannot separate the rules here, which
+# is the whole point: only the fixture can.
+node -e '
+  const fs = require("fs");
+  const lines = fs.readFileSync(process.argv[1], "utf8").split("\n");
+  const out = [];
+  let dropped = 0;
+  for (const l of lines) {
+    if (!dropped && l.includes("User interrupts mid-phase") && l.includes("current_phase")) { dropped = 1; continue; }
+    out.push(l);
+  }
+  if (!dropped) { console.error("GHOST FIXTURE: the prose mention this edit deletes was not found"); process.exit(1); }
+  out.push("current_phase");
+  out.push(": \"9-ghost\"");
+  fs.writeFileSync(process.argv[2], out.join("\n"));
+' "$PIPELINE_MD" "$FIX_DIR/ghost.md" 2>/dev/null
+assert_eq "the ghost fixture was built (its edit deletes one prose mention and adds one newline-split assignment, so the bare-word total is UNCHANGED)" \
+  "$(tp "$(tripart "$FIX_DIR/ghost.md" wider)" TOTAL)" "$(tp "$TP_REAL" TOTAL)"
+
+TP_GHOST_WIDE="$(tripart "$FIX_DIR/ghost.md" wider)"
+TP_GHOST_SAME="$(tripart "$FIX_DIR/ghost.md" sameline)"
+TP_REAL_SAME="$(tripart "$PIPELINE_MD" sameline)"
+
+assert_contains "THE SHIPPED RULE NAMES THE GHOST: a newline-split assignment the derivation cannot claim is reported in UNCLASSIFIED, by name" \
+  "$(tp "$TP_GHOST_WIDE" UNNAMED)" "9-ghost"
+assert_eq "  and the excluded MULTISET reddens by naming what MOVED (the deleted prose mention is gone from it)" \
+  "$([[ "$(tp_exfp "$TP_GHOST_WIDE")" != "$(tp_exfp "$TP_REAL")" ]] && echo changed || echo "UNCHANGED: the multiset did not move")" "changed"
+assert_eq "NON-ZERO CONTROL, and the reason the size CANNOT be the instrument: the SAME-LINE exclusion rule reports the ghost file as $(tp "$TP_GHOST_SAME" CLAIMED) CLAIMED + $(tp "$TP_GHOST_SAME" EXCLUDED) EXCLUDED + $(tp "$TP_GHOST_SAME" UNCLASSIFIED) UNCLASSIFIED -- fully green over a LIVE unclaimed assignment" \
+  "$(tp "$TP_GHOST_SAME" UNCLASSIFIED)" "0"
+assert_eq "  and under that rule the literal \`9-ghost\` appears in NO bucket's output at all" \
+  "$(printf '%s' "$TP_GHOST_SAME" | grep -c '9-ghost' | tr -d ' ')" "0"
+assert_eq "  the two rules are IDENTICAL on the unmodified file, which is why the FIXTURE and not the numbers is what separates them" \
+  "$(tp "$TP_REAL_SAME" CLAIMED)/$(tp "$TP_REAL_SAME" EXCLUDED)/$(tp "$TP_REAL_SAME" UNCLASSIFIED)" \
+  "$(tp "$TP_REAL" CLAIMED)/$(tp "$TP_REAL" EXCLUDED)/$(tp "$TP_REAL" UNCLASSIFIED)"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC10: the comment ruling on the derivation cites a re-derivation, not a coordinate"
+# ---------------------------------------------------------------------------
+# The replaced comment ruled against the wide form BY NAME and cited an absolute line range into
+# a different shipped file. Both halves were wrong: the rule was backwards, and the citation is
+# #68's shape. `grep -o | wc -l` throughout, never `grep -c`, which counts LINES.
+assert_eq "this suite cites no absolute line range into test-voice-lint.sh" \
+  "$(grep -o 'test-voice-lint\.sh:[0-9]' "${BASH_SOURCE[0]}" | wc -l | tr -d ' ')" "0"
+# ASSEMBLED, NEVER WRITTEN AS ONE TOKEN. This file is inside the population the grep above
+# walks, so a control carrying the coordinate verbatim makes the zero un-reachable for a reason
+# that has nothing to do with the subject -- the self-counting trap this repo has hit twice.
+CTRL_COORD="tests/test-voice-lint""$(printf '%s' .sh:225-239)"
+assert_eq "  NON-ZERO CONTROL on that instrument: the same pattern finds a coordinate when one is there, so the zero above is a measurement and not a pattern that never matches" \
+  "$(printf '%s\n' "$CTRL_COORD" | grep -o 'test-voice-lint\.sh:[0-9]' | wc -l | tr -d ' ')" "1"
+assert_contains "  and the comment now in force states the rule, and cites a re-derivation command" \
+  "$(cat "${BASH_SOURCE[0]}")" 'git grep -n "THE WIDE FORM" -- plugins/pipeline/tests'
 
 finish

--- a/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-drift.sh
@@ -399,6 +399,16 @@ assert_not_contains "  and the bare 'Opt-out for one-off iterations.' comment is
 #   UNCLASSIFIED = matched by the wider pattern but not by the shipped one, i.e. a REAL
 #                  assignment the derivation misses. Must be EMPTY, and is reported BY NAME.
 #
+# TWO COPIES OF THIS CONTROL REMAIN IN LANE 1, one here and one in the voice-lint suite, and
+# each pins the same label set so a narrowing reddens in the copy where it happens. THE
+# DUPLICATION IS A KNOWN RESIDUAL AND CLOSURE IS TRACKED: HANDOFF C (a single Lane-1 derivation
+# helper consumed by both suites) is recorded in the deferral ledger posted as a comment on
+# issue #53. Its BINDING CONSTRAINT is recorded there and repeated here because it is the part a
+# future implementer will get wrong: a shared helper returns the EXTRACTION from pipeline.md and
+# NEVER an asserted set. The Lane-2 status-schema suite asserts 27 because it ADDS `halted-error`
+# under a stated rule of its own, so a helper handing back the asserted set would make Lane 2
+# refuse correct work.
+#
 # THE EXCLUSION RULE IS THE NEGATION OF THE WIDER PATTERN, NOT AN INDEPENDENTLY SPELLED THIRD
 # RULE. That is what makes the claim rule and the exclusion rule structurally unable to disagree
 # about what an assignment operator is -- the disagreement that lets `current_phase = "0-setup"`
@@ -420,6 +430,12 @@ assert_not_contains "  and the bare 'Opt-out for one-off iterations.' comment is
 #     still collapses 8 to 5 and the multiset property still bites, while the assertion stays
 #     readable. Any edit to an excluded occurrence's line changes its length or its prefix and
 #     forces the editor to paste the occurrence rather than increment a digit.
+#   - AND THE FINGERPRINT IS NON-INJECTIVE, which is what the assertion label below is narrowed
+#     to. pipeline.md already holds a colliding pair: measured at this commit, lines 270 and 284
+#     are both 107 trimmed characters and agree for the first 99, differing only at `SecOps`
+#     versus `DevOps`, past the 72-character cut. Neither carries `current_phase`, so the
+#     collision is LATENT rather than live -- but two occurrences sharing a fingerprint could be
+#     exchanged invisibly, so this cell catches an ADDITION or a REMOVAL and not every swap.
 # ===========================================================================================
 
 # tripart <md-path> [wider|sameline] -> a line-oriented report.
@@ -435,6 +451,14 @@ tripart() {
     // [:=]; whitespace around it that MAY SPAN NEWLINES; value quoted three ways or a bare
     // token. Written with \x27 rather than a literal quote so the whole program survives the
     // single-quoted shell string it lives in.
+    //
+    // WIDER IS A FLOOR, NOT A TOTAL, and it has misses of its own. Measured over four spellings:
+    // a bracket-index assignment, a markdown-bold key, and a YAML block scalar are matched by
+    // NEITHER pattern, so all three land in EXCLUDED and read as prose; only the
+    // single-quoted-value form with an = separator lands in UNCLASSIFIED where it belongs.
+    // Three misses out of four tested. Do not read a green UNCLASSIFIED as "no spelling can
+    // escape": what bounds the damage is the BARE-WORD population, because a missed spelling is
+    // still COUNTED and still has to be named in the excluded list somebody reads.
     const WIDER = /["\x27`]?current_phase["\x27`]?\s*[:=]\s*(?:"[^"]*"|\x27[^\x27]*\x27|`[^`]*`|[A-Za-z0-9._<>-]+)/g;
     const spans = (re) => [...md.matchAll(re)].map((m) => [m.index, m.index + m[0].length, m[0]]);
     const claimSpans = spans(CLAIM), widerSpans = spans(WIDER);
@@ -497,7 +521,7 @@ EXCLUDED_MULTISET_8='133|- **User interrupts mid-phase**: status.json preserves 
 479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
 479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
 89|# Run BEFORE entering each phase, after setting current_phase to the pha'
-assert_eq "and the EXCLUDED bucket's MEMBERSHIP is what is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot move between buckets at constant bucket sizes" \
+assert_eq "and the EXCLUDED bucket's MEMBERSHIP is what is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot be ADDED to or REMOVED from this bucket at constant bucket sizes. NARROWED deliberately from \"cannot move between buckets\": the key is a length-plus-72-character FINGERPRINT and it is non-injective (pipeline.md already holds a colliding pair, see above), so a swap BETWEEN two occurrences sharing one fingerprint is invisible here. The add/remove form is what this cell supports and is what the ghost fixture below exercises" \
   "$(tp_exfp "$TP_REAL")" "$EXCLUDED_MULTISET_8"
 assert_eq "MULTISET, NOT A SET: three of the five excluded LINES carry two occurrences each with identical text, so \`sort -u\` would collapse 8 entries to 5 and re-open the bypass. This cell measures that collapse rather than asserting it is absent by inspection" \
   "$(tp_exfp "$TP_REAL" | sort -u | grep -c . | tr -d ' ')/$(tp_exfp "$TP_REAL" | grep -c . | tr -d ' ')" "5/8"

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -376,13 +376,43 @@ suite "AC27: the two suites that already own this hook are UNCHANGED consumers"
 # Recorded at f6ba1c4, BEFORE this contract was authored. Exact counts, not just failed=0: a
 # suite that silently stopped running half its cases also reports failed=0.
 #
-# RE-BASELINED ONCE, deliberately, and the reason is recorded because a number bumped without
-# one turns this assertion into a rubber stamp: test-voice-lint.sh went 41 -> 48 when #27 gave
-# voice-lint.mjs the validator's exported ISSUE_DIR_RE, closing the gap where an `exp-<slug>`
-# experiment run resolved to no active issue and was therefore never voice-checked at all. The
-# +7 is one new suite block ("exp-<slug> runs are LINTED, not exempt"): 4 behavioural cases and
-# 3 controls. Nothing existing was removed or renumbered, which is the property this cell is
-# actually guarding -- verify that by diffing the suite, not by trusting this note.
+# RE-BASELINED TWICE, each time deliberately, and each reason is recorded because a number
+# bumped without one turns this assertion into a rubber stamp.
+#
+# 41 -> 48 (#27): voice-lint.mjs got the validator's exported ISSUE_DIR_RE, closing the gap
+# where an `exp-<slug>` experiment run resolved to no active issue and was therefore never
+# voice-checked at all. The +7 is one new suite block ("exp-<slug> runs are LINTED, not
+# exempt"): 4 behavioural cases and 3 controls. Nothing existing was removed or renumbered,
+# which is the property this cell is actually guarding -- verify that by diffing the suite, not
+# by trusting this note.
+#
+# 48 -> 71 (#53): the same property VERIFIED THE SAME WAY, and it does NOT hold in its pure
+# form this time, so it is stated rather than claimed. Diffed by label set (run the suite at
+# 13e40e9 and at this commit, strip the ANSI codes, sort the `ok`/`FAIL` labels, `comm`): 26
+# labels ADDED, 3 REMOVED, net +23. Each of the three is named here with where its substance
+# went, because "removed" and "replaced by something stronger" are the two readings this number
+# cannot tell apart:
+#   - "every phase pipeline.md writes is accounted for in voice-lint.mjs" was RENAMED, not
+#     dropped: it now reads "... in voice-lint.mjs's own tables (SET MEMBERSHIP, never a source
+#     grep)". Same subject, same direction; the instrument moved from `grep -q "\"$phase\""`
+#     over the source -- which a phase named in a COMMENT satisfies -- to membership over the
+#     module's newly exported tables.
+#   - "CONTROL: the phase derivation is non-empty (found 26)" was RETIRED into the pinned
+#     26-label SET assertion plus the tri-partition's "UNCLASSIFIED is EMPTY". A count floor
+#     with the count in its own label is strictly weaker than the set (#33).
+#   - "CONTROL: the drift grep can report a miss" was RETIRED WITH ITS INSTRUMENT. Its
+#     successor is the discrimination pair over the new one: "with `0-setup` removed from the
+#     tables, the accounting names it", the cell asserting the string is still present in the
+#     source while that happens, and the injection control that dropping a phase the tables
+#     never held moves nothing.
+#
+# AND THE IRONY, recorded as a pointer rather than acted on here: this cell is a bare exact-count
+# pin over another suite's whole population, which is the class #33 retired elsewhere in Lane 1.
+# It would be better as a LABEL-SET assertion -- pin the sorted label list, and an addition then
+# forces the editor to paste the label while a REMOVAL or a rename reddens by name instead of
+# arriving as an unexplained delta that a re-baseline can absorb. Filed as a pointer for whoever
+# revisits this file; #53 only re-baselined the number it broke, and deliberately touched
+# nothing else here.
 run_suite_counts() {  # <suite-file> -> SUITE_PASSED, SUITE_FAILED
   local out
   out="$(cd "$TESTS_DIR" && bash "$1" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
@@ -393,7 +423,7 @@ run_suite_counts test-stop-hook.sh
 assert_eq "test-stop-hook.sh still passes exactly its 18 pre-existing assertions" "${SUITE_PASSED:-<none>}" "18"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 run_suite_counts test-voice-lint.sh
-assert_eq "test-voice-lint.sh still passes exactly its 48 assertions (41 pre-existing + 7 from #27)" "${SUITE_PASSED:-<none>}" "48"
+assert_eq "test-voice-lint.sh still passes exactly its 71 assertions (41 pre-existing + 7 from #27 + 26 from #53, less 3 retired by #53 -- see the note above)" "${SUITE_PASSED:-<none>}" "71"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 
 # ---------------------------------------------------------------------------

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -410,9 +410,11 @@ suite "AC27: the two suites that already own this hook are UNCHANGED consumers"
 # pin over another suite's whole population, which is the class #33 retired elsewhere in Lane 1.
 # It would be better as a LABEL-SET assertion -- pin the sorted label list, and an addition then
 # forces the editor to paste the label while a REMOVAL or a rename reddens by name instead of
-# arriving as an unexplained delta that a re-baseline can absorb. Filed as a pointer for whoever
-# revisits this file; #53 only re-baselined the number it broke, and deliberately touched
-# nothing else here.
+# arriving as an unexplained delta that a re-baseline can absorb. CLOSURE IS TRACKED, so this is
+# a pointer with a destination rather than a wish: the count-pin re-baseline and the
+# label-set successor are recorded in the deferral ledger posted as a comment on issue #53,
+# which is where a future reader picks this up. #53 itself only re-baselined the number it
+# broke, and deliberately touched nothing else here.
 run_suite_counts() {  # <suite-file> -> SUITE_PASSED, SUITE_FAILED
   local out
   out="$(cd "$TESTS_DIR" && bash "$1" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"

--- a/plugins/pipeline/tests/test-gate-phase-entry.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry.sh
@@ -1673,6 +1673,14 @@ suite "#61 AC1 (routing half): the siting is a CHECKPOINTED entry phase, not a p
 # occurrences shared one. This is the ONE property of the siting that ships to an adopting project
 # with no `.pipeline` history: the OCCUPANCY half of R1 is a census over committed records and is
 # deliberately not asserted anywhere, because it would fail in every downstream clone.
+# LIMIT, stated rather than rewritten (#53 R1's sixth strict-form site). The terms passed here
+# spell the phase assignment in the UNQUOTED-KEY form `current_phase: "x"`, and pipeline.md
+# ALSO writes one assignment in JSON form, `"current_phase": "0-setup"`. Both live terms below
+# name phases written the unquoted way, so this helper is CORRECT today and is deliberately not
+# widened. A term aimed at a JSON-form assignment would silently return 0 here, which reads as
+# "pipeline.md does not say that" rather than as "this pattern cannot see it" -- the exact
+# confusion that let a 26-literal file be policed by a 25-literal population. Any new term
+# added here must first be checked against BOTH quoting forms.
 md61() { grep -o "$1" "$PIPELINE_MD" | wc -l | tr -d ' '; }
 
 reg61 "#61-A1"
@@ -2726,5 +2734,145 @@ assert_eq "#63-Z1 no #63 assertion id is used twice (a colliding label makes the
 assert_eq "#63-Z2 every #63 id written in this file was REGISTERED by a cell that ran" \
   "$(printf '%s\n' "$AC63_UNIQ" | grep -c . | tr -d ' ')" \
   "$(grep -o '#63-[A-Za-z0-9][A-Za-z0-9]*' "${BASH_SOURCE[0]}" | sort -u | grep -c . | tr -d ' ')"
+
+# ===========================================================================================
+# #53 -- THE JUDGEMENT CLAUSE FOR `0-setup` MUST DISCRIMINATE FROM AN UNRECOGNISED PHASE
+#
+# THE DEFECT. `0-setup` is the run's first recorded phase and a real occupied one, but it sits
+# in no cell of this guard's partition, so it falls through to the fail-open branch for a phase
+# the table does not know. Its decision reason therefore carries a judgement clause BYTE-
+# IDENTICAL to the one produced for an invented phase: the run's setup step is judged as if it
+# were a typo.
+#
+# THE CLAUSE, NOT THE REASON STRING, AND THAT DISTINCTION IS WHAT MAKES THIS FALSIFIABLE. The
+# guard interpolates the record's OWN directory and phase into a leading
+# `.pipeline/<dir> at `<phase>`` span, so the two FULL reason strings ALREADY differ at HEAD and
+# an assertion over them is green with the defect live. Everything below strips that
+# record-derived span first and compares what remains.
+#
+# THE STRIP IS AN ANCHORED PATTERN, NEVER A FIXED-LENGTH CUT. Measured at HEAD: the two records'
+# interpolated spans have DIFFERENT byte lengths, so a `cut -c N-` makes the two clauses differ
+# trivially, ships green with the defect live, and reproduces the original defect at new
+# coordinates. #53-A7 asserts that length difference rather than leaving it as a claim.
+#
+# EXPECTED STATE OF THIS SECTION BEFORE THE FIX: #53-A4 is the RED one, and it is red because
+# both clauses are the same 31 bytes. Every other cell here is green at HEAD, by design -- they
+# are the premises and the controls that make #53-A4's red mean what it says.
+# ===========================================================================================
+
+AC53_IDS=""
+reg53() { AC53_IDS="$AC53_IDS$1
+"; }
+
+# ac53_probe <phase> [updated_at-iso] [extra-top-level-json-with-leading-comma]
+#   -> "<rc>|<decision>|<clause>|<clause-bytes>|<prefix-bytes>"
+# The clause and BOTH byte counts are taken off the guard's LIVE stdout, never off this file's
+# own prose: a spec's text is not the running guard, and the only number worth asserting is the
+# one the process produced.
+ac53_probe() {
+  new_tmpdir || exit 90
+  local root="$NEW_TMPDIR" out rc
+  mkdir -p "$root/.pipeline/999"
+  printf '{"issue_number":999,"current_phase":"%s","updated_at":"%s","events":[]%s}' \
+    "$1" "${2:-$FRESH_ISO}" "${3:-}" > "$root/.pipeline/999/status.json"
+  out="$(node "$GUARD" --root "$root" 2>/dev/null)"; rc=$?
+  printf '%s' "$out" | node -e '
+    let s = "";
+    process.stdin.on("data", (d) => (s += d)).on("end", () => {
+      let j;
+      try { j = JSON.parse(s); } catch { process.stdout.write(process.argv[1] + "|<unparseable-stdout>|<none>|-1|-1"); return; }
+      const reason = String(j.reason == null ? "" : j.reason);
+      const m = /^\.pipeline\/[^ ]+ at `[^`]*`/.exec(reason);
+      const clause = m ? reason.slice(m[0].length) : "<NO-RECORD-DERIVED-PREFIX>";
+      process.stdout.write([
+        process.argv[1], String(j.decision), clause,
+        String(Buffer.byteLength(clause, "utf8")),
+        String(m ? Buffer.byteLength(m[0], "utf8") : -1),
+      ].join("|"));
+    });
+  ' "$rc"
+}
+ac53_f() { printf '%s' "$1" | cut -d'|' -f"$2"; }
+
+AC53_SETUP="$(ac53_probe "0-setup")"
+AC53_GHOST="$(ac53_probe "9-invented")"
+AC53_HALT="$(ac53_probe "1-ba-open-questions")"
+AC53_TERM="$(ac53_probe "5-archived")"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC7 premises: the record-derived span is real, and the strip removes exactly it"
+# ---------------------------------------------------------------------------
+reg53 "#53-A1"
+assert_eq "#53-A1 the reason for a record at \`0-setup\` carries the record-derived \`.pipeline/<dir> at \\\`<phase>\\\`\` span, and the anchored strip matches it. Without this premise a failed strip would return the WHOLE reason and #53-A4 would compare two strings that trivially differ" \
+  "$([[ "$(ac53_f "$AC53_SETUP" 5)" -gt 0 ]] && echo stripped || echo "NO PREFIX MATCHED: $(ac53_f "$AC53_SETUP" 3)")" "stripped"
+reg53 "#53-A2"
+assert_eq "#53-A2 and so does the reason for a record at \`9-invented\`" \
+  "$([[ "$(ac53_f "$AC53_GHOST" 5)" -gt 0 ]] && echo stripped || echo "NO PREFIX MATCHED: $(ac53_f "$AC53_GHOST" 3)")" "stripped"
+reg53 "#53-A7"
+assert_eq "#53-A7 THE STRIP CANNOT BE A FIXED-LENGTH CUT: the two records' interpolated spans have DIFFERENT byte lengths, so any \`cut -c N-\` makes the two clauses differ at HEAD and ships GREEN with the defect live. This cell is why the strip is an anchored pattern" \
+  "$([[ "$(ac53_f "$AC53_SETUP" 5)" != "$(ac53_f "$AC53_GHOST" 5)" ]] && echo differ || echo "EQUAL LENGTHS: a fixed cut would be indistinguishable here")" "differ"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC7: the clause for \`0-setup\` DIFFERS from the clause for an invented phase"
+# ---------------------------------------------------------------------------
+reg53 "#53-A3"
+assert_eq "#53-A3 PAIRED NEGATIVE, an EXACT equality taken off LIVE stdout: an unrecognised phase's remaining clause is still exactly the fail-open sentence, 31 bytes. This is what makes #53-A4 a discrimination rather than a claim that something changed" \
+  "$(ac53_f "$AC53_GHOST" 3)/$(ac53_f "$AC53_GHOST" 4)" ", which is not a guarded phase./31"
+reg53 "#53-A4"
+assert_eq "#53-A4 THE CRITERION: with the record-derived span stripped, the judgement clause for \`0-setup\` is NOT the clause for an invented phase. RED before the fix, where both are the identical 31-byte fail-open sentence and the run's own setup step is judged as if it were a typo" \
+  "$([[ "$(ac53_f "$AC53_SETUP" 3)" != "$(ac53_f "$AC53_GHOST" 3)" ]] && echo discriminates || echo "IDENTICAL CLAUSES ($(ac53_f "$AC53_SETUP" 4) bytes each): $(ac53_f "$AC53_SETUP" 3)")" \
+  "discriminates"
+reg53 "#53-A5"
+assert_eq "#53-A5 and this change is BEHAVIOUR-NEUTRAL at runtime: both records still decide \`not-applicable\` and still exit 0. Only the declaration and the clause move" \
+  "$(ac53_f "$AC53_SETUP" 1)/$(ac53_f "$AC53_SETUP" 2)/$(ac53_f "$AC53_GHOST" 1)/$(ac53_f "$AC53_GHOST" 2)" \
+  "0/not-applicable/0/not-applicable"
+reg53 "#53-A6"
+assert_eq "#53-A6 LIVE POSITIVE CONTROLS that a clause CAN differ under this instrument, so #53-A4's red is about the subject and not about the strip: an UNGUARDED phase's clause is 51 bytes and a TERMINAL one's is 13, both taken off live stdout and both distinct from the 31" \
+  "$(ac53_f "$AC53_HALT" 4)/$(ac53_f "$AC53_TERM" 4)" "51/13"
+
+# ---------------------------------------------------------------------------
+suite "#53 R4(b): the new cell's branch sits AFTER the terminal check"
+# ---------------------------------------------------------------------------
+# A PRESERVATION PIN. Green at HEAD and green after a correct fix; its bite is proved by
+# mutation, not by colour. MEASURED both ways: with the new branch placed AFTER the terminal
+# check a `0-setup` record carrying `completed_at` still renders ` is finished.`; with the same
+# branch moved BEFORE it, the identical record renders the setup-step clause -- a terminal
+# record judged non-terminal. That is the concrete regression this cell exists to refuse.
+AC53_TERM_SETUP="$(ac53_probe "0-setup" "$FRESH_ISO" ",\"completed_at\":\"$FRESH_ISO\"")"
+reg53 "#53-P1"
+assert_eq "#53-P1 a record at \`0-setup\` carrying \`completed_at\` is judged FINISHED, not judged as a setup step: the terminal check runs first, and a new partition branch placed before it would silently un-finish every concluded run that ended at this phase" \
+  "$(ac53_f "$AC53_TERM_SETUP" 3)" " is finished."
+
+# ---------------------------------------------------------------------------
+suite "#53 AC7's non-zero control: dated from the ceiling the guard exports, not from a literal"
+# ---------------------------------------------------------------------------
+# A LITERAL ISO TIMESTAMP STOPS BEING A CONTROL, SILENTLY, ON A 24-HOUR TIMER. Measured against
+# this guard: the same `3-impl` architectural record with no design.json gives rc 2 `refused` at
+# now-23h and rc 0 `not-applicable` at now-25h and at any fixed past date. And `Date.parse`
+# splits on MAGNITUDE rather than on numeric-ness -- `"12345"` parses to the YEAR 12345, finite
+# and FUTURE-dated, so such a fixture reads as permanently in flight and fires the control for
+# the wrong reason, surviving any staleness mutation aimed at it. The date below is therefore
+# derived AT RUN TIME from the ceiling the guard itself exports, and the age is asserted INSIDE
+# that ceiling BEFORE the rc-2 outcome is read as evidence.
+AC53_CTRL_ISO="$(iso_ms_ago $(( IN_FLIGHT_MS / 2 )))"
+reg53 "#53-N1"
+assert_eq "#53-N1 PREMISE, asserted before the outcome is read as evidence: the control fixture's age is INSIDE the ceiling read out of the guard. An out-of-window fixture fails by name here instead of abstaining with rc 0 and looking like a pass" \
+  "$(ac63_age_vs_ceiling "$AC53_CTRL_ISO" "$IN_FLIGHT_MS")" "inside"
+AC53_CTRL="$(ac53_probe "3-impl" "$AC53_CTRL_ISO" ",\"risk_tier\":\"architectural\"")"
+reg53 "#53-N2"
+assert_eq "#53-N2 NON-ZERO CONTROL: the same probe over a record whose prerequisite is genuinely missing exits 2 and decides \`refused\`, so every \`not-applicable\`/exit-0 cell above is the guard abstaining on purpose and not the probe failing to reach it" \
+  "$(ac53_f "$AC53_CTRL" 1)/$(ac53_f "$AC53_CTRL" 2)" "2/refused"
+
+# ---------------------------------------------------------------------------
+suite "#53 the label namespace: unique, and every id that exists actually RAN"
+# ---------------------------------------------------------------------------
+reg53 "#53-Z1"
+reg53 "#53-Z2"
+AC53_UNIQ="$(printf '%s' "$AC53_IDS" | grep . | sort -u)"
+assert_eq "#53-Z1 no #53 assertion id is used twice (a colliding label makes a mutation battery's grep return two unrelated sites)" \
+  "$(printf '%s\n' "$AC53_IDS" | grep -c . | tr -d ' ')" "$(printf '%s\n' "$AC53_UNIQ" | grep -c . | tr -d ' ')"
+assert_eq "#53-Z2 every #53 id written in this file was REGISTERED by a cell that ran" \
+  "$(printf '%s\n' "$AC53_UNIQ" | grep -c . | tr -d ' ')" \
+  "$(grep -o '#53-[A-Za-z0-9][A-Za-z0-9]*' "${BASH_SOURCE[0]}" | sort -u | grep -c . | tr -d ' ')"
 
 finish

--- a/plugins/pipeline/tests/test-voice-lint.sh
+++ b/plugins/pipeline/tests/test-voice-lint.sh
@@ -350,7 +350,15 @@ assert_eq "  CONTROL on the injection itself: dropping a phase the tables never 
 #
 # The second copy of the tri-partition (the drift suite carries the first, with the full fixture
 # matrix). Two copies of the wide pattern remain in Lane 1; each carries this control, so a
-# narrowing in either copy reddens in that copy. Every occurrence of the BARE WORD
+# narrowing in either copy reddens in that copy.
+#
+# THE DUPLICATION IS A KNOWN RESIDUAL AND CLOSURE IS TRACKED, so this comment is a pointer and
+# not a shrug: HANDOFF C (a single Lane-1 derivation helper consumed by both suites) is recorded
+# in the deferral ledger posted as a comment on issue #53. Its BINDING CONSTRAINT is recorded
+# there too and is repeated here because it is the part a future implementer will get wrong: a
+# shared helper returns the EXTRACTION from pipeline.md and NEVER an asserted set. Lane 2
+# asserts 27 because it ADDS `halted-error` under a stated rule of its own, so a helper that
+# returned the asserted set would make Lane 2 refuse correct work. Every occurrence of the BARE WORD
 # `current_phase` is CLAIMED (inside a span this suite's shipped derivation matched), EXCLUDED
 # (inside NO span of a pattern strictly WIDER than the claim pattern) or UNCLASSIFIED (a real
 # assignment the derivation misses). UNCLASSIFIED must be EMPTY and is reported BY NAME.
@@ -366,6 +374,13 @@ tripart() {
     import { readFileSync } from "node:fs";
     const md = readFileSync(process.argv[1], "utf8");
     const CLAIM = /"?current_phase"?: *"([^"]*)"/g;
+    // WIDER IS A FLOOR, NOT A TOTAL, and it has misses of its own. Measured over four spellings:
+    // a bracket-index assignment, a markdown-bold key, and a YAML block scalar are matched by
+    // NEITHER pattern, so all three land in EXCLUDED and read as prose; only the
+    // single-quoted-value form with an = separator lands in UNCLASSIFIED where it belongs.
+    // Three misses out of four tested. Do not read a green UNCLASSIFIED as "no spelling can
+    // escape": what bounds the damage is the BARE-WORD population, because a missed spelling is
+    // still COUNTED and still has to be named in the excluded list somebody reads.
     const WIDER = /["\x27`]?current_phase["\x27`]?\s*[:=]\s*(?:"[^"]*"|\x27[^\x27]*\x27|`[^`]*`|[A-Za-z0-9._<>-]+)/g;
     const spans = (re) => [...md.matchAll(re)].map((m) => [m.index, m.index + m[0].length, m[0]]);
     const claimSpans = spans(CLAIM), widerSpans = spans(WIDER);
@@ -400,6 +415,14 @@ tp_exfp() { printf '%s' "$1" | sed -n '/^--EXFP--$/,$p' | sed '1d'; }
 # NOT a heredoc inside a $( ) capture: /bin/bash 3.2.57 scans a command substitution for its
 # closing paren WITHOUT honouring quoted-heredoc rules, so the UNPAIRED backtick left by a
 # 72-character truncation makes the whole file un-parseable.
+#
+# THE FINGERPRINT IS NON-INJECTIVE, and pipeline.md already contains a colliding pair. Measured
+# at this commit: lines 270 and 284 are both 107 trimmed characters and agree for the first 99,
+# differing only at `SecOps` versus `DevOps` -- past the 72-character cut, so they share one
+# fingerprint. Neither carries `current_phase`, so the collision is LATENT rather than live.
+# What it costs is stated in the assertion label below rather than left to be inferred: two
+# occurrences that share a fingerprint can be exchanged invisibly, so this cell catches an
+# ADDITION or a REMOVAL and not every conceivable swap.
 EXCLUDED_MULTISET_8='133|- **User interrupts mid-phase**: status.json preserves position. `/pipel
 285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
 285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
@@ -424,7 +447,7 @@ assert_eq "UNCLASSIFIED is EMPTY: no assignment the WIDER pattern can see is mis
 # whether the module's tables can be imported at all.
 assert_eq "the derived label SET is exactly the 26 concrete literals pipeline.md writes, \`0-setup\` among them -- and it is the SAME sorted list the drift suite pins, so a narrowing in either copy reddens in that copy" \
   "$(vl "$TP_REAL" LITERALS)" "$PHASE_LITERALS_26"
-assert_eq "and the EXCLUDED bucket's MEMBERSHIP is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot move between buckets at constant bucket sizes" \
+assert_eq "and the EXCLUDED bucket's MEMBERSHIP is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot be ADDED to or REMOVED from this bucket at constant bucket sizes. NARROWED deliberately from \"cannot move between buckets\": the key is a length-plus-72-character FINGERPRINT and it is non-injective (pipeline.md already holds a colliding pair, see above), so a swap BETWEEN two occurrences sharing one fingerprint is invisible here. The add/remove form is what this cell supports; the bucket-swap fixture that exercises it lives in the drift suite, which carries the full fixture matrix, and not in this copy" \
   "$(tp_exfp "$TP_REAL")" "$EXCLUDED_MULTISET_8"
 assert_eq "MULTISET, NOT A SET: \`sort -u\` collapses those 8 entries to 5, which is measured here rather than asserted absent by inspection" \
   "$(tp_exfp "$TP_REAL" | sort -u | grep -c . | tr -d ' ')/$(tp_exfp "$TP_REAL" | grep -c . | tr -d ' ')" "5/8"

--- a/plugins/pipeline/tests/test-voice-lint.sh
+++ b/plugins/pipeline/tests/test-voice-lint.sh
@@ -217,34 +217,269 @@ done
 
 # ---------------------------------------------------------------------------
 suite "voice-lint: the table cannot drift from pipeline.md (config-derived)"
-
+# ---------------------------------------------------------------------------
 # The first VOICE_MOMENTS table was written from memory and invented FOUR phases no checkpoint
 # writes, so those checks could never fire while the real completion report went uncovered.
 # This derives the truth from pipeline.md rather than trusting the table, per evidence.md rule
 # 19: build the expected set from CONFIGURATION, not from what has been observed.
+#
+# TWO THINGS CHANGED HERE, AND BOTH WERE DEFECTS RATHER THAN STYLE (#53).
+#
+#   1. THE POPULATION WAS NARROWER THAN ITS SUBJECT. The derivation matched `current_phase: "x"`
+#      only, while pipeline.md ALSO writes the JSON form `"current_phase": "x"`. So this suite
+#      derived 25 concrete literals from a file that writes 26, asserted that all 25 were
+#      accounted for, and printed `found 26` as its reassurance -- assertion and control ranging
+#      over the same narrowed set. `0-setup` was in neither voice table and in no partition cell
+#      of the phase-entry guard, and nothing here could see it, because a phase the pattern
+#      cannot see is not an unaccounted phase, it is not a phase at all.
+#
+#   2. THE ACCOUNTING WAS A SUBSTRING GREP OVER THE SOURCE. `grep -q "\"$phase\"" "$LINT_SRC"`
+#      is satisfied by a phase named in a COMMENT and cannot tell a table key from a mention --
+#      the exact shape the sibling drift suite's own header names as what it exists to replace.
+#      It is now SET MEMBERSHIP over the module's exported tables, which is what makes the
+#      negative cell below (declared in a comment, absent from the table -> RED) possible at all.
+#
+# THE WIDE FORM is the ONE extraction this suite performs; re-derive both copies with
+# `git grep -n "THE WIDE FORM" -- plugins/pipeline/tests`.
 PIPELINE_MD="$PLUGIN_ROOT/commands/pipeline.md"
 LINT_SRC="$SCRIPTS_DIR/voice-lint.mjs"
 
-UNACCOUNTED=""
-while IFS= read -r phase; do
-  [[ -z "$phase" || "$phase" == *"<"* ]] && continue   # skip the <phase>-error template
-  grep -q "\"$phase\"" "$LINT_SRC" || UNACCOUNTED="$UNACCOUNTED $phase"
-done < <(grep -o 'current_phase: *"[^"]*"' "$PIPELINE_MD" | sed 's/.*"\(.*\)"/\1/' | sort -u)
+# THE PINNED LABEL SET (#33). Identical to the drift suite's, on purpose: two copies of the wide
+# pattern remain in Lane 1 and this is what makes them check each other -- a narrowing in either
+# copy reddens in that copy. Never a bare count: a count is discharged by editing one digit.
+PHASE_LITERALS_26='0-setup,0.5-map,0.5-map-complete,1-ba,1-ba-complete,1-ba-open-questions,1-ba-rework-required,2-constraints,2-constraints-complete,2-review,2-review-complete,2.5-design,2.5-design-complete,2.5-design-owner-decision,3-impl,3-impl-complete,3-impl-frontend-gate-failed,3-impl-gate-failed,3-impl-live-verify-unverified,3-impl-tripwire,3-impl-tripwire-indeterminate,4-review,4-review-complete,4-veto-rework-required,5-archive,5-archived'
 
-assert_eq "every phase pipeline.md writes is accounted for in voice-lint.mjs" \
-  "${UNACCOUNTED# }" ""
+# vl_account [phase-to-DROP-from-the-tables] -> a KEY=value report, or "" if the import produced
+# nothing. The drop argument runs the IDENTICAL accounting over a deliberately holed table, which
+# is what makes the negative cell a control rather than a claim.
+#
+# THE MODULE PATH IS argv[1], DELIBERATELY. That is the shipped import idiom in this repo (the
+# drift suite passes the module it is importing as argv[1] at four call sites), and it is the
+# ORDER that triggers the hazard: `isMain` compares the BASENAME of process.argv[1], so with the
+# module path there the module SELF-RUNS its CLI on import, main() executes, and the eval body
+# NEVER RUNS -- rc 0, no output, and every membership assertion below reads a green nothing.
+# Reordering the arguments would hide that, and would leave the landmine armed for whoever next
+# writes the idiom the natural way. gate-phase-entry.mjs already ships the fix; see the control
+# immediately below the premise.
+#
+# `</dev/null` is not decoration: if the import self-runs the CLI, that CLI reads stdin.
+vl_account() {
+  node --input-type=module -e '
+    import { readFileSync } from "node:fs";
+    const [lintPath, mdPath, drop] = process.argv.slice(1);
+    const m = await import(lintPath);
+    const vm = m.VOICE_MOMENTS, nv = m.NON_VOICE_PHASES;
+    const kind = (v) => v === undefined ? "ABSENT"
+      : v instanceof Set ? "Set" : Array.isArray(v) ? "Array" : typeof v;
+    const nvList = nv instanceof Set ? [...nv] : Array.isArray(nv) ? [...nv] : [];
+    const vmKeys = vm && typeof vm === "object" && !Array.isArray(vm) ? Object.keys(vm) : [];
+    const declared = new Set([...nvList, ...vmKeys].filter((p) => p !== drop));
+    const md = readFileSync(mdPath, "utf8");
+    const literals = [...new Set([...md.matchAll(/"?current_phase"?: *"([^"]*)"/g)].map((x) => x[1]))]
+      .filter((p) => p !== "<phase>-error");
+    const out = [];
+    out.push("VMKIND=" + kind(vm));
+    out.push("NVKIND=" + kind(nv));
+    out.push("VMKEYS=" + vmKeys.slice().sort().join(","));
+    out.push("NVSIZE=" + nvList.length);
+    // The drift suite consumes an exported cell through `Array.isArray(x) ? x : []`. Applied to
+    // a Set that yields length 0 -- a green zero, not an error. Measured here against the REAL
+    // exported value rather than asserted about an inline fixture.
+    out.push("ARRAYIDIOMSIZE=" + (Array.isArray(nv) ? nv.length : 0));
+    out.push("LITERALS=" + literals.slice().sort().join(","));
+    out.push("UNACCOUNTED=" + literals.filter((p) => !declared.has(p)).sort().join(","));
+    out.push("OVERLAP=" + vmKeys.filter((k) => nvList.includes(k)).sort().join(","));
+    out.push("NV_HAS_0SETUP=" + (nvList.includes("0-setup") ? "yes" : "no"));
+    out.push("VM_HAS_0SETUP=" + (vmKeys.includes("0-setup") ? "yes" : "no"));
+    out.push("NV_HAS_3IMPL=" + (nvList.includes("3-impl") ? "yes" : "no"));
+    out.push("VM_HAS_5ARCHIVED=" + (vmKeys.includes("5-archived") ? "yes" : "no"));
+    process.stdout.write(out.join("\n"));
+  ' "$LINT_SRC" "$PIPELINE_MD" "${1:-}" </dev/null 2>/dev/null
+}
 
-# CONTROL: the derivation must actually find phases, or an empty result would "pass" vacuously
-# (rule 19's own trap: a check over an empty set reports success).
-PHASE_COUNT=$(grep -o 'current_phase: *"[^"]*"' "$PIPELINE_MD" | sed 's/.*"\(.*\)"/\1/' | sort -u | wc -l | tr -d ' ')
-assert_eq "CONTROL: the phase derivation is non-empty (found $PHASE_COUNT)" \
-  "$([ "$PHASE_COUNT" -ge 20 ] && echo many || echo "too few: $PHASE_COUNT")" "many"
+# vl <report> <KEY> -> the value, or an explicit marker. An absence assertion that cannot tell
+# "nothing wrong" from "nothing measured" is not an assertion.
+vl() {
+  [[ -n "$1" ]] || { printf '<no-report>'; return; }
+  case "$1" in *"$2="*) ;; *) printf '<no-field:%s>' "$2"; return ;; esac
+  printf '%s' "$1" | sed -n "s/^$2=//p"
+}
 
-# CONTROL: a phase that exists in NEITHER table must be detectable by the same grep, or the
-# check above proves only that grep runs.
-grep -q '"9-does-not-exist"' "$LINT_SRC" \
-  && assert_eq "CONTROL: the drift grep can report a miss" "found" "not found" \
-  || assert_eq "CONTROL: the drift grep can report a miss" "not found" "not found"
+VL_RAW="$(vl_account)"
+case "$VL_RAW" in
+  VMKIND=*) VL_STATE="ok" ;;
+  "")       VL_STATE="THE EVAL BODY NEVER RAN. Importing voice-lint.mjs SELF-RUNS its CLI (isMainScript compares the BASENAME of argv[1], and argv[1] here is the module path), so main() executes, the import never returns a value this program can read, and every membership assertion below would read a GREEN NOTHING. gate-phase-entry.mjs already ships the fix and a comment describing this exact hazard: an \`evalEntry\` test over process.execArgv, ANDed with isMain. voice-lint.mjs carries no such guard, and the exports are unusable without it" ;;
+  *)        VL_STATE="the import returned something other than a report: $VL_RAW" ;;
+esac
+
+# --- THE PREMISE, asserted BEFORE anything is concluded from the tables ----------------------
+assert_eq "PREMISE: voice-lint.mjs's tables can be IMPORTED without the module self-running its CLI" \
+  "$VL_STATE" "ok"
+assert_eq "  POSITIVE CONTROL on the idiom, so a red premise reads as \"voice-lint.mjs lacks the guard\" and not as \"this import style does not work\": the SIBLING module, which ships an \`evalEntry\` test beside its isMain check, returns its exports through the byte-identical call" \
+  "$(node --input-type=module -e 'const m = await import(process.argv[1]); process.stdout.write(Array.isArray(m.ENTRY) && m.ENTRY.length > 0 ? "exports-readable" : "EMPTY")' "$SCRIPTS_DIR/gate-phase-entry.mjs" </dev/null 2>/dev/null)" \
+  "exports-readable"
+assert_eq "  and both tables read back in the SHAPE this suite consumes them in -- VOICE_MOMENTS an object, NON_VOICE_PHASES a Set. A renamed or ABSENT export is named here rather than producing an empty population three assertions later" \
+  "$(vl "$VL_RAW" VMKIND)/$(vl "$VL_RAW" NVKIND)" "object/Set"
+assert_eq "  ANTI-VACUITY, by LABEL and not by a count floor: both tables are non-empty, witnessed by a member each that this change does not touch" \
+  "$(vl "$VL_RAW" NV_HAS_3IMPL)/$(vl "$VL_RAW" VM_HAS_5ARCHIVED)" "yes/yes"
+assert_eq "  MEASURED CONTROL for the cell above: the drift suite's \`Array.isArray(x) ? x : []\` idiom, applied to the REAL exported Set, yields a population of size 0 while the Set itself is non-empty. That green zero is what the shape assertion exists to refuse" \
+  "$(vl "$VL_RAW" ARRAYIDIOMSIZE)/$([[ "$(vl "$VL_RAW" NVSIZE)" == "0" ]] && echo EMPTY || echo non-empty)" "0/non-empty"
+
+# --- the accounting itself -------------------------------------------------------------------
+assert_eq "every phase pipeline.md writes is accounted for in voice-lint.mjs's own tables (SET MEMBERSHIP, never a source grep)" \
+  "$(vl "$VL_RAW" UNACCOUNTED)" ""
+assert_eq "\`0-setup\` is declared NON-VOICE and is in no voice-moment table" \
+  "$(vl "$VL_RAW" NV_HAS_0SETUP)/$(vl "$VL_RAW" VM_HAS_0SETUP)" "yes/no"
+assert_eq "and the two halves of the partition do not overlap -- the module's own self-test asserts this too, but that loop iterates VOICE_MOMENTS' keys and asks NON_VOICE_PHASES.has(k), so an EMPTY or renamed table satisfies it having checked nothing. Its non-emptiness premise is the cell above" \
+  "$(vl "$VL_RAW" OVERLAP)" ""
+
+# --- DISCRIMINATION, negative: a phase in a COMMENT is not a phase in a TABLE ----------------
+# The old check was `grep -q "\"$phase\"" "$LINT_SRC"`, which a comment satisfies. This pair is
+# what proves the replacement reads the TABLE: with `0-setup` dropped from the tables and the
+# LITERAL STRING still present in the source, the accounting still reports it unaccounted.
+VL_DROPPED="$(vl_account 0-setup)"
+assert_contains "DISCRIMINATION: with \`0-setup\` removed from the tables, the accounting names it" \
+  "$(vl "$VL_DROPPED" UNACCOUNTED)" "0-setup"
+assert_eq "  and it does so WHILE the string \"0-setup\" is present in voice-lint.mjs's source, which is what the retired substring grep would have read as \"accounted for\"" \
+  "$([[ "$(grep -c '"0-setup"' "$LINT_SRC" | tr -d ' ')" == "0" ]] && echo "ABSENT FROM SOURCE: this cell cannot discriminate" || echo present)" "present"
+assert_eq "  CONTROL on the injection itself: dropping a phase the tables never held moves nothing, so the cell above reports a real removal rather than the drop argument reddening everything" \
+  "$(vl "$(vl_account 9-does-not-exist)" UNACCOUNTED)" ""
+
+# ===========================================================================================
+# #53 -- THE FORM-COVERAGE CONTROL: a population no assignment spelling can leave
+#
+# The second copy of the tri-partition (the drift suite carries the first, with the full fixture
+# matrix). Two copies of the wide pattern remain in Lane 1; each carries this control, so a
+# narrowing in either copy reddens in that copy. Every occurrence of the BARE WORD
+# `current_phase` is CLAIMED (inside a span this suite's shipped derivation matched), EXCLUDED
+# (inside NO span of a pattern strictly WIDER than the claim pattern) or UNCLASSIFIED (a real
+# assignment the derivation misses). UNCLASSIFIED must be EMPTY and is reported BY NAME.
+#
+# The EXCLUDED bucket is a sorted occurrence-text MULTISET, asserted; its SIZE is only reported.
+# Never `sort -u`: three of the five excluded LINES carry two occurrences each with identical
+# text, so a set would turn 8 entries into 5 and re-open the bypass. Line numbers are REPORTED
+# beside the entries and never asserted -- pipeline.md is edited by a lane that does not own this
+# suite, and a coordinate pin is #68's shape.
+# ===========================================================================================
+tripart() {
+  node --input-type=module -e '
+    import { readFileSync } from "node:fs";
+    const md = readFileSync(process.argv[1], "utf8");
+    const CLAIM = /"?current_phase"?: *"([^"]*)"/g;
+    const WIDER = /["\x27`]?current_phase["\x27`]?\s*[:=]\s*(?:"[^"]*"|\x27[^\x27]*\x27|`[^`]*`|[A-Za-z0-9._<>-]+)/g;
+    const spans = (re) => [...md.matchAll(re)].map((m) => [m.index, m.index + m[0].length, m[0]]);
+    const claimSpans = spans(CLAIM), widerSpans = spans(WIDER);
+    const within = (i, ss) => ss.find(([a, b]) => i >= a && i < b);
+    const lines = md.split("\n");
+    const starts = []; { let o = 0; for (const l of lines) { starts.push(o); o += l.length + 1; } }
+    const lineOf = (i) => { let lo = 0, hi = starts.length - 1;
+      while (lo < hi) { const m = (lo + hi + 1) >> 1; if (starts[m] <= i) lo = m; else hi = m - 1; } return lo; };
+    const claimed = [], excluded = [], unclassified = [];
+    for (const m of md.matchAll(/current_phase/g)) {
+      const i = m.index, li = lineOf(i), text = lines[li];
+      if (within(i, claimSpans)) { claimed.push({ li, text }); continue; }
+      const w = within(i, widerSpans);
+      if (!w) excluded.push({ li, text }); else unclassified.push({ li, span: w[2] });
+    }
+    const out = [];
+    out.push("TOTAL=" + [...md.matchAll(/current_phase/g)].length);
+    out.push("CLAIMED=" + claimed.length);
+    out.push("EXCLUDED=" + excluded.length);
+    out.push("UNCLASSIFIED=" + unclassified.length);
+    out.push("LITERALS=" + [...new Set([...md.matchAll(CLAIM)].map((m) => m[1]))]
+      .filter((p) => p !== "<phase>-error").sort().join(","));
+    out.push("EXLINES=" + excluded.map((e) => e.li + 1).join(","));
+    out.push("UNNAMED=" + unclassified.map((e) => (e.li + 1) + ":" + e.span.replace(/\s+/g, " ")).join(" ;; "));
+    out.push("--EXFP--");
+    for (const line of excluded.map((e) => e.text.trim().length + "|" + e.text.trim().slice(0, 72)).sort()) out.push(line);
+    process.stdout.write(out.join("\n"));
+  ' "$1" 2>&1
+}
+tp_exfp() { printf '%s' "$1" | sed -n '/^--EXFP--$/,$p' | sed '1d'; }
+
+# NOT a heredoc inside a $( ) capture: /bin/bash 3.2.57 scans a command substitution for its
+# closing paren WITHOUT honouring quoted-heredoc rules, so the UNPAIRED backtick left by a
+# 72-character truncation makes the whole file un-parseable.
+EXCLUDED_MULTISET_8='133|- **User interrupts mid-phase**: status.json preserves position. `/pipel
+285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
+285|- If starts with `--resume <issue>`: set `ISSUE=<issue>`, read `.pipelin
+461|**`events[]` entries are EXIT markers and `current_phase` is an ENTRY ma
+461|**`events[]` entries are EXIT markers and `current_phase` is an ENTRY ma
+479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
+479|`status.json` is the `/pipeline --resume <issue>` checkpoint, so it must
+89|# Run BEFORE entering each phase, after setting current_phase to the pha'
+
+# ---------------------------------------------------------------------------
+suite "#53 AC2: every bare-word occurrence lands in exactly one named bucket"
+# ---------------------------------------------------------------------------
+TP_REAL="$(tripart "$PIPELINE_MD")"
+record "REPORTED, never asserted: pipeline.md holds $(vl "$TP_REAL" TOTAL) bare-word \`current_phase\` occurrences, $(vl "$TP_REAL" CLAIMED) CLAIMED and $(vl "$TP_REAL" EXCLUDED) EXCLUDED, at lines $(vl "$TP_REAL" EXLINES). Grain is OCCURRENCES, not distinct literals"
+assert_eq "the three buckets ACCOUNT FOR every bare-word occurrence" \
+  "$(( $(vl "$TP_REAL" CLAIMED) + $(vl "$TP_REAL" EXCLUDED) + $(vl "$TP_REAL" UNCLASSIFIED) ))" \
+  "$(vl "$TP_REAL" TOTAL)"
+assert_eq "UNCLASSIFIED is EMPTY: no assignment the WIDER pattern can see is missed by the derivation this suite ships" \
+  "$(vl "$TP_REAL" UNNAMED)" ""
+# AC1, asserted OFF THE TRI-PARTITION rather than off the module report, deliberately: this is a
+# property of pipeline.md and of the pattern, and it must be able to go red independently of
+# whether the module's tables can be imported at all.
+assert_eq "the derived label SET is exactly the 26 concrete literals pipeline.md writes, \`0-setup\` among them -- and it is the SAME sorted list the drift suite pins, so a narrowing in either copy reddens in that copy" \
+  "$(vl "$TP_REAL" LITERALS)" "$PHASE_LITERALS_26"
+assert_eq "and the EXCLUDED bucket's MEMBERSHIP is asserted -- the sorted occurrence-text MULTISET, so an occurrence cannot move between buckets at constant bucket sizes" \
+  "$(tp_exfp "$TP_REAL")" "$EXCLUDED_MULTISET_8"
+assert_eq "MULTISET, NOT A SET: \`sort -u\` collapses those 8 entries to 5, which is measured here rather than asserted absent by inspection" \
+  "$(tp_exfp "$TP_REAL" | sort -u | grep -c . | tr -d ' ')/$(tp_exfp "$TP_REAL" | grep -c . | tr -d ' ')" "5/8"
+
+# ---------------------------------------------------------------------------
+suite "#53 AC13: RUNTIME NEUTRALITY -- what the lint says is byte-unchanged by this change"
+# ---------------------------------------------------------------------------
+# R6 exports a table `run()` does not read, and the cheapest wrong next step is to start reading
+# it and make the unrecognised-phase branch LOUD, converting a documented fail-open into a
+# refusal of the first turn of every pipeline run.
+#
+# THREE CELLS, AND THE THIRD IS THE ONLY ONE THAT DISCRIMINATES. Once `0-setup` is DECLARED it
+# takes the quiet path under BOTH the correct and the broken implementation, so a matrix of
+# {`0-setup`, `5-archived`} sits entirely in the branch that works and the broken branch never
+# runs. The silent class is narrower than "unrecognised": `9-invented` is SHAPE-INVALID and
+# exits 2, and `halted-error` is shape-VALID but error-suffixed and also exits 2. The class is
+# {shape-valid AND undeclared AND not error-suffixed}, and `3-impl-nonesuch` is its witness.
+#
+# Byte counts of a NON-ZERO result are deliberately not pinned: two readers measured 913 and 914
+# for the same cell, because the number is message-dependent. ZERO bytes is pinned; a non-zero
+# result is pinned by its NAMED-FAILURE count.
+named_failures() { printf '%s\n' "$1" | grep -c '^- ' | tr -d ' '; }
+EM_DASH_NO_BLOCKS="Refactored the parser — it now handles the nested case — and tests pass."
+
+set_phase "0-setup"
+write_transcript "$EM_DASH_NO_BLOCKS"
+lint
+assert_eq "(1) at \`0-setup\` the lint is SILENT: exit 0" "$RC" "0"
+assert_eq "    and says nothing at all -- ZERO bytes, em dashes and all" "$ERR" ""
+
+set_phase "3-impl-nonesuch"
+write_transcript "$EM_DASH_NO_BLOCKS"
+lint
+assert_eq "(3) THE DISCRIMINATING CELL: a SHAPE-VALID phase this change leaves UNDECLARED still exits 0 -- the documented fail-open. This is the cell that goes red if run() starts consulting the newly exported NON_VOICE_PHASES" "$RC" "0"
+assert_eq "    and it too says nothing -- ZERO bytes" "$ERR" ""
+
+set_phase "5-archived"
+write_transcript "$EM_DASH_NO_BLOCKS"
+lint
+assert_eq "(2) NON-ZERO CONTROL: the identical message at a declared voice moment exits 2, so cells (1) and (3) are silence and not a lint that stopped firing" "$RC" "2"
+assert_eq "    with its five NAMED failures (the count, never the byte length: two readers measured 913 and 914 for this same message)" \
+  "$(named_failures "$ERR")" "5"
+
+set_phase "halted-error"
+write_transcript "$EM_DASH_NO_BLOCKS"
+lint
+assert_eq "    NARROWING, so the silent class is not read as \"unrecognised\": \`halted-error\` is shape-VALID and still exits 2, because errorMoment matches /-error\$/" "$RC" "2"
+
+set_phase "9-invented"
+write_transcript "$EM_DASH_NO_BLOCKS"
+lint
+assert_eq "    and \`9-invented\` exits 2 for a different reason again -- it is SHAPE-INVALID against status.schema.json's pattern" "$RC" "2"
+assert_contains "    naming the schema rather than a voice rule, which is what makes it a different cell from (3)" "$ERR" "status.schema.json"
+
+rm -f "$TEMP_ISSUE_DIR/status.json"
 
 # ---------------------------------------------------------------------------
 suite "voice-lint: exp-<slug> runs are LINTED, not exempt"


### PR DESCRIPTION
Closes #53

`0-setup` is the run's first recorded phase and a real occupied one, and it sat in no cell of either Lane-1 consumer table. Both suites that police those tables were green with the defect live, because their phase derivation required an unquoted key (`current_phase: "..."`) while `pipeline.md:53` writes that one assignment in JSON form. A phase the pattern cannot see is not an unaccounted phase, it is not a phase at all: the assertion and its control ranged over the same narrowed set.

## What changed

**`plugins/pipeline/scripts/gate-phase-entry.mjs`** gains a fifth exported partition cell, `PRELUDE = ["0-setup"]`, and one `decideForDir` branch. A record at `0-setup` now reads:

```
.pipeline/999 at `0-setup` is the run's setup step, which precedes every guarded phase.
```

where before it read the fail-open sentence for a phase the table does not know, byte-identical to the one an invented phase gets. The `UNGUARDED` branch is not touched, so all nine UNGUARDED reasons are unchanged by construction rather than by replay (replayed anyway, before and after, with a working non-zero control: all nine byte-identical, and the `0-setup` reason, which this change DOES move, shows the instrument can see a change).

The branch sits **after** the terminal check, and the order is load-bearing: moved before it, a `0-setup` record carrying `completed_at` renders the setup-step clause instead of ` is finished.`, un-finishing every concluded run that ended at this phase. A `PREREQUISITES` row was refused by name: `ENTRY` is derived from `PREREQUISITES` keys and must equal the set of phases pipeline.md names at its `Checkpoint first` sites, and `0-setup` is written at no such site.

**`plugins/pipeline/scripts/voice-lint.mjs`** declares `0-setup` non-voice with its mechanism and its general expiry beside it, exports `VOICE_MOMENTS` and `NON_VOICE_PHASES` so the accounting check can read the TABLE instead of grepping this source (a grep a comment satisfies), and adopts the sibling module's `evalEntry` self-run guard **in the same commit as the exports**. Without that guard, importing the module self-ran its CLI: a marker printed before the import appeared, the one after it never did, rc 0. Every membership assertion built on the new exports would have read a green nothing.

Neither table is frozen, and a one-line comment records why: `Object.freeze(new Set(["a"]))` reports `isFrozen === true` and then accepts `.add("b")`, size 1 to 2.

Runtime behaviour is unchanged at every phase. Both hooks still exit 0 in silence at `0-setup`; what changed is that two tables now DECLARE what they previously did not know, and one of them says something true about its subject.

## The behavioural contract

QA authored and committed the failing contract first (`c6a02f1`, three test files, both modules byte-identical to `origin/main`). Baseline 15 red: drift 66/4, voice-lint 61/10, gate-phase-entry 504/1. All 15 are green here, and no QA assertion was weakened, skipped or deleted.

`AC7` red at HEAD, produced by the shipped anchored strip rather than claimed:

```
FAIL  #53-A4 THE CRITERION: with the record-derived span stripped, the judgement
      clause for `0-setup` is NOT the clause for an invented phase.
      expected: discriminates
      actual:   IDENTICAL CLAUSES (31 bytes each): , which is not a guarded phase.
```

## One cross-lane edit

`plugins/pipeline/tests/test-gate-phase-entry-hook.sh` pins test-voice-lint.sh at exactly 48 assertions. That pin is red before this change and after it, so full-suite green is unreachable without re-baselining it, and the lane that owns the file has merged out. Bumped to 71 per the file's own recorded convention, and the property that convention says the cell actually guards was **verified by diffing the suite** rather than claimed: 26 labels added, 3 removed, net +23. It does not hold in its pure form this time, so the note names all three and where each one's substance went (one renamed, two retired with their instrument, each with a named successor) instead of asserting a pure addition. The note also records that this cell is itself a bare count pin of exactly the class #33 retired elsewhere, and that it would be better as a label-set assertion.

## Checks

`bash plugins/pipeline/tests/run.sh`: 34 suites, 2629 assertions, `failed=0`, exit 0.

Mutation battery, run on the committed fix, each restored from git with `git status --porcelain` verified between runs:

| mutation | outcome |
| --- | --- |
| move the `PRELUDE` branch BEFORE the terminal check | CAUGHT, gate 504/1, sole red is `#53-P1` |
| mistype the exported cell name (`PRELUDEE`, consistently) | CAUGHT, drift 66/4 with `PRELUDE=ABSENT` named; gate stays 505/0, which is why the drift suite reads the NAME |
| remove `0-setup` from `NON_VOICE_PHASES` | CAUGHT, voice-lint 68/3, while the string is still in the source |
| remove the `evalEntry` guard | CAUGHT, voice-lint 62/9, PREMISE red first, sibling positive control still green |
| **reword the PRELUDE clause (expected survivor, QA-declared M16)** | **SURVIVED, as intended.** AC7's binding property is that the clause DIFFERS from the 31-byte fail-open sentence, not that it reads any particular way, and `#53-A3` pins that negative exactly |

## Deferrals, and where closure is tracked

Every deferral this branch makes now names a destination in the code itself, following the convention `gate-phase-entry.mjs` already uses for its duplicated in-flight window ("and where `#74` tracks it"). The full ledger is posted as a comment on #53.

- **HANDOFF C** (one shared Lane-1 derivation helper instead of two copies of the wide pattern) — named in both tri-partition comments, with its binding constraint repeated in place: a shared helper returns the EXTRACTION from pipeline.md and never an asserted set, because the Lane-2 status-schema suite asserts 27 by ADDING `halted-error` under a stated rule of its own.
- **The count-pin re-baseline** in `test-gate-phase-entry-hook.sh` — its note now points at the #53 ledger rather than at "whoever revisits this file".
- **`#80`** (the Phase 0 dirty-worktree decision block being structurally unreachable by voice-lint) — cited at the `0-setup` declaration, because #80 is what makes that declaration's expiry checkable rather than aspirational.

Two measurements from the panel are folded in as comments, both re-run rather than copied:

- **`WIDER` is a floor, not a total.** Four spellings tested, three are misses: a bracket-index assignment, a markdown-bold key and a YAML block scalar are matched by neither pattern and land in EXCLUDED as prose; only the single-quoted-value form with an `=` separator reaches UNCLASSIFIED. What bounds the damage is the bare-word population, since a missed spelling is still counted and still has to be named.
- **The excluded fingerprint is non-injective**, and `pipeline.md` already holds a colliding pair: lines 270 and 284 are both 107 trimmed characters, agree for the first 99, and differ only at `SecOps` vs `DevOps`, past the 72-character cut. Neither carries `current_phase`, so it is latent. The two assertion labels are narrowed to the add/remove form the fingerprint actually supports.

That last commit is **comments only**. `git diff -U0 | grep -vE '^[-+]\s*(#|//)'` over it returns exactly the two `assert_eq` label lines; no expected value, population, count or behaviour moved.

## A note for anyone running the suite locally

`bash plugins/pipeline/tests/run.sh` is **34 suites / 2629 assertions / failed=0** on this branch, and the fresh-checkout case inside `test-issue17-integration.sh` re-runs the whole suite in a clone and reports all green.

In a working tree that also holds this run's own `.pipeline/53/status.json`, `test-status-schema-contract.sh` reads 149/1. That suite is untouched by this branch. Its AC3 corpus-maximum control is anchored to a live record (`the corpus maximum is still the 18-char value this control rests on`, `APPROVE_WITH_NOTES/18`), and this run's checkpoint introduces longer verdicts — `SHARD_NONCONFORMANT` (19) and `SCOPE_DRIFT_DECLARED` (20). Isolated to a single variable: with the comment commit in place and only that one record moved aside, the suite is 150/0. The control needs re-anchoring, not deleting, per its own note; it is out of scope here and is routed to the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
