### PR TITLE
0.29.0: the frontend gate could not tell "nothing changed" from "I cannot tell"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "A risk-tiered multi-agent development pipeline for Claude Code, with a file-based knowledge store and no external service dependencies.",
-    "version": "0.28.0"
+    "version": "0.29.0"
   },
   "plugins": [
     {
       "name": "pipeline",
       "source": "./plugins/pipeline",
       "description": "Risk-tiered multi-agent pipeline: spec and tier, single-writer implementation with tests, adversarial review panel. Ships BA, DBA, DevOps, SecOps, Dev, QA, Design, Art Director, and Librarian agents plus /pipeline, /phase, and /warmup.",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "category": "development"
     }
   ]

--- a/plugins/pipeline/.claude-plugin/plugin.json
+++ b/plugins/pipeline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Risk-tiered multi-agent development pipeline. BA specs and tiers an ask, a single-writer implements code and tests together, an adversarial panel reviews the finished diff. File-based knowledge store, no external services.",
   "author": {
     "name": "NS Media"

--- a/plugins/pipeline/scripts/gate-pre-phase4-frontend.mjs
+++ b/plugins/pipeline/scripts/gate-pre-phase4-frontend.mjs
@@ -19,6 +19,12 @@
  *     to verify, nothing to gate. Absence of a trigger is never read as missing evidence.
  *   - A frontend file DID change -> require recorded evidence (a design_review verdict
  *     present + a lint pass + an accessibility (a11y) pass). Missing evidence HALTS (exit 1).
+ *   - The changed-path list could NOT be determined (no --changed paths AND the impl-report is
+ *     absent, unreadable, unparseable, or records no file list at all) -> HARD ERROR (exit 1),
+ *     never a skip. "I could not determine what changed" is a DIFFERENT state from "nothing
+ *     frontend changed", and only the latter may pass. Conflating them let a wrong
+ *     --impl-report path silently no-op this control into a pass, in exactly the state where
+ *     design evidence is most likely absent.
  *
  * Evidence is RECORDED by the Design agent inside its dispatch (it runs the accessibility
  * snapshot and the lint + a11y pass) and lands in peer-review.design_review.json /
@@ -194,6 +200,34 @@ export function changedFilesFromReport(report) {
   return [...out];
 }
 
+// True when the report records ANY file list at all (changed or removed, on any commit or at the
+// top level). A report that records none is INCONCLUSIVE about what changed: deriving [] from it
+// and skipping would be the same fail-open as reading no report at all. files_removed counts, so a
+// delete-only diff stays conclusive and is still evaluated.
+export function reportRecordsAnyFiles(report) {
+  if (!report || typeof report !== "object") return false;
+  if ((report.files_removed || []).some((f) => typeof f === "string")) return true;
+  for (const commit of report.commits || []) {
+    if (!commit || typeof commit !== "object") continue;
+    if ((commit.files_changed || []).some((f) => typeof f === "string")) return true;
+    if ((commit.files_removed || []).some((f) => typeof f === "string")) return true;
+  }
+  return false;
+}
+
+// Same derivation as changedFilesFromReport, but REFUSES to return an inconclusive empty list.
+// Throwing here routes into main()'s fail-closed catch (exit 1) instead of falling through to
+// diffTouchesFrontend([]) === false, which prints SKIP and exits 0.
+export function changedFilesFromReportStrict(report, label = "impl-report.json") {
+  if (!reportRecordsAnyFiles(report)) {
+    throw new Error(
+      `${label} records no files_changed/files_removed on any commit: cannot determine what the ` +
+        `diff touched. Refusing to infer an empty diff (that would skip this gate).`,
+    );
+  }
+  return changedFilesFromReport(report);
+}
+
 function resolveImplReportPath(args, issueDir) {
   if (args.implReport) return args.implReport;
   if (!issueDir) return null;
@@ -223,9 +257,23 @@ async function main() {
   const issueDir = args.issue ? path.join(PROJECT_ROOT, ".pipeline", String(args.issue)) : null;
   const implReportPath = resolveImplReportPath(args, issueDir);
 
+  // Explicit --changed paths are authoritative. Otherwise the impl-report is the ONLY source for
+  // what the diff touched, so an absent/unreadable/unparseable/fileless report is a hard error,
+  // NOT an empty change list: loadJsonOrThrow and changedFilesFromReportStrict both throw into the
+  // fail-closed catch below. Do not reintroduce an existsSync short-circuit here; that is the
+  // fail-open this replaced.
   let changed = args.changed;
-  if (changed.length === 0 && implReportPath && existsSync(implReportPath)) {
-    changed = changedFilesFromReport(loadJsonOrThrow(implReportPath, "impl-report.json"));
+  if (changed.length === 0) {
+    if (!implReportPath) {
+      throw new Error(
+        "cannot determine the changed-path list: no --changed paths given and neither --issue " +
+          "nor --impl-report resolved an impl-report.json path",
+      );
+    }
+    changed = changedFilesFromReportStrict(
+      loadJsonOrThrow(implReportPath, "impl-report.json"),
+      implReportPath,
+    );
   }
   const touchesFrontend = diffTouchesFrontend(changed);
 

--- a/plugins/pipeline/tests/test-gate-pre-phase4-frontend.sh
+++ b/plugins/pipeline/tests/test-gate-pre-phase4-frontend.sh
@@ -129,6 +129,73 @@ EOF
 gate --issue 4245 --changed "$FRONTEND_PATH"
 assert_eq "the Phase 2 review Design shard is accepted as evidence" "$RC" "0"
 
+suite "frontend gate: an undeterminable change list HALTS, never skips"
+
+# THE fail-open this section exists for: with no --changed paths the impl-report is the only
+# source for what the diff touched, and an ABSENT one used to leave the list empty, so
+# diffTouchesFrontend([]) was false and the gate printed SKIP and exited 0. A control designed to
+# halt no-opped into a pass in exactly the state where design evidence is most likely absent.
+# "I could not determine what changed" is a different state from "nothing frontend changed", and
+# only the second may pass. Reproduced against a real run by SecOps.
+gate --issue 4250
+assert_eq "an --issue whose dir holds no impl-report halts" "$RC" "1"
+assert_contains "the halt names the missing report" "$ERR" "not found"
+assert_not_contains "and it does NOT report the legitimate skip" "$OUT" "SKIP"
+
+gate --impl-report "$TEMP_PROJECT/nowhere/impl-report.json"
+assert_eq "an --impl-report path with no file there halts" "$RC" "1"
+assert_not_contains "and it does NOT report the legitimate skip" "$OUT" "SKIP"
+
+printf '%s' '{ not json' > "$TEMP_PROJECT/impl-unparseable.json"
+gate --impl-report "$TEMP_PROJECT/impl-unparseable.json"
+assert_eq "an unparseable impl-report halts" "$RC" "1"
+assert_contains "the halt says the report is not valid JSON" "$ERR" "not valid JSON"
+
+# A report that PARSES but records no file list anywhere is the same defect one layer in:
+# files_changed is optional per commit, so deriving [] from it and skipping would be the same
+# no-op reached by a different route.
+printf '%s' '{"commits":[{"sha":"a","message":"m"}]}' > "$TEMP_PROJECT/impl-fileless.json"
+gate --impl-report "$TEMP_PROJECT/impl-fileless.json"
+assert_eq "an impl-report recording no file list halts" "$RC" "1"
+assert_contains "the halt says the change list is undeterminable" "$ERR" "cannot determine"
+assert_not_contains "and it does NOT report the legitimate skip" "$OUT" "SKIP"
+
+gate
+assert_eq "no --changed and nothing to resolve a report from halts" "$RC" "1"
+assert_contains "the halt says so plainly" "$ERR" "cannot determine the changed-path list"
+
+# CONTROLS. The halts above must not have been bought by making the gate refuse everything:
+# a CONCLUSIVE change list with no frontend surface still skips, and a real frontend diff with
+# real evidence still passes. If either of these goes red the gate is stuck closed and blocks
+# every backend PR, which is the failure mode on the other side of this fix.
+mkdir -p "$TEMP_PROJECT/.pipeline/4251"
+cat > "$TEMP_PROJECT/.pipeline/4251/impl-report.json" <<'EOF'
+{"commits":[{"sha":"a","message":"m","files_changed":["scripts/tool.mjs"]}]}
+EOF
+gate --issue 4251
+assert_eq "a conclusive backend-only report still skips" "$RC" "0"
+assert_contains "and says why it skipped" "$OUT" "SKIP: no frontend surface in the diff"
+
+mkdir -p "$TEMP_PROJECT/.pipeline/4252"
+cat > "$TEMP_PROJECT/.pipeline/4252/impl-report.json" <<'EOF'
+{"commits":[{"sha":"a","message":"m","files_changed":["app/components/Button.tsx"]}],
+ "design_gate":{"verdict":"APPROVE","lint_pass":true,"a11y_pass":true}}
+EOF
+gate --issue 4252
+assert_eq "a conclusive frontend report with full evidence still passes" "$RC" "0"
+assert_contains "and says the gate passed" "$OUT" "OK: frontend visual-verification gate passed."
+
+# A delete-only diff stays CONCLUSIVE (files_removed is a recorded file list) and the deletion
+# exemption still empties the changed set, so it skips rather than halting. This is the case a
+# naive "empty derived list means undeterminable" rule would false-halt.
+mkdir -p "$TEMP_PROJECT/.pipeline/4253"
+cat > "$TEMP_PROJECT/.pipeline/4253/impl-report.json" <<'EOF'
+{"commits":[{"sha":"a","message":"m","files_changed":["app/components/Gone.tsx"],
+             "files_removed":["app/components/Gone.tsx"]}]}
+EOF
+gate --issue 4253
+assert_eq "a delete-only frontend diff is conclusive and skips" "$RC" "0"
+
 suite "frontend gate: screenshot containment (AC18)"
 
 # A legitimate screenshot inside the gitignored issue tree passes. This is the control that


### PR DESCRIPTION
## The defect

`gate-pre-phase4-frontend.mjs` derived its changed-path list from `impl-report.json`. When that file was absent or unreadable, `main()` left `changed = []`, `diffTouchesFrontend([])` returned false, and the gate printed `SKIP: no frontend surface in the diff` and exited 0.

A control whose entire purpose is to halt the panel when recorded design evidence is missing no-opped into a pass whenever it could not read its input, which is exactly the state where that evidence is most likely absent. Reproduced by SecOps against a live run: pointed at the real impl-report it printed `OK`, pointed one directory over it printed `SKIP`, both exit 0.

The distinction the gate has to preserve is between **"no frontend files changed"** (a legitimate skip, the twin of the live-DB gate exiting 0 when its trigger is absent) and **"I could not determine what changed"** (a halt). Only the first may pass.

## The fix

- Explicit `--changed` paths stay authoritative; an absent report is not an error there.
- Otherwise the impl-report is the only source for what the diff touched, so an absent, unreadable, or unparseable one throws into the existing fail-closed catch.
- A report that *parses* but records no `files_changed`/`files_removed` anywhere is the same defect one layer in (`files_changed` is optional per commit). `changedFilesFromReportStrict` refuses that inconclusive empty list too. `files_removed` counts as a recorded list, so a delete-only diff stays conclusive and the deletion exemption still empties it without halting.

## Gate-bites proof

Both directions are pinned in `test-gate-pre-phase4-frontend.sh`.

| | pre-fix gate | this gate |
|---|---|---|
| new undeterminable-diff assertions | **10 FAIL** | 10 ok |
| controls (backend-only skips, frontend+evidence passes, delete-only skips) | ok | ok |
| suite total | 43 passed / 10 failed | **53 passed / 0 failed** |

The controls stay green in both, so a stuck-closed gate blocking every backend PR would redden here as loudly as the stuck-open one failed to.

Full plugin suite: **267 passed, 0 failed**.

## Version

0.28.0 to 0.29.0, `marketplace.json` regenerated via `scripts/sync-manifests.mjs` (in sync at 0.29.0, 9 agents, 3 commands).

## Downstream note

BesideCare carried its own copy of this gate with the byte-identical defect. As of nsmedia-io/besidecare-mono#2283 that repo retired its in-repo pipeline and adopted this plugin as the source, so this is now the only copy that runs and no parallel fix is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)