### PR TITLE
fix(pipeline): SubagentStop validator ignores every namespaced agent_type

### DIFF
--- a/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
+++ b/plugins/pipeline/scripts/validate-pipeline-artifact.mjs
@@ -761,7 +761,13 @@ function evidenceFor(issueDir, now, data) {
 // to exactly those roots so a self-test can never escape to the real .pipeline of the checkout
 // running it. Production callers never pass it.
 export function checkArtifacts(agentType, input, now = Date.now(), rootsOverride) {
-  const rules = AGENT_RULES[String(agentType || "").toLowerCase()];
+  // A dispatch from the installed-plugin path (the shipping default) carries a NAMESPACED
+  // agent_type ("pipeline:secops"), not the bare role name AGENT_RULES is keyed on. Take the
+  // segment after the LAST colon before lowercasing, so "pipeline:secops" and "secops" resolve
+  // identically. Without this, every namespaced dispatch missed AGENT_RULES entirely and this
+  // validator silently checked nothing -- see #66 and #98's Phase 4 panel, which proved it live.
+  const bareAgentType = String(agentType || "").split(":").pop();
+  const rules = AGENT_RULES[bareAgentType.toLowerCase()];
   const failures = [];
   if (!rules) return { failures };
 
@@ -1196,6 +1202,20 @@ function selfTest() {
       // decoy is genuinely defective (so the isolation case is meaningful).
       const rDecoy = checkArtifacts("secops", { cwd: decoyCheckout });
       check("scoping: the decoy ambient defect is genuinely detectable without the override (control)", rDecoy.failures, true);
+
+      // NAMESPACED agent_type resolution (#98, #66). Every installed-plugin dispatch (the
+      // shipping default) carries agent_type "pipeline:<role>", not the bare role name
+      // AGENT_RULES is keyed on. Reuse the active-issue defect fixture above.
+      writeFileSync(path.join(active, "peer-review.secops.json"), JSON.stringify(brokenPanel));
+      const rBare = checkArtifacts("secops", { cwd: root, active_issue: "1965" }, Date.now(), pin);
+      check("namespacing: bare 'secops' catches the active-issue defect (control)", rBare.failures, true);
+      const rNamespaced = checkArtifacts("pipeline:secops", { cwd: root, active_issue: "1965" }, Date.now(), pin);
+      check("namespacing: 'pipeline:secops' catches the SAME defect the bare name catches", rNamespaced.failures, true);
+      const rMixedCase = checkArtifacts("Pipeline:SecOps", { cwd: root, active_issue: "1965" }, Date.now(), pin);
+      check("namespacing: mixed-case 'Pipeline:SecOps' still resolves", rMixedCase.failures, true);
+      writeFileSync(path.join(active, "peer-review.secops.json"), JSON.stringify(validPanel));
+      const rNamespacedValid = checkArtifacts("pipeline:secops", { cwd: root, active_issue: "1965" }, Date.now(), pin);
+      check("namespacing: 'pipeline:secops' does not false-positive on a VALID artifact", rNamespacedValid.failures, false);
     } finally {
       process.chdir(prevCwd);
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- `checkArtifacts()` looked up `AGENT_RULES[agentType.toLowerCase()]` on the bare `agentType`, but every installed-plugin dispatch (the shipping default) passes a namespaced value like `pipeline:secops`, not `secops`. The lookup missed on every real dispatch, so `checkArtifacts` silently returned zero failures — the property-not-the-fix enforcement for dba/devops/secops (including SecOps's veto backing) has been inert for any namespaced dispatch since it shipped.
- Found independently by QA and SecOps during issue #98's Phase 4 panel review (an unrelated spike), corroborating the risk #66 had only theorized.
- Fix: take the segment after the last colon before the lowercase lookup, so `pipeline:secops` and `secops` resolve identically (case-insensitively).

## Test plan
- [x] Reproduced live: bare `"secops"` against a malformed `vulnerabilities[]` row (missing remediation) caught the defect; `"pipeline:secops"` against the identical artifact returned zero failures — confirmed the bug before fixing it.
- [x] Applied the one-line fix plus a comment citing #66 and #98.
- [x] Added 4 new self-test regression cases covering bare/namespaced/mixed-case resolution and a valid-artifact non-false-positive check.
- [x] Self-test: 81/81 passing.
- [x] Mutation-verified: temporarily reverted the fix, confirmed exactly the 2 new namespacing cases went red and nothing else; restored the fix, confirmed 81/81 again.
- [x] Full suite: `bash plugins/pipeline/tests/run.sh` — 267/267 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)