### PR TITLE
voice-lint.mjs follow-ups from #56: name the failing suites, rule on the turn-boundary tie, hygiene (#91)

### DIFF
--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -154,8 +154,14 @@
  *          31 observed carry BOTH origin.kind 'peer' AND isMeta true. sessionId is NOT a third
  *          guard, and that is measured rather than assumed: all 31 are stamped with the
  *          RECEIVING session's own id, so an equality test cannot see them. DIRECTION: none left
- *          open (excluded twice over, by origin.kind and by isMeta independently); no residual
- *          EXPIRY applies.
+ *          open by a drift in EITHER label alone, because the two exclusions are independent.
+ *          WHAT IS NOT CLOSED, and this sentence is corrected at #91 because the line it replaces
+ *          read "no residual EXPIRY applies" and that OVERCLAIMED: isMeta is a vendor-controlled
+ *          label exactly as origin.kind is, so this class sits INSIDE (iv)'s already-declared
+ *          scope rather than outside it. Two independent guards make the class robust to either
+ *          label drifting alone; they do not take it out of the vendor's hands. EXPIRY: (iv)'s,
+ *          and no separate one -- re-run the origin.kind census over a fresh corpus, and check
+ *          isMeta on the peer class in the same pass.
  *   (vi)   On clients predating the origin field the predicate finds no human turn, the boundary
  *          is unresolvable, and the lint fires unconditionally, which is today's behaviour.
  *          Measured: 8 of 84 transcripts (9.5%) contain no origin.kind 'human' record at all,
@@ -375,6 +381,24 @@ function readJson(file) {
  * divergence table compares (the two derivations return different types, so comparing their
  * return values directly would be vacuous). Precedence, the strict-mtime winner and the tie
  * abstention are byte-for-byte what they were.
+ *
+ * THE WRAPPER IS BEHAVIOUR-PRESERVING ONLY BECAUSE THIS EXPORT HAS ONE PRODUCTION IMPORTER, and
+ * a second one expires that premise (#91). This used to return a bare `null` where it now
+ * returns `{ status, dir, mtimeMs }`, and the two are NOT interchangeable in general, because
+ * `status` may itself be null: the fallback branch hands back `readJson(newest)`, which is null
+ * when the newest record is unparseable. So `resolveStatus(...) === null` is true on the FOUR
+ * no-record paths (no .pipeline dir, an unreadable .pipeline dir, an mtime tie, no candidate at
+ * all) and FALSE on an unparseable record, while "there is no usable phase" is true on all five.
+ * run() is written for exactly that -- it reads `resolved?.status?.current_phase` and treats a
+ * falsy phase as no phase -- so the difference is invisible TO IT and to nothing else. A new
+ * importer writing `if (!resolveStatus(...)) return;` silently treats a record it COULD NOT READ
+ * as a record it read, which is a fail-open path that looks like a guard. Test the field you
+ * mean: check `.status`, or `.status?.current_phase`, never the wrapper's truthiness.
+ *
+ * THE MTIME TIE HERE ABSTAINS AND run()'s TURN-BOUNDARY TIE REFUSES, i.e. the two resolve
+ * OPPOSITE WAYS, deliberately. The ruling and its reasoning sit at the comparison in run(); this
+ * pointer exists because #91 was filed by a reader who found the asymmetry and no statement of
+ * it. AC9(e) in tests/test-voice-lint.sh pins this half, the #91 cells pin the other.
  */
 export function resolveStatus(projectDir, envIssue) {
   const base = path.join(projectDir, ".pipeline");
@@ -628,6 +652,31 @@ export function run(payload, projectDir, scriptDir = SCRIPT_DIR) {
   // it is downstream of the two unusable-transcript returns above, so no input that is silent
   // today acquires a new refusal. A null boundary skips the block entirely: an unresolvable
   // boundary can never silence a refusal this code would otherwise have produced.
+  //
+  // THE TIE IS RULED ON, AND IT RESOLVES THE OPPOSITE WAY FROM resolveStatus's MTIME TIE. The
+  // asymmetry is deliberate and #91 filed it because nothing here said so. THE TWO ARE DIFFERENT
+  // QUESTIONS, which is why matching them would be the mistake. resolveStatus ties BETWEEN TWO
+  // CANDIDATE RECORDS, where picking either means picking by readdirSync order -- hash order on
+  // ext4, insertion order on APFS (#27) -- so it abstains rather than let the filesystem decide
+  // whose run gets voice-checked. This compares ONE record against ONE boundary: there is no
+  // second candidate and nothing arbitrary to refuse, and equality means the record was touched
+  // at the instant the turn began. So the turn window is HALF-OPEN, [humanTurnMs, now], and a
+  // record dated exactly at the boundary is IN the turn.
+  //
+  // WHY STRICT `<` AND NOT `<=`, in this file's own terms: this comparison is the ONLY new
+  // suppressor #56 added, and the governing direction above says this change must never be the
+  // reason for silence. `<=` would make an exactly-tied record read stale and silence a refusal
+  // the pre-#56 code produced, on an input whose ordering is not established. resolveStatus's
+  // abstention is not the counter-example it looks like: it predates #56 and is byte-for-byte
+  // what it was, so its silence is not this change's silence.
+  //
+  // REACHABILITY, MEASURED, because a direction nobody can reach is a comment and this one is
+  // pinned by tests. mtimeMs is fractional here (12 of 12 live .pipeline records) while a parsed
+  // transcript timestamp is a whole millisecond, so the tie is reachable only through the
+  // updated_at term -- and 10 of those 12 records write updated_at at WHOLE-SECOND grain, while
+  // 0 of 523 observed origin.kind 'human' timestamps land on a whole second. OBSERVED TIES:
+  // ZERO. The direction is pinned anyway, at the cost of three cells, because a vendor
+  // coarsening either clock makes ties common overnight and this line would then decide silence.
   if (humanTurnMs !== null && recordFreshnessMs(resolved.mtimeMs, resolved.status?.updated_at) < humanTurnMs) {
     return { failures: [], phase };
   }

--- a/plugins/pipeline/scripts/voice-lint.mjs
+++ b/plugins/pipeline/scripts/voice-lint.mjs
@@ -660,8 +660,9 @@ export function run(payload, projectDir, scriptDir = SCRIPT_DIR) {
   // ext4, insertion order on APFS (#27) -- so it abstains rather than let the filesystem decide
   // whose run gets voice-checked. This compares ONE record against ONE boundary: there is no
   // second candidate and nothing arbitrary to refuse, and equality means the record was touched
-  // at the instant the turn began. So the turn window is HALF-OPEN, [humanTurnMs, now], and a
-  // record dated exactly at the boundary is IN the turn.
+  // at the instant the turn began. So the turn window is CLOSED AT ITS LEFT END -- a record is
+  // in-turn when recordFreshnessMs >= humanTurnMs -- and one dated exactly at the boundary is IN
+  // the turn.
   //
   // WHY STRICT `<` AND NOT `<=`, in this file's own terms: this comparison is the ONLY new
   // suppressor #56 added, and the governing direction above says this change must never be the

--- a/plugins/pipeline/tests/fixtures/voice-lint-56/capture.py
+++ b/plugins/pipeline/tests/fixtures/voice-lint-56/capture.py
@@ -1,7 +1,27 @@
-import glob, json, collections, datetime, sys
+"""Re-derives captured-records.json from the live Claude Code transcripts on THIS machine.
 
-OUT = "/Users/brandonsmith/WebstormProjects/agent-pipeline/.claude/worktrees/harddrive-space-review-4c7a9e/plugins/pipeline/tests/fixtures/voice-lint-56/captured-records.json"
-files = sorted(glob.glob('/Users/brandonsmith/.claude/projects/*/*.jsonl'))
+TWO INPUTS, AND ONLY ONE OF THEM IS PORTABLE (#91). The OUTPUT path is derived from this file's
+own location, so the script writes beside itself in whatever checkout it is run from; it used to
+be an absolute path naming an author's home directory and an ephemeral worktree, which made the
+documented re-derivation recipe break the moment that worktree was removed.
+
+THE INPUT IS NOT PORTABLE AND CANNOT BE MADE SO, so the constraint is stated rather than hidden:
+these fixtures are captured from real transcripts, and transcripts are not in the repo and never
+will be (they are the owner's conversations). Running this on a machine with no Claude Code
+history exits non-zero naming the class it could not find, rather than writing a thinner file
+that would silently weaken every cell it feeds. The transcript root defaults to
+~/.claude/projects and can be pointed elsewhere with CLAUDE_PROJECTS_DIR.
+"""
+
+import glob, json, collections, datetime, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(HERE, "captured-records.json")
+PROJECTS = os.environ.get("CLAUDE_PROJECTS_DIR") or os.path.expanduser("~/.claude/projects")
+files = sorted(glob.glob(os.path.join(PROJECTS, '*', '*.jsonl')))
+if not files:
+    sys.exit("NO TRANSCRIPTS under " + PROJECTS + ". Set CLAUDE_PROJECTS_DIR, or run this on a "
+             "machine with Claude Code history: these fixtures are CAPTURED, never hand-written.")
 
 def content_str(r):
     c = r.get('message', {}).get('content')
@@ -129,7 +149,10 @@ doc = {
         "  - origin.kind is VERBATIM. Every other origin key keeps its name and loses its value.",
         "  - timestamp is the captured one and is OVERWRITTEN per cell by the fixture builder.",
         "",
-        "RE-DERIVE (author machine, records are the owner's own transcripts and are not in the repo):",
+        "RE-DERIVE (records are the owner's own transcripts and are not in the repo, so this",
+        "needs a machine with Claude Code history; the script writes beside itself, in whatever",
+        "checkout it is run from, and reads ~/.claude/projects unless CLAUDE_PROJECTS_DIR says",
+        "otherwise):",
         "  python3 plugins/pipeline/tests/fixtures/voice-lint-56/capture.py",
         "",
         "STALENESS: every field these fixtures are pinned on is asserted as a present-tense fact",

--- a/plugins/pipeline/tests/run.sh
+++ b/plugins/pipeline/tests/run.sh
@@ -4,15 +4,50 @@
 #
 # Wire this as your checkCommand to gate the plugin's own development:
 #   { "checkCommand": "bash plugins/pipeline/tests/run.sh" }
+#
+# THE SUMMARY NAMES THE SUITES, not only how many there were (#91). A count alone is an
+# observability defect with a measured cost: this summary reported "1 suite(s) FAILED" against a
+# ~40-suite run during #56's review, and identifying WHICH suite meant grepping back through a
+# transcript that scrolls past a terminal's scrollback. The per-suite `== name ==` banner is
+# printed BEFORE the suite runs and says nothing about its outcome, so it is not a substitute.
+#
+# TWO PROPERTIES OF THIS HARNESS THAT LOOK LIKE FLAKES AND ARE NOT (#91, both reproduced during
+# #56's review). Read these before concluding that a one-off red is a real regression.
+#
+#   (a) DO NOT RUN THIS CONCURRENTLY WITH AN IN-FLIGHT EDIT TO ../scripts/*.mjs. Every test-*.sh
+#       here shells out to the LIVE checkout path (harness.sh's SCRIPTS_DIR is `../scripts`, a
+#       read path into the working tree) rather than to a snapshot taken at the start of the run.
+#       An editor or tool save that is mid-write when a suite reads the file yields a partial
+#       file, so node reports a transient SyntaxError in exactly one invocation and the same
+#       suite is green on the next run. DIRECTION: a FALSE RED, which is the cheap direction, but
+#       it costs an investigation each time. It is a TOCTOU window, not a race this harness can
+#       close from inside: the fix would be running against a snapshot, which would then test
+#       code that is not the code in the tree.
+#
+#   (b) test-issue17-integration.sh's AC41(c) IS STRUCTURALLY BLIND TO UNCOMMITTED CHANGES. That
+#       cell does `git clone file://$REPO_ROOT` into a temp dir and runs this script inside the
+#       CLONE. A clone transfers committed refs only, so the nested run tests the tree as of the
+#       last commit and never the working tree. If you are iterating on an uncommitted fix, the
+#       nested run reports the PRE-implementation pass/fail tally while your outer run reports
+#       the post-implementation one, and the two disagree for a reason that has nothing to do
+#       with the change. COMMIT FIRST, then re-run, before treating that disagreement as a bug.
 set -u
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
 FAILED=0
+# A newline-delimited STRING and not an array, matching harness.sh's TMP_REGISTRY for the same
+# reason: bash 3.2 is what macOS ships and what this script runs under, and `"${arr[@]}"` on an
+# empty array is an unbound-variable error there under `set -u`.
+FAILED_SUITES=""
 for t in test-*.sh; do
   [[ -f "$t" ]] || continue
   printf '\n\033[1m== %s ==\033[0m\n' "$t"
-  bash "$t" || FAILED=$((FAILED + 1))
+  bash "$t" || {
+    FAILED=$((FAILED + 1))
+    FAILED_SUITES="${FAILED_SUITES}  ${t}
+"
+  }
 done
 
 printf '\n'
@@ -21,4 +56,5 @@ if [[ "$FAILED" -eq 0 ]]; then
   exit 0
 fi
 printf '%s suite(s) FAILED.\n' "$FAILED"
+printf '%s' "$FAILED_SUITES"
 exit 1

--- a/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
+++ b/plugins/pipeline/tests/test-gate-phase-entry-hook.sh
@@ -441,7 +441,9 @@ suite "AC27: the two suites that already own this hook are UNCHANGED consumers"
 # 9 labels added, 2 "removed", and both of those two are the SAME population-report lines carrying
 # their own count in the label (95 -> 101 mtime stamps, 81 -> 84 exit codes), re-baselined by the
 # three extra lint runs. 0 real removals, 0 renames. THIS COUNT IS RE-DERIVED FROM A RUN, never
-# incremented by hand -- measured passed=267 failed=0 at the commit that adds it.
+# incremented by hand -- measured passed=267 failed=0 at the commit that adds it, and re-derived
+# to passed=272 failed=0 at #91, which added five cells (a premise, the tie, its one-millisecond
+# twin either side, and a reported measurement) and removed none.
 #
 # AND THE IRONY, recorded as a pointer rather than acted on here: this cell is a bare exact-count
 # pin over another suite's whole population, which is the class #33 retired elsewhere in Lane 1.
@@ -462,7 +464,7 @@ run_suite_counts test-stop-hook.sh
 assert_eq "test-stop-hook.sh still passes exactly its 18 pre-existing assertions" "${SUITE_PASSED:-<none>}" "18"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 run_suite_counts test-voice-lint.sh
-assert_eq "test-voice-lint.sh still passes exactly its 267 assertions (41 pre-existing + 7 from #27 + 26 from #53, less 3 retired by #53, + 186 from #56's authored contract, + 3 from #56's Phase-4 gap closure, + 7 from #56's Phase-4 residual (ix) pin -- see the note above)" "${SUITE_PASSED:-<none>}" "267"
+assert_eq "test-voice-lint.sh still passes exactly its 272 assertions (41 pre-existing + 7 from #27 + 26 from #53, less 3 retired by #53, + 186 from #56's authored contract, + 3 from #56's Phase-4 gap closure, + 7 from #56's Phase-4 residual (ix) pin, + 5 from #91's turn-boundary tie block -- see the note above)" "${SUITE_PASSED:-<none>}" "272"
 assert_eq "  with none failing" "${SUITE_FAILED:-<none>}" "0"
 
 # ---------------------------------------------------------------------------

--- a/plugins/pipeline/tests/test-harness.sh
+++ b/plugins/pipeline/tests/test-harness.sh
@@ -487,4 +487,50 @@ assert_not_contains "a non test-*.sh file never runs" "$OUT" "helper-not-a-suite
 assert_contains "run.sh still discovers via the test-*.sh glob" "$(cat "$TESTS_DIR/run.sh")" 'for t in test-*.sh'
 assert_contains "run.sh still invokes each suite with bash" "$(cat "$TESTS_DIR/run.sh")" 'bash "$t"'
 
+suite "run.sh: the final summary NAMES the failing suites, not only how many (#91)"
+
+# WHY THE CELL ABOVE DID NOT ALREADY COVER THIS, because that is the whole point of adding one.
+# "the failing suite is named in the run" is satisfied by the `== <name> ==` banner run.sh prints
+# BEFORE it runs each suite, which says nothing about the outcome and appears identically for
+# every green suite. So it passed against a summary that reported a bare count, and finding which
+# of ~40 suites failed meant grepping back through a transcript. Everything below is asserted
+# against the SUMMARY BLOCK ALONE -- the text after the count line -- so a banner cannot satisfy
+# it. Mutation: delete the name-printing line from run.sh and the first two cells here go red
+# while every cell in the AC2 suite above stays green.
+summary_block() {  # <full run.sh output> -> the text AFTER the count line
+  printf '%s' "${1##*FAILED.}"
+}
+
+new_tmpdir || exit 90
+NAMEDIR="$NEW_TMPDIR"
+cp "$TESTS_DIR/run.sh" "$NAMEDIR/run.sh"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$NAMEDIR/test-alpha-green.sh"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$NAMEDIR/test-bravo-red.sh"
+OUT=$(bash "$NAMEDIR/run.sh" 2>&1); RC=$?
+NAMED="$(summary_block "$OUT")"
+assert_eq "PREMISE: the fixture tree is one green suite and one red one, so run.sh exits 1" "$RC" "1"
+assert_contains "the summary block names the suite that FAILED" "$NAMED" "test-bravo-red.sh"
+assert_not_contains "and it does NOT name a suite that passed, so the block is a verdict and not a roster" \
+  "$NAMED" "test-alpha-green.sh"
+# Without this, the not_contains above would pass just as well on an EMPTY block, which is
+# exactly what run.sh printed before #91. It also proves the extractor sliced the banners off
+# rather than handing back the whole transcript.
+assert_not_contains "CONTROL ON THE EXTRACTOR: the block is the summary, carrying none of the per-suite banners" \
+  "$NAMED" "=="
+assert_contains "CONTROL: the green suite DID run, so its absence from the block is a choice and not a suite that never executed" \
+  "$OUT" "== test-alpha-green.sh =="
+
+printf '#!/usr/bin/env bash\nexit 1\n' > "$NAMEDIR/test-charlie-red.sh"
+OUT=$(bash "$NAMEDIR/run.sh" 2>&1)
+NAMED="$(summary_block "$OUT")"
+assert_contains "with TWO failures the count still reports both" "$OUT" "2 suite(s) FAILED."
+assert_contains "and the block names the first of them" "$NAMED" "test-bravo-red.sh"
+assert_contains "and the second, so the list is not truncated to whichever failed last" \
+  "$NAMED" "test-charlie-red.sh"
+
+rm -f "$NAMEDIR/test-bravo-red.sh" "$NAMEDIR/test-charlie-red.sh"
+OUT=$(bash "$NAMEDIR/run.sh" 2>&1); RC=$?
+assert_eq "and the SAME tree exits 0 once the red suites are removed" "$RC" "0"
+assert_not_contains "a green run prints no name list at all" "$OUT" "test-bravo-red.sh"
+
 finish

--- a/plugins/pipeline/tests/test-status-schema-contract.sh
+++ b/plugins/pipeline/tests/test-status-schema-contract.sh
@@ -2,9 +2,11 @@
 # status.schema.json's own contract: the verdict cap (#34) and the current_phase example
 # list (#42).
 #
-# WHY THIS FILE EXISTS. status.schema.json has exactly ONE runtime reader -- voice-lint.mjs:247 (the
-# readFileSync in phaseShapeFailure), which reads properties.current_phase.pattern at :249 and
-# nothing else. The file appears in no
+# WHY THIS FILE EXISTS. status.schema.json has exactly ONE runtime reader -- the readFileSync in
+# voice-lint.mjs's `phaseShapeFailure`, which reads properties.current_phase.pattern out of it and
+# nothing else. CITED BY SYMBOL AND NOT BY LINE (#91): the two line numbers that used to sit here
+# were both stale, having moved three times inside #56's own review, and a stale coordinate sends
+# the next reader to an unrelated line with no signal that it is the wrong one. The file appears in no
 # AGENT_RULES entry in validate-pipeline-artifact.mjs, and that walker does not implement
 # maxLength at all, so a maxLength written into this schema refuses nothing by itself. Both
 # defects this suite pins are the same condition: a constraint nobody reads can be absent
@@ -484,7 +486,7 @@ assert_eq "AC7 CONTROL: and that literal is still present as a negative-control 
 # ---------------------------------------------------------------------------
 suite "AC8: UNCHANGED CONSUMER -- current_phase.pattern is byte-identical"
 # ---------------------------------------------------------------------------
-# voice-lint.mjs:249 (in phaseShapeFailure) reads exactly this one key out of this file and
+# voice-lint.mjs's `phaseShapeFailure` reads exactly this one key out of this file and
 # nothing else. Pinned by
 # VALUE, not by presence: a presence check survives any edit to the regex, which is the thing the
 # only runtime reader actually consumes. The literal below is the pre-change bytes.
@@ -1011,5 +1013,30 @@ assert_eq "AC-54b: ...and every derived anchor really is issue-numbered" \
 assert_eq "AC-54b: the derived union floor from AC2 is still live alongside this one" \
   "$([[ "${CORPUS_FLOOR:-0}" -ge 1 && "${CORPUS_N:-0}" -ge "$CORPUS_FLOOR" ]] && echo enough || echo "union floor lost: $CORPUS_N vs $CORPUS_FLOOR")" "enough"
 
+# ---------------------------------------------------------------------------
+suite "#91: the citations into voice-lint.mjs are SYMBOLS, not line coordinates"
+# ---------------------------------------------------------------------------
+# THE DEFECT, and it had already happened rather than being anticipated. This suite and
+# test-telemetry-exit-attribution.sh each pointed a reader at voice-lint.mjs by LINE NUMBER, and
+# all three coordinates were stale: the cited line moved three times inside #56's own review, and
+# #56's final commit had to apply this same fix to a citation of its own. A stale coordinate is
+# worse than none, because it lands the reader on an unrelated line with nothing to signal that it
+# is the wrong one. `grep -o | wc -l` throughout, never `grep -c`, which counts LINES and would
+# report 1 for a line carrying two coordinates. Precedent and idiom: #53 AC10 in
+# test-gate-phase-entry-drift.sh, which pins the same property against the same file.
+for f in test-status-schema-contract.sh test-telemetry-exit-attribution.sh; do
+  assert_eq "$f cites no line coordinate into voice-lint.mjs" \
+    "$(grep -o 'voice-lint\.mjs:[0-9]' "$TESTS_DIR/$f" | wc -l | tr -d ' ')" "0"
+done
+# ASSEMBLED, NEVER WRITTEN AS ONE TOKEN. This file is inside the population the grep above walks,
+# so a control carrying the coordinate verbatim would make the zero unreachable for a reason that
+# has nothing to do with the subject.
+CTRL_VL_COORD="voice-lint""$(printf '%s' .mjs:247)"
+assert_eq "NON-ZERO CONTROL on that instrument: the same pattern finds a coordinate when one is present, so the zeroes above are measurements and not a pattern that never matches" \
+  "$(printf '%s\n' "$CTRL_VL_COORD" | grep -o 'voice-lint\.mjs:[0-9]' | wc -l | tr -d ' ')" "1"
+# And the symbol the citations now name has to EXIST, or they are a different kind of dangling
+# pointer: one that reads as precise and resolves to nothing.
+assert_contains "and the symbol those citations now name is really defined in voice-lint.mjs" \
+  "$(cat "$VOICE_LINT")" "function phaseShapeFailure("
 
 finish

--- a/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
+++ b/plugins/pipeline/tests/test-telemetry-exit-attribution.sh
@@ -338,7 +338,9 @@ suite "AC25: the schema stops forbidding a value its own corpus produces"
 # SUPPORTED SIGNAL. phase_elapsed_ms correctly stays non-negative because the code guards
 # delta >= 0. Asserted as a shape read of the schema, in the idiom this suite already uses.
 # NOTE, so nobody reads more urgency into this than it has: nothing in this repo validates
-# status.json against status.schema.json (voice-lint.mjs:261, the phaseShapeFailure message, says so outright), so no validator
+# status.json against status.schema.json (the refusal text `phaseShapeFailure` returns in
+# voice-lint.mjs says so outright; cited by SYMBOL rather than by line, per #91, because the
+# line this used to name had already drifted), so no validator
 # is about to fire. It is a contract that contradicts its own corpus and its own sibling field.
 assert_eq "AC25: total_lead_time_ms declares no \`minimum\`" \
   "$(SCHEMA="$SCHEMA" node -e '

--- a/plugins/pipeline/tests/test-voice-lint.sh
+++ b/plugins/pipeline/tests/test-voice-lint.sh
@@ -1261,7 +1261,7 @@ VL91_TIE_PROBE="$(node -e '
 ' "$VL56_PROJECT/.pipeline/4244/status.json" "$VL56_TRANSCRIPT" 2>&1)"
 assert_eq "#91 PREMISE: the fixture really constructs an EXACT tie -- the record's updated_at and the owner record's timestamp parse to the same integer millisecond. Without this the cell below could pass by being one ms LATE, which exercises the strictly-greater path and witnesses nothing about the tie" \
   "$VL91_TIE_PROBE" "EXACT"
-assert_eq "#91(a) THE TIE ITSELF: a record dated EXACTLY at the turn boundary is IN the turn and still gets graded: exit 2. The turn window is half-open, [humanTurnMs, now]. MUTATION THIS CELL EXISTS FOR: change run()'s \`<\` to \`<=\` and this flips to 0 -- and nothing else in this suite moves, which is what made the mutation survivable before #91" \
+assert_eq "#91(a) THE TIE ITSELF: a record dated EXACTLY at the turn boundary is IN the turn and still gets graded: exit 2. The turn window is CLOSED AT ITS LEFT END: in-turn means recordFreshnessMs >= humanTurnMs. MUTATION THIS CELL EXISTS FOR: change run()'s \`<\` to \`<=\` and this flips to 0 -- and nothing else in this suite moves, which is what made the mutation survivable before #91" \
   "$VL91_TIE_RC" "2"
 
 vl91_tie "$((VL56_OWNER_MS - 1))"

--- a/plugins/pipeline/tests/test-voice-lint.sh
+++ b/plugins/pipeline/tests/test-voice-lint.sh
@@ -1220,6 +1220,61 @@ assert_eq "AC16(d) ONE-VARIABLE CONTROL: the identical fixture with only the mti
 record "REPORTED, so a reader does not count (d) as coverage of the restore class: its INPUT is structurally identical to AC3's stale cell, and its value is the LABEL and the EXPIRY, not new coverage. The signature is built with utimesSync plus a stale updated_at written into the content and NEVER by shelling out to cp -p, rsync or tar -- that pair is the restore's whole signature in the two fields the predicate reads, and shelling out would reintroduce the touch -t portability ban in another costume (rsync is not verified present on ubuntu-latest, and BSD and GNU cp differ). ctime DOES differ between a restored record and an untouched stale one, and ctime is rejected as a mechanism for a separate measured reason: utimesSync leaves ctime fresh, so a ctime-inclusive composition would force every stale fixture in this suite to be rebuilt by write-ordering against ~1.1s of real elapsed time"
 
 # ---------------------------------------------------------------------------------------------
+suite "#91: the TURN-BOUNDARY TIE resolves toward REFUSING, the opposite way from AC9(e)'s mtime tie"
+# ---------------------------------------------------------------------------------------------
+# WHAT THIS BLOCK EXISTS FOR. run()'s turn-scoping comparison is `recordFreshnessMs(...) <
+# humanTurnMs`, and mutating that `<` to `<=` SURVIVED this whole suite -- a live coverage hole
+# found reviewing #56 and filed as #91. The direction is not a detail: `<` keeps an exactly-tied
+# record IN the turn and therefore LOUD, `<=` reads it stale and SILENCES a refusal the pre-#56
+# code produced, which is the one thing the module's governing direction forbids of its own new
+# suppressor. resolveStatus's mtime tie resolves the other way (AC9(e): abstain to null) and that
+# is deliberate, because it ties between TWO CANDIDATE RECORDS where picking either means picking
+# by readdir order; this comparison has one record and one boundary and nothing arbitrary to
+# refuse. Both halves are now pinned, so a future reader finds a ruling instead of an asymmetry.
+#
+# THE TIE IS CONSTRUCTED THROUGH updated_at AND NOT THROUGH mtime, deliberately and by
+# measurement: utimesSync-stamped mtimes read back with a fractional millisecond on APFS (the
+# STAMP ledger at the end of this block records every drift), so an mtime tie against a
+# whole-millisecond parsed timestamp is not constructible here. updated_at is an ISO string on
+# both sides of the comparison, so `Date.parse` lands on the same integer and the tie is EXACT
+# -- and the cell below asserts that exactness as a premise rather than assuming it, because a
+# fixture that missed by one millisecond would exercise `>` and pass while proving nothing.
+
+vl91_tie() {  # <updated_at ms> -> RC, with the mtime held far stale so updated_at decides
+  vl56_ac16 "$VL56_STALE_MS" "$1"
+}
+
+vl91_tie "$VL56_OWNER_MS"
+VL91_TIE_RC="$RC"
+VL91_TIE_PROBE="$(node -e '
+  const { readFileSync } = require("node:fs");
+  const [statusFile, transcript] = process.argv.slice(1);
+  const stated = Date.parse(JSON.parse(readFileSync(statusFile, "utf8")).updated_at);
+  const owner = readFileSync(transcript, "utf8").split("\n").filter(Boolean)
+    .map((l) => JSON.parse(l))
+    .filter((r) => r && r.origin && r.origin.kind === "human").pop();
+  if (!owner) { process.stdout.write("NO_OWNER_RECORD"); }
+  else {
+    const boundary = Date.parse(owner.timestamp);
+    process.stdout.write(stated === boundary ? "EXACT" : "OFF_BY_" + (stated - boundary));
+  }
+' "$VL56_PROJECT/.pipeline/4244/status.json" "$VL56_TRANSCRIPT" 2>&1)"
+assert_eq "#91 PREMISE: the fixture really constructs an EXACT tie -- the record's updated_at and the owner record's timestamp parse to the same integer millisecond. Without this the cell below could pass by being one ms LATE, which exercises the strictly-greater path and witnesses nothing about the tie" \
+  "$VL91_TIE_PROBE" "EXACT"
+assert_eq "#91(a) THE TIE ITSELF: a record dated EXACTLY at the turn boundary is IN the turn and still gets graded: exit 2. The turn window is half-open, [humanTurnMs, now]. MUTATION THIS CELL EXISTS FOR: change run()'s \`<\` to \`<=\` and this flips to 0 -- and nothing else in this suite moves, which is what made the mutation survivable before #91" \
+  "$VL91_TIE_RC" "2"
+
+vl91_tie "$((VL56_OWNER_MS - 1))"
+assert_eq "#91(b) THE DISCRIMINATING TWIN, ONE MILLISECOND MOVED: the same fixture with updated_at one ms BEFORE the boundary reads stale and goes silent: exit 0. Paired with (a) this is what makes (a) a statement about the TIE rather than about a record that is fresh by a wide margin" \
+  "$RC" "0"
+
+vl91_tie "$((VL56_OWNER_MS + 1))"
+assert_eq "#91(c) and one millisecond AFTER the boundary is loud again: exit 2. The three cells bracket the comparison, so a mutation to \`>\`, \`<=\` or \`>=\` reddens at least one of them" \
+  "$RC" "2"
+
+record "REPORTED, so the direction is not read as a live-bug fix: no behaviour changed at #91, only the ruling was written down and pinned. OBSERVED TIES IN PRODUCTION: ZERO. Measured on this machine, re-derivable: 12 of 12 live status.json records under this repo's own pipeline state dir carry a fractional-millisecond mtime while a parsed transcript timestamp is a whole one, so the mtime term cannot tie; 10 of those 12 records write updated_at at WHOLE-SECOND grain, and 0 of 523 observed origin.kind 'human' timestamps land on a whole second, so the updated_at term does not tie either today. The cells cost three fixtures and hold the direction against a vendor coarsening either clock, at which point this line decides between loud and silent on a common input"
+
+# ---------------------------------------------------------------------------------------------
 suite "#56 AC7: NO DISARM VECTOR -- every removed input leaves behaviour EXACTLY AS TODAY"
 # ---------------------------------------------------------------------------------------------
 # THE GOVERNING PROPERTY, stated so the two directions in this suite do not read as a


### PR DESCRIPTION
Closes #91.

Four of the five items in #91. Item 5 is deliberately untouched (see the bottom). The production
module's diff is **comment-only**: `git diff origin/main -- plugins/pipeline/scripts/voice-lint.mjs`
with comment and blank lines stripped is empty. No behaviour changed in `voice-lint.mjs`.

## Item 2 -- `run.sh` reports a count with no names (the highest-value one)

The final summary said `N suite(s) FAILED` and nothing else, so finding which of 36 suites failed
meant grepping back through a transcript. The per-suite `== name ==` banner is printed *before* the
suite runs, so it says nothing about the outcome and is not a substitute -- which is exactly why
the existing cell "the failing suite is named in the run" passed against the broken summary.

The count line is unchanged (`N suite(s) FAILED.`), so both existing assertions that match it still
match; the names follow it, indented, one per line.

New suite in `test-harness.sh` (10 assertions), asserted against **the summary block alone** -- the
text after the count line -- so a banner cannot satisfy it:

| cell | before | after |
| --- | --- | --- |
| the summary block names the suite that FAILED | **FAIL** (block was empty) | ok |
| and it does NOT name a suite that passed | ok | ok |
| CONTROL: the block carries no per-suite banners | ok | ok |
| CONTROL: the green suite did run | ok | ok |
| with TWO failures, the block names both | **FAIL**, **FAIL** | ok, ok |

`test-harness.sh` measured **passed=94 failed=3** against the pre-fix `run.sh` and **passed=97
failed=0** after. The pre-fix `run.sh` was restored from git (`git show HEAD:...`), not retyped.

Also documented, in `run.sh`'s own header, the two harness properties that read as flakes and are
not (both reproduced during #56's review):

- the suites shell out to the **live** `../scripts` path rather than a snapshot, so a concurrent
  `.mjs` save yields a transient `SyntaxError` in exactly one invocation. It is a TOCTOU window
  this harness cannot close from inside: running against a snapshot would test code that is not
  the code in the tree.
- `test-issue17-integration.sh`'s AC41(c) does `git clone file://$REPO_ROOT` and runs the suite in
  the **clone**, which carries committed refs only. Iterating on an uncommitted fix makes the
  nested run report the pre-implementation tally while the outer run reports the post-. Commit
  first, then re-run.

## Item 3 -- tie direction, and `resolveStatus`'s fallback shape

**Ruling: strict `<` is correct, the two ties deliberately differ, and both halves are now pinned.**

They are different questions, which is why matching them would be the mistake:

- `resolveStatus` ties **between two candidate records** at the newest mtime. Picking either means
  picking by `readdirSync` order (hash order on ext4, insertion order on APFS, #27), so it abstains
  rather than let the filesystem decide whose run gets voice-checked. Pinned already, at AC9(e).
- `run()` compares **one record against one boundary**. There is no second candidate and nothing
  arbitrary to refuse, and equality means the record was touched at the instant the turn began. The
  turn window is closed at its left end: in-turn means `recordFreshnessMs >= humanTurnMs`.

And the direction is forced by the module's own governing rule. This comparison is the only new
suppressor #56 added, and the header says this change must never be the reason for silence. `<=`
would make an exactly-tied record read stale and silence a refusal the pre-#56 code produced, on an
input whose ordering is not established. `resolveStatus`'s abstention is not a counter-example: it
predates #56 and is byte-for-byte what it was, so its silence is not this change's silence.

**Mutation evidence** (the whole point of this item). `<` -> `<=` planted by exact literal
replacement, refusing to proceed unless the literal occurred exactly once, with the changed line
printed before and after:

```
680:  ... resolved.status?.updated_at) < humanTurnMs) {     <- before
planted: replaced 1 occurrence of "updated_at) < humanTurnMs)" with "updated_at) <= humanTurnMs)"
680:  ... resolved.status?.updated_at) <= humanTurnMs) {    <- after
```

- with the mutation: `test-voice-lint.sh` **passed=271 failed=1**, the one red being `#91(a) THE TIE
  ITSELF`, and **nothing else in the suite moved** -- which is the issue's claim reproduced.
- restored with `git checkout --` (the fix was committed first): **passed=272 failed=0**.

Three bracketing cells plus an exactness premise, built through the `updated_at` term rather than
mtime because a `utimesSync` stamp reads back with a fractional millisecond while a parsed ISO
timestamp is a whole one, so an mtime tie is not constructible here. The premise cell asserts the
two values parse to the *same integer millisecond* -- without it the tie cell could pass by being
one millisecond late, exercising `>` and witnessing nothing.

Reachability, measured on this machine rather than asserted: 12 of 12 live `status.json` records
carry a fractional-millisecond mtime; 10 of those 12 write `updated_at` at whole-second grain; 0 of
523 observed `origin.kind: human` timestamps land on a whole second. **Observed ties: zero.** The
direction is pinned anyway, at the cost of three fixtures, because a vendor coarsening either clock
makes ties common overnight and this line would then decide between loud and silent.

`resolveStatus`'s wrapper return now carries a doc comment recording that the shape change is
behaviour-preserving **only while it has one production importer**. `status` may itself be null (the
fallback branch hands back `readJson(newest)`), so `resolveStatus(...) === null` is true on the four
no-record paths and **false** on an unparseable record, while "no usable phase" is true on all five.
A new importer writing `if (!resolveStatus(...)) return;` silently treats a record it could not read
as one it read.

## Item 4 -- hygiene

- `capture.py` now derives its output path from `__file__` and reads `CLAUDE_PROJECTS_DIR` or
  `~/.claude/projects`, replacing an absolute path naming an author home directory and an ephemeral
  worktree. The input stays non-portable by nature (the transcripts are the owner's conversations
  and are not in the repo) and the docstring says so rather than hiding it; on an empty corpus it
  exits non-zero naming the constraint rather than writing a thinner fixture that would quietly
  weaken every cell it feeds. Verified both ways: an empty `CLAUDE_PROJECTS_DIR` exits 1 with the
  committed fixture's checksum unchanged, and a copy of the script run from a temp directory wrote
  `captured-records.json` **beside itself** and re-derived the same seven provenance classes, with
  the committed fixture still untouched.
- Three line-number citations into `voice-lint.mjs` (`:247`, `:249`, `:261`, all naming
  `phaseShapeFailure`, which now sits around :660) replaced with the symbol. All three had drifted:
  a stale coordinate is worse than none, because it lands the reader on an unrelated line with
  nothing to signal it is wrong. Pinned with a new cell in `test-status-schema-contract.sh` in #53
  AC10's idiom -- `grep -o | wc -l` over both files, a non-zero control assembled from fragments so
  this file's own text cannot make the zero unreachable, and an assertion that the symbol it now
  names really is defined. Bite proof: re-planting one stale coordinate took that suite to
  **passed=153 failed=1** naming `test-telemetry-exit-attribution.sh`; restored from git,
  **passed=154 failed=0**.
- Residual (v)'s "no residual EXPIRY applies" tightened. `isMeta` is a vendor-controlled label
  exactly as `origin.kind` is, so the class sits **inside** residual (iv)'s declared scope. Two
  independent guards make it robust to either label drifting alone; they do not take it out of the
  vendor's hands. It now points at (iv)'s expiry instead of claiming none.

## Item 1 -- NOT DONE, and why

`.pipeline/56/spec.json` **does not exist**. `.gitignore:23` is `.pipeline/*/*` with only
`status.json` negated, so it was never committed, and the local copy is gone from both the source
checkout and this worktree. Nothing was fabricated.

The durable record that *did* survive is `knowledge/issue-archive/56.json`, whose
`spec.requirements[6]` (R7) has the same gap -- it enumerates (i) through (vii) and omits (viii),
which ships in the header. Its `(v)` also still reads "not bounded as a residual", which this PR
corrects in the code. That file is the Librarian's to write, so it is **raised, not edited**:

> `knowledge/issue-archive/56.json` -- store says R7 enumerates residuals (i)-(vii) and describes
> (v) as "not bounded as a residual"; live reality is that `voice-lint.mjs`'s header ships residual
> (viii) and, as of this PR, scopes (v) under (iv). Evidence: the shipped header, and
> `spec.requirements[6]` in that archive. Severity: low (a documentation contradiction between two
> artifacts, no behaviour depends on it).

## Item 5 -- deliberately out of scope

`current_phase` echoed unbounded into stderr and re-injected as Stop-hook feedback. Pre-existing at
`origin/main`, SecOps recommended it be its own follow-up, and it is not a #91 item. Untouched.

## Checks

`bash plugins/pipeline/tests/run.sh`: **36 suites, all passed, exit 0**, zero `FAIL` lines anywhere
in the transcript, including AC41(c)'s nested clone run. `test-voice-lint.sh` moved 267 -> 272
assertions and the exact-count pin in `test-gate-phase-entry-hook.sh` was re-derived from that run
rather than incremented by hand. No existing assertion was weakened or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
