### PR TITLE
fix(hooks): correct hooks.json's three timeout fields to seconds, not ms

### DIFF
--- a/plugins/pipeline/hooks/hooks.json
+++ b/plugins/pipeline/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
-            "timeout": 10000
+            "timeout": 20
           }
         ]
       }
@@ -17,7 +17,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh",
-            "timeout": 120000
+            "timeout": 600
           }
         ]
       }
@@ -28,7 +28,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop.sh",
-            "timeout": 15000
+            "timeout": 15
           }
         ]
       }

--- a/plugins/pipeline/tests/test-pretooluse-gate-declaration.sh
+++ b/plugins/pipeline/tests/test-pretooluse-gate-declaration.sh
@@ -28,11 +28,13 @@ suite "AC1: the PreToolUse declaration, and its timeout in SECONDS"
 #
 # THE UNIT IS FIXED BY THE RUNTIME, NOT BY THE FILE'S NEIGHBOURS. Claude Code 2.1.85's hook-exec
 # path computes `E = H.timeout ? H.timeout*1000 : EL` with `EL = 600000`, so `timeout` is SECONDS
-# and the implicit ceiling is 600 s. The three already-shipped entries (10000, 120000, 15000) are
-# therefore 2.8 h, 33.3 h and 4.2 h -- every one of them ABOVE the platform's own default -- so
-# "smaller than Stop's 120000" bounds nothing and is refused here as a comparison. That
-# seconds/milliseconds defect in the shipped three is #108 and is NOT fixed by this issue, which
-# is why the assertion below is written against 600 and not against the neighbours.
+# and the implicit ceiling is 600 s. At the commit this file was authored against, the three
+# already-shipped entries (10000, 120000, 15000) were therefore 2.8 h, 33.3 h and 4.2 h -- every
+# one of them ABOVE the platform's own default -- so "smaller than Stop's 120000" bounded nothing
+# and was refused here as a comparison; the assertion below was written against 600 for that
+# reason and stays written against 600 now that #108 has corrected the three neighbours (20, 600,
+# 15) below, since PreToolUse's own bound must independently hold regardless of what the other
+# three declare.
 #
 # Version recorded beside the assertion, per the measurement rule: the ceiling is a property of
 # the runtime under test, so a host on another version produces a different recorded number
@@ -87,18 +89,20 @@ assert_eq "and is a plausible bound for one node start plus one git subprocess (
   "$("$GATE_REAL_NODE" -e 'const t=Number(process.argv[1]); process.stdout.write(Number.isFinite(t)&&t>0&&t<=30?"in-range":"OUT-OF-RANGE: "+process.argv[1])' "${DECLARED_TIMEOUT:-NaN}" 2>/dev/null)" \
   "in-range"
 
-# The three existing event keys are unchanged IN CONTENT. Pinned as the exact serialization of
-# each, so a change to a command or a timeout reddens here rather than only in whichever suite
-# happens to drive that hook.
-assert_eq "SessionStart entry is unchanged in content" \
+# The three existing event keys are pinned as the exact serialization of each, so a change to a
+# command or a timeout reddens here rather than only in whichever suite happens to drive that
+# hook. #108 corrected all three from a milliseconds-shaped value to the SECONDS value the
+# runtime actually reads (10000->20, 120000->600, 15000->15; see #108's PR for the per-entry
+# measurement each bound is derived from), so the pinned content changes here too.
+assert_eq "SessionStart entry carries #108's corrected (seconds) timeout" \
   "$(gate_hook_probe 'JSON.stringify(h.hooks.SessionStart)')" \
-  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh","timeout":10000}]}]'
-assert_eq "Stop entry is unchanged in content" \
+  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh","timeout":20}]}]'
+assert_eq "Stop entry carries #108's corrected (seconds) timeout" \
   "$(gate_hook_probe 'JSON.stringify(h.hooks.Stop)')" \
-  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh","timeout":120000}]}]'
-assert_eq "SubagentStop entry is unchanged in content" \
+  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh","timeout":600}]}]'
+assert_eq "SubagentStop entry carries #108's corrected (seconds) timeout" \
   "$(gate_hook_probe 'JSON.stringify(h.hooks.SubagentStop)')" \
-  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop.sh","timeout":15000}]}]'
+  '[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop.sh","timeout":15}]}]'
 
 # The declared command must actually be EXECUTABLE by the runtime, which runs the string through a
 # shell. A declaration pointing at a file that is not there is the #106 shape one level up.


### PR DESCRIPTION
## What

`hooks.json`'s `timeout` field is read by the Claude Code runtime in **seconds**, not
milliseconds. The three pre-existing entries were authored as if the unit were
milliseconds, making them ~1000x oversized and, in practice, unbounded (`SessionStart`
10000 = 2.8h, `Stop` 120000 = 33.3h, `SubagentStop` 15000 = 4.2h).

## Independent unit confirmation

Verified directly against the installed Claude Code 2.1.85 binary
(`/Users/brandonsmith/.local/share/claude/versions/2.1.85`), not taken from the issue or
from #106's prior re-derivation:

- The runtime's own Zod schema documents the field: `timeout:h.number().positive().optional().describe("Timeout in seconds for this specific command")`.
- The hook-exec path computes `E = H.timeout ? H.timeout*1000 : EL` with `EL = 600000`
  (600s / 10min default) — the exact formula #106's DBA cited, re-derived independently
  here.
- The runtime kills an over-time hook by spawning the command via `child_process.spawn`
  and tying an `AbortSignal.timeout(E)` to it; `sa1=143` (SIGTERM exit) appears alongside
  the kill path, matching the behavior of a shell `timeout` wrapper.

Units confirmed as SECONDS. Proceeding with the fix in the direction the issue describes.

## Per-entry bounds and reasoning

| Hook | Old (ms-shaped) | New (seconds) | Measured | Headroom | Fail direction on kill |
|---|---|---|---|---|---|
| SessionStart | 10000 | **20** | 0.9–1.5s (10 runs, with/without the `gh issue view` branch-match path) | ~13–16x | Fails OPEN, safely: best-effort context banner only. No correctness or security impact. |
| Stop | 120000 | **600** | This repo's own `checkCommand` (`bash plugins/pipeline/tests/run.sh`, the full suite) measured 399–458s across 3 clean `ubuntu-latest` GitHub Actions runs (`gh run list` / `gh api .../jobs`) | ~30–50% over the worst clean-CI sample | Fails OPEN, expensively: the check silently never blocks completion, so a failing check ships as if it passed. Highest-stakes of the three — headroom prioritized over tightness. Pinned explicitly at the platform's own 600s ceiling rather than left implicit, since a smaller number would routinely kill this repo's own legitimate check, and an implicit default is itself an unpinned value that could silently drift with a future runtime release. |
| SubagentStop | 15000 | **15** | ~90–100ms (10 runs, both the no-artifact miss path and a real-artifact validation path) | ~150x | Fails OPEN: `decision:block` is lost, so an invalid/over-cap artifact is silently accepted. Demonstrated with a non-zero control (below). |

Stop's checkCommand is inherently project-specific and unbounded in principle; 600s is not
a "divide by 1000" number, it is the largest defensible bound given real measured cost on
the heaviest known legitimate case (this repo's own dogfood suite).

## Binding non-zero control

Direct invocation of `hooks/subagent-stop.sh` bypasses the platform's own dispatcher, so a
proxy was used to demonstrate the exact mechanism the binary implements (spawn + timed
abort + SIGTERM), via a scratch plugin root with an artificially slow validator, wrapped in
`timeout 15s` (the chosen SubagentStop bound):

- **Killed**: validator sleeps 20s (exceeds bound) → `timeout -s TERM 15s ... subagent-stop.sh` exits `124` at `15017ms`, **zero stdout** — the `decision:block` payload that would have flagged a bad artifact is lost entirely.
- **Baseline**: same hook, validator completes in 2s (under bound) → exits `0` at `2116ms`, decision payload (`{"decision":"block","reason":"fast-path artifact"}`) passed through intact.

This confirms the chosen bound actually binds, and shows precisely the fail-open harm a
too-tight bound (or a genuinely slow validator) causes.

## Cross-platform headroom

Timing bounds are the most runner-dependent thing in this repo (per evidence.md's rendered-
measurement rule). All three chosen bounds carry deliberate margin against that:

- SessionStart's 20s gives ~13–16x over a 0.9–1.5s measurement taken on this Mac; a slower
  CI runner's extra git-fetch/`gh` network latency has ample room before it matters, and
  the fail-open direction means even a tight miss costs nothing but a missing banner.
- Stop's 600s was deliberately **not** shrunk despite being "only" ~30–50% over the worst
  of 3 *clean, uncontended* `ubuntu-latest` CI samples (399–458s) — CI runners are commonly
  slower and noisier than a dev laptop, and shrinking further risks routinely killing this
  repo's own real, currently-passing check for the sake of a tidier number. The platform's
  own ceiling is already the effective floor here; going lower trades real coverage for
  cosmetic tightness.
- SubagentStop's 15s gives ~150x over a ~100ms measurement because the validated work
  (directory-mtime scan + one JSON schema check) has a cost profile that stays flat as the
  `.pipeline` archive grows — there's no scaling term a slower/loaded CI box would expose,
  so the number was kept close to the original documented intent rather than shrunk purely
  because the measured margin allowed it.

## Test updates

`test-pretooluse-gate-declaration.sh`'s AC1 block hard-pinned the *old* (buggy)
serialization of all three entries as "unchanged in content," with an explicit comment
deferring the fix to #108. Both the pinned JSON and the explanatory comment are updated to
match the corrected values; the AC1 assertions about the *new* PreToolUse entry (bounded
under the 600s platform ceiling) are unaffected, since they were already written
independently of the three legacy entries for exactly this reason.

## Suite results

- `bash plugins/pipeline/tests/run.sh` at the rebased HEAD: run twice locally (0 failed
  both times; see PR thread for the second, post-rebase count).
- Rebased cleanly onto `origin/main` at `0b354c2` (no conflicts); picked up #117's already-
  updated module-count pin (18, including `check-status-record.mjs`) with no further edits
  needed.

Closes #108