### PR TITLE
AC28's filter premise must hold in BOTH base eras (fixes red main)

### DIFF
--- a/plugins/pipeline/tests/test-pretooluse-gate-declaration.sh
+++ b/plugins/pipeline/tests/test-pretooluse-gate-declaration.sh
@@ -478,18 +478,37 @@ EVAL-IMPORT rc=$r out=[$o] err=[$e]"
   o="$( ( cd "$PINNED_CWD" && printf '%s' '{"hook_event_name":"SubagentStop","session_id":"paired","agent_type":"pipeline:qa"}' \
         | CLAUDE_PROJECT_DIR="$PINNED_CWD" "$GATE_REAL_NODE" "$sd/validate-pipeline-artifact.mjs" 2>"$TEMP_PROJECT/e3" ) )"; r=$?
   # The #115 attribution line is a DELIBERATE difference from the reviewed commit: the validator
-  # now writes one `agent-pipeline SubagentStop: ...` line to stderr on every stop, because before
-  # it a lookup miss and a clean artifact were byte-identical. It is stripped HERE and only here,
-  # so exit code, stdout and every OTHER stderr byte stay pinned; a SECOND new stderr line would
-  # still redden this. The premise -- that the line exists at HEAD and not at the base -- is
-  # asserted in test-pretooluse-gate-ownership.sh's AC28 FILTER PREMISE pair.
-  e="$(grep -v '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/e3" || true)"
+  # writes one `agent-pipeline SubagentStop: ...` line to stderr on every stop, because before it a
+  # lookup miss and a clean artifact were byte-identical. A SECOND new stderr line still reddens
+  # this, which is what the strip must never absorb.
+  #
+  # STRIPPED ONLY IN THE ERA THAT NEEDS IT. The base is `merge-base HEAD origin/main`, so whether
+  # it carries this line depends on whether #128 has merged -- and an unconditional strip is
+  # therefore a control whose justification silently expires. Once #128 is in the base, BOTH sides
+  # emit the line, the strip becomes a no-op, and stripping would only serve to HIDE a divergence
+  # in the line's own text. So the strip is applied only when the base predates it, which makes the
+  # comparison UNFILTERED and strictly stronger in the era that now persists. The era is measured
+  # into AC36_BASE_ANNOUNCE below, never assumed. (The same reasoning, with its assertions, is in
+  # test-pretooluse-gate-ownership.sh's AC28 FILTER PREMISE / AC28 ERA block; that is where the
+  # premise is proven in both directions.)
+  if [[ "${AC36_BASE_ANNOUNCE:-0}" -eq 0 ]]; then
+    e="$(grep -v '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/e3" || true)"
+  else
+    e="$(cat "$TEMP_PROJECT/e3")"
+  fi
   out="$out
 VALIDATOR-STDIN rc=$r out=[$o] err=[$e]"
   printf '%s' "$out"
 }
 
 if [[ "$BASE_OK" == "yes" ]]; then
+  # MEASURE THE ERA before capturing, so capture3 knows whether its strip is load-bearing or a
+  # no-op. See the comment inside capture3 for why an unconditional strip expires on merge.
+  ( cd "$PINNED_CWD" && printf '%s' '{"hook_event_name":"SubagentStop","session_id":"paired","agent_type":"pipeline:qa"}' \
+      | CLAUDE_PROJECT_DIR="$PINNED_CWD" "$GATE_REAL_NODE" "$BASE_WT/plugins/pipeline/scripts/validate-pipeline-artifact.mjs" ) \
+      >/dev/null 2>"$TEMP_PROJECT/e0"
+  AC36_BASE_ANNOUNCE="$(grep -c '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/e0" | tr -d ' ')"
+  record "AC36(b) ERA: base $BASE_SHA emits $AC36_BASE_ANNOUNCE attribution line(s); the strip is $([[ "$AC36_BASE_ANNOUNCE" -eq 0 ]] && echo 'LOAD-BEARING' || echo 'a NO-OP, so this comparison runs UNFILTERED')"
   CAP_BASE="$(capture3 "$BASE_WT/plugins/pipeline/scripts")"
   CAP_HEAD="$(capture3 "$GATE_PLUGIN_DIR/scripts")"
   record "PAIRED CAPTURE, reviewed commit: $(printf '%s' "$CAP_BASE" | tr '\n' ' | ')"

--- a/plugins/pipeline/tests/test-pretooluse-gate-ownership.sh
+++ b/plugins/pipeline/tests/test-pretooluse-gate-ownership.sh
@@ -946,41 +946,66 @@ if [[ "$SS_OK" == "yes" ]]; then
   gate_inflight_status "$SS_ROOT/.pipeline/39/status.json" "3-impl"
   gate_inflight_status "$SS_ROOT/.pipeline/98/status.json" "4-review"
   sleep 0.05; touch "$SS_ROOT/.pipeline/98/status.json"
-  # THE ONE LINE THIS COMPARISON DOES NOT PIN, and why it is named rather than dropped. #115 makes
+  # THE ONE LINE THIS COMPARISON MAY NOT PIN, and why it is named rather than dropped. #115 makes
   # the validator write a single `agent-pipeline SubagentStop: ...` attribution line to stderr on
   # every stop, deliberately: before it, "no rules matched this agent" and "this agent's artifacts
-  # are valid" were byte-identical, which is the defect that issue is about. That line is a
-  # DIFFERENCE FROM THE REVIEWED COMMIT BY DESIGN, so an unfiltered byte comparison would redden
-  # forever and this criterion would be deleted rather than read. Everything else about the
-  # SubagentStop path -- exit code, stdout, and any OTHER stderr -- is still pinned byte for byte,
-  # which is what AC28 is actually for: a change reviewed for one thing silently altering a
-  # shipped gate. If the validator grows a second stderr line, this comparison reddens, correctly.
+  # are valid" were byte-identical, which is the defect that issue is about. Everything else about
+  # the SubagentStop path -- exit code, stdout, and any OTHER stderr -- is pinned byte for byte,
+  # which is what AC28 is actually for: a change reviewed for one thing silently altering a shipped
+  # gate. If the validator grows a SECOND stderr line, this comparison reddens, correctly.
+  #
+  # THE BASE IS A MOVING TARGET, AND THAT IS WHAT BROKE THIS ONCE ALREADY. The base is resolved
+  # dynamically as `merge-base HEAD origin/main`, so what it emits DEPENDS ON WHETHER #128 HAS
+  # MERGED YET. The first version of this block asserted flatly that the base emits no attribution
+  # line -- true only while #128 was unmerged, i.e. on exactly the one PR that introduced it. The
+  # moment #128 landed, every branch's merge-base carried the line, and the assertion turned main
+  # red and failed #130, which was blameless. A premise stated against a base that moves must be
+  # stated PER ERA, or it is a control with a shelf life measured in one merge.
+  #
+  # So the era is MEASURED, never assumed, and each era asserts the strongest thing available:
+  #   PRE-#128 base  -> base emits 0, HEAD emits 1: the strip is LOAD-BEARING, and the stripped
+  #                     comparison above is the guarantee.
+  #   POST-#128 base -> base and HEAD both emit 1: the strip is a NO-OP, so the UNFILTERED capture
+  #                     must match byte for byte too. That is STRICTLY STRONGER than the stripped
+  #                     comparison, because it also pins the attribution line's OWN bytes, which
+  #                     the strip would otherwise hide -- a divergence in the line's text between
+  #                     base and HEAD is invisible to a filtered comparison and caught here.
+  # Either way HEAD must emit EXACTLY ONE, and the base must never emit more than one, so a second
+  # unexpected line reddens in both eras rather than being absorbed by the filter.
   ss_strip_announce() { grep -v '^agent-pipeline SubagentStop: ' || true; }
-  ss_capture() {
-    local sd="$1" o e r
+  ss_run() {  # <scripts-dir> <errfile> -> "rc=.. out=[..]" and the FULL stderr left in <errfile>
+    local sd="$1" ef="$2" o r
     o="$( ( cd "$SS_ROOT" && printf '%s' '{"hook_event_name":"SubagentStop","session_id":"ac28","agent_type":"pipeline:qa"}' \
-        | CLAUDE_PROJECT_DIR="$SS_ROOT" "$GATE_REAL_NODE" "$sd/validate-pipeline-artifact.mjs" 2>"$TEMP_PROJECT/ss.err" ) )"; r=$?
-    e="$(ss_strip_announce < "$TEMP_PROJECT/ss.err")"
-    printf 'rc=%s out=[%s] err=[%s]' "$r" "$o" "$e"
+        | CLAUDE_PROJECT_DIR="$SS_ROOT" "$GATE_REAL_NODE" "$sd/validate-pipeline-artifact.mjs" 2>"$ef" ) )"; r=$?
+    printf 'rc=%s out=[%s]' "$r" "$o"
   }
-  SS_A="$(ss_capture "$SS_WT/plugins/pipeline/scripts")"
-  SS_B="$(ss_capture "$GATE_PLUGIN_DIR/scripts")"
+  SS_A_HEAD="$(ss_run "$SS_WT/plugins/pipeline/scripts" "$TEMP_PROJECT/ss.base.err")"
+  SS_B_HEAD="$(ss_run "$GATE_PLUGIN_DIR/scripts" "$TEMP_PROJECT/ss.head.err")"
+  SS_A="$SS_A_HEAD err=[$(ss_strip_announce < "$TEMP_PROJECT/ss.base.err")]"
+  SS_B="$SS_B_HEAD err=[$(ss_strip_announce < "$TEMP_PROJECT/ss.head.err")]"
+  SS_A_RAW="$SS_A_HEAD err=[$(cat "$TEMP_PROJECT/ss.base.err")]"
+  SS_B_RAW="$SS_B_HEAD err=[$(cat "$TEMP_PROJECT/ss.head.err")]"
   record "AC28 reviewed-commit SubagentStop resolution on a two-in-flight-dir root: $SS_A"
   assert_eq "AC28: the SubagentStop path resolves EXACTLY as it does at the reviewed commit" "$SS_B" "$SS_A"
-  # THE FILTER'S OWN PREMISE, asserted so it cannot hide what it was written to excuse. The strip
-  # above makes the comparison blind to the #115 attribution line; if that line ever stopped being
-  # emitted, AC28 would go green on a validator that had lost the very announcement it filters.
-  # So: it must be there at HEAD, and it must NOT be there at the reviewed commit.
-  ( cd "$SS_ROOT" && printf '%s' '{"hook_event_name":"SubagentStop","session_id":"ac28","agent_type":"pipeline:qa"}' \
-      | CLAUDE_PROJECT_DIR="$SS_ROOT" "$GATE_REAL_NODE" "$GATE_PLUGIN_DIR/scripts/validate-pipeline-artifact.mjs" ) \
-      >/dev/null 2>"$TEMP_PROJECT/ss.head.err"
-  ( cd "$SS_ROOT" && printf '%s' '{"hook_event_name":"SubagentStop","session_id":"ac28","agent_type":"pipeline:qa"}' \
-      | CLAUDE_PROJECT_DIR="$SS_ROOT" "$GATE_REAL_NODE" "$SS_WT/plugins/pipeline/scripts/validate-pipeline-artifact.mjs" ) \
-      >/dev/null 2>"$TEMP_PROJECT/ss.base.err"
-  assert_eq "AC28 FILTER PREMISE(+): HEAD does emit the #115 attribution line the strip removes" \
-    "$(grep -c '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/ss.head.err" | tr -d ' ')" "1"
-  assert_eq "AC28 FILTER PREMISE(-): the reviewed commit emits none, so the strip is what makes the two comparable" \
-    "$(grep -c '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/ss.base.err" | tr -d ' ')" "0"
+
+  SS_HEAD_LINES="$(grep -c '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/ss.head.err" | tr -d ' ')"
+  SS_BASE_LINES="$(grep -c '^agent-pipeline SubagentStop: ' "$TEMP_PROJECT/ss.base.err" | tr -d ' ')"
+  assert_eq "AC28 FILTER PREMISE(+): HEAD emits EXACTLY ONE attribution line, so the strip cannot hide its loss" \
+    "$SS_HEAD_LINES" "1"
+  assert_eq "AC28 FILTER PREMISE: the base emits at most one, so a second unexpected line is never absorbed" \
+    "$([[ "$SS_BASE_LINES" -le 1 ]] && echo ok || echo "base emitted $SS_BASE_LINES")" "ok"
+  record "AC28 ERA: base $SS_BASE_SHA emits $SS_BASE_LINES attribution line(s); HEAD emits $SS_HEAD_LINES"
+  if [[ "$SS_BASE_LINES" -eq 0 ]]; then
+    # Pre-#128 base. The strip is doing real work; prove it, by showing the UNFILTERED capture
+    # genuinely differs. Without this the "load-bearing" claim is untested in the era it describes.
+    assert_eq "AC28 ERA(pre-#128): the strip is LOAD-BEARING -- unfiltered, the two genuinely differ" \
+      "$([[ "$SS_B_RAW" != "$SS_A_RAW" ]] && echo differs || echo "identical, so the strip was never needed")" "differs"
+  else
+    # Post-#128 base: both carry the line, so the strip removes the same thing from both and the
+    # unfiltered comparison must ALSO hold. This is the assertion that keeps working from here on.
+    assert_eq "AC28 ERA(post-#128): the strip is a NO-OP, so the UNFILTERED capture matches byte for byte" \
+      "$SS_B_RAW" "$SS_A_RAW"
+  fi
   git -C "$GATE_REPO_ROOT" worktree remove --force "$SS_WT" >/dev/null 2>&1
 else
   assert_eq "AC28: the paired capture did not run -- reported as a FAILURE, never a skip" "could-not-check-out" "ran"


### PR DESCRIPTION
`main` is red, and the assertion that broke it is mine — introduced in #128.

## The defect

`AC28 FILTER PREMISE(-)` asserted *"the reviewed commit emits none"* of the `agent-pipeline SubagentStop:` attribution line. The base is resolved dynamically as `merge-base HEAD origin/main`, which is good design — but it means **what the base emits depends on whether #128 has merged.** The premise was true only while #128 was unmerged, i.e. on exactly the one PR that introduced it. Once #128 landed, every branch's merge-base carried the line.

**A premise stated against a moving base is a control with a shelf life of one merge.** It went red on `2e28f8d` (#128's own merge commit) and failed #130, which was blameless.

## Reproduced before fixing

On a branch off `3d1d942` (merge-base includes #128):

```
merge-base HEAD origin/main = 3d1d942   (includes #128? YES)
  ok    AC28: the SubagentStop path resolves EXACTLY as it does at the reviewed commit
  ok    AC28 FILTER PREMISE(+): HEAD does emit the #115 attribution line the strip removes
  FAIL  AC28 FILTER PREMISE(-): the reviewed commit emits none, so the strip is what makes the two comparable
passed=129 failed=1
```

## The fix: measure the era, assert the strongest thing available in each

| base era | what holds | what is asserted |
|---|---|---|
| **pre-#128** | base emits 0, HEAD emits 1 | the strip is **load-bearing** — and that is now asserted directly: unfiltered, the two captures must genuinely **differ**. The old version never tested this claim in the era it described. |
| **post-#128** | both emit 1 | the strip is a **no-op**, so the **unfiltered** capture must match byte for byte |

The post-#128 branch is **strictly stronger than the assertion it replaces**: it also pins the attribution line's *own bytes*, so a divergence in that line's text between base and HEAD — previously invisible to a filtered comparison — is now caught.

Both eras additionally require HEAD to emit **exactly one** such line and the base **at most one**, so a second unexpected line reddens in either era rather than being absorbed by the filter. That is the guarantee the strip exists to protect, and it is preserved.

`AC36(b)` in `test-pretooluse-gate-declaration.sh` carried the same era-dependent strip. It was green today but silently hiding the same divergence, so it now strips **only in the era that needs it** — the comparison runs fully unfiltered from here on — and records which era it measured.

## Verified in BOTH eras by real runs

An unexecuted branch is a claim, not a check. A probe worktree based on `d4a61e4` (pre-#128) with the announcement applied reproduces the pre-era path; the branch itself is the post-era path.

```
post-#128:  AC28 ERA: base 3d1d942… emits 1 attribution line(s); HEAD emits 1
            ok  AC28 ERA(post-#128): the strip is a NO-OP, so the UNFILTERED capture matches byte for byte
pre-#128:   AC28 ERA: base d4a61e4… emits 0 attribution line(s); HEAD emits 1
            ok  AC28 ERA(pre-#128): the strip is LOAD-BEARING -- unfiltered, the two genuinely differ
```

Both `passed=132 failed=0`. AC36(b): `passed=68 failed=0` in both eras.

## Mutation battery, run in BOTH eras

Running it in one era only would reproduce the original mistake one level up.

| id | expect | POST | PRE | what it breaks |
|---|---|---|---|---|
| N1 | RED | RED | RED | a second, **non-matching** stderr line — the thing the strip must never absorb |
| N2 | RED | RED | RED | a second line **wearing the attribution prefix** (the case the strip *would* absorb) — caught by the exactly-one count |
| N3 | RED | RED | RED | the announcement lost entirely — the filter must not excuse its own subject |
| **N4** | **SURVIVE** | **SURVIVED** | **SURVIVED** | comment-only no-op edit |

**N4 is the harness control**: it changes no emitted byte, so no era can distinguish it. Had it reddened, the suite would be reacting to the file being touched rather than to behaviour, and every RED above would be worthless.

Each RED landed on the *specific* assertion it should: N1 on the byte comparison, N2/N3 on `PREMISE(+)`, and N3 additionally on the pre-era load-bearing assertion.